### PR TITLE
Ajustes para compilação Linux

### DIFF
--- a/Sources/Core/Base/Dext.Utils.pas
+++ b/Sources/Core/Base/Dext.Utils.pas
@@ -32,12 +32,12 @@ uses
   WinApi.Windows;
 {$ENDIF}
 
-procedure SetConsoleCharSet(CharSet: UINT = 65001);
+procedure SetConsoleCharSet(CharSet: Cardinal = 65001);
 procedure DebugLog(const AMessage: string);
 
 implementation
 
-procedure SetConsoleCharSet(CharSet: UINT);
+procedure SetConsoleCharSet(CharSet: Cardinal);
 begin
 {$IFDEF MSWINDOWS}
  SetConsoleOutputCP(65001);

--- a/Sources/Data/Dext.Entity.Drivers.FireDAC.Manager.pas
+++ b/Sources/Data/Dext.Entity.Drivers.FireDAC.Manager.pas
@@ -5,7 +5,6 @@ interface
 {$I Dext.inc}
 
 uses
-  Winapi.Windows,
   System.SysUtils,
   System.Classes,
   System.Generics.Collections,

--- a/Sources/Web/Dext.Auth.JWT.pas
+++ b/Sources/Web/Dext.Auth.JWT.pas
@@ -24,6 +24,7 @@
 {                                                                           }
 {***************************************************************************}
 unit Dext.Auth.JWT;
+{$I ..\Dext.inc}
 
 interface
 
@@ -35,6 +36,7 @@ uses
   System.NetEncoding,
   System.Rtti,
   System.SysUtils,
+  System.Hash,
   IdGlobal,
   IdHashSHA,
   IdHMAC,
@@ -597,5 +599,7 @@ begin
 end;
 
 end.
+
+
 
 


### PR DESCRIPTION
Ajustes para compilar para o Linux

- Sources\Core\Base\Dext.Utils.pas
    - Trocado no método SetConsoleCharSet o tipo do parametro de entrada Charset para Cardinal.
- Sources\Core\Data\Dext.Entity.Drivers.FireDAC.Manager.pas
    - Remoção da unit Winapi.Windows do uses. Não estava sendo usada.	
- Sources\Core\Web\Dext.Auth.JWT
    - Adicionado a diretiva de compilação {$I ..\Dext.inc}
    - Adicionado a unit System.Hash no uses	
- Sources\Core\Web\Dext.Web.Indy.Server.pas
    - Ajustado uses conforme ambiente MSWINDOWS e POSIX
    - Ajustado o método ConsoleCtrlHandler para ser compilado somente para o Windows
    - Criado o método SignalHandler para ser compilado para o Linux
    - Ajustado o método TIndyWebServer.Run de acordo com o ambiente