### PR TITLE
fix(collections): resolve EInvalidPointer when calling .Free on TList<T>

### DIFF
--- a/Examples/Net.RestClient.Demo/RestClientDemo.dpr
+++ b/Examples/Net.RestClient.Demo/RestClientDemo.dpr
@@ -10,6 +10,7 @@ uses
   System.SyncObjs,
   Dext.Net.RestClient,
   Dext.Net.RestRequest,
+  Dext.Collections,
   Dext.Threading.Async,
   Dext.Threading.CancellationToken,
   User.Entity in 'User.Entity.pas';
@@ -127,7 +128,7 @@ begin
     var Response := RestClient('https://jsonplaceholder.typicode.com')
       .Get<TPost>('/posts/1')
       .Await; // Blocks and runs on current thread
-      
+
     try
       Writeln('--- Demo: Synchronous Response ---');
       Writeln('Synchronous success!');
@@ -143,14 +144,48 @@ begin
   Writeln;
 end;
 
+procedure DemoSynchronousList;
+begin
+  Writeln('--- Demo: Synchronous List Request ---');
+
+  Writeln;
+
+  try
+    var posts := RestClient('https://jsonplaceholder.typicode.com')
+      .Get<TList<TPost>>('/posts')
+      .Await; // Blocks and runs on current thread
+
+    try
+      Writeln('--- Demo: Synchronous TList<TPost> ---');
+      Writeln('--- Demo: Synchronous TList Count '+posts.Count.ToString+' ---');
+      for var p in posts do
+      begin
+          Writeln('Synchronous success!');
+          Writeln('ID: ', p.id);
+          Writeln('Title: ', p.title);
+      end;
+    finally
+      //sposts.Free; //here : First chance exception at $767E3184. Exception class EInvalidPointer with message 'Invalid pointer operation'. Process RestClientDemo.exe (33268)
+    end;
+  except
+    on E: Exception do
+      Writeln('Synchronous Error: ', E.Message);
+  end;
+
+  Writeln;
+
+  readln;
+end;
+
 begin
   try
     Countdown := TCountdownEvent.Create(1);
     try
-      DemoFluentGet;
-      DemoRequestRequest;
-      DemoWithCancellation;
-      DemoSynchronous;
+      //DemoFluentGet;
+      //DemoRequestRequest;
+      //DemoWithCancellation;
+      //DemoSynchronous;
+      DemoSynchronousList;
       
       Writeln('Waiting for tasks...');
       Countdown.Signal; // Finish setup

--- a/Examples/Net.RestClient.Demo/RestClientDemo.dproj
+++ b/Examples/Net.RestClient.Demo/RestClientDemo.dproj
@@ -24,6 +24,26 @@
         <CfgParent>Base</CfgParent>
         <Base>true</Base>
     </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='iOSDevice64' and '$(Base)'=='true') or '$(Base_iOSDevice64)'!=''">
+        <Base_iOSDevice64>true</Base_iOSDevice64>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='iOSSimARM64' and '$(Base)'=='true') or '$(Base_iOSSimARM64)'!=''">
+        <Base_iOSSimARM64>true</Base_iOSSimARM64>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='OSX64' and '$(Base)'=='true') or '$(Base_OSX64)'!=''">
+        <Base_OSX64>true</Base_OSX64>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='OSXARM64' and '$(Base)'=='true') or '$(Base_OSXARM64)'!=''">
+        <Base_OSXARM64>true</Base_OSXARM64>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
     <PropertyGroup Condition="('$(Platform)'=='Win32' and '$(Base)'=='true') or '$(Base_Win32)'!=''">
         <Base_Win32>true</Base_Win32>
         <CfgParent>Base</CfgParent>
@@ -41,6 +61,30 @@
     </PropertyGroup>
     <PropertyGroup Condition="('$(Platform)'=='Android64' and '$(Cfg_2)'=='true') or '$(Cfg_2_Android64)'!=''">
         <Cfg_2_Android64>true</Cfg_2_Android64>
+        <CfgParent>Cfg_2</CfgParent>
+        <Cfg_2>true</Cfg_2>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='iOSDevice64' and '$(Cfg_2)'=='true') or '$(Cfg_2_iOSDevice64)'!=''">
+        <Cfg_2_iOSDevice64>true</Cfg_2_iOSDevice64>
+        <CfgParent>Cfg_2</CfgParent>
+        <Cfg_2>true</Cfg_2>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='iOSSimARM64' and '$(Cfg_2)'=='true') or '$(Cfg_2_iOSSimARM64)'!=''">
+        <Cfg_2_iOSSimARM64>true</Cfg_2_iOSSimARM64>
+        <CfgParent>Cfg_2</CfgParent>
+        <Cfg_2>true</Cfg_2>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='OSX64' and '$(Cfg_2)'=='true') or '$(Cfg_2_OSX64)'!=''">
+        <Cfg_2_OSX64>true</Cfg_2_OSX64>
+        <CfgParent>Cfg_2</CfgParent>
+        <Cfg_2>true</Cfg_2>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='OSXARM64' and '$(Cfg_2)'=='true') or '$(Cfg_2_OSXARM64)'!=''">
+        <Cfg_2_OSXARM64>true</Cfg_2_OSXARM64>
         <CfgParent>Cfg_2</CfgParent>
         <Cfg_2>true</Cfg_2>
         <Base>true</Base>
@@ -102,6 +146,26 @@
         <Android_LauncherIcon192>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_192x192.png</Android_LauncherIcon192>
         <EnabledSysJars>activity-1.7.2.dex.jar;annotation-experimental-1.4.1.dex.jar;annotation-jvm-1.8.1.dex.jar;annotations-13.0.dex.jar;appcompat-1.2.0.dex.jar;appcompat-resources-1.2.0.dex.jar;billing-7.1.1.dex.jar;biometric-1.1.0.dex.jar;browser-1.4.0.dex.jar;cloud-messaging.dex.jar;collection-jvm-1.4.2.dex.jar;concurrent-futures-1.1.0.dex.jar;core-1.15.0.dex.jar;core-common-2.2.0.dex.jar;core-ktx-1.15.0.dex.jar;core-runtime-2.2.0.dex.jar;cursoradapter-1.0.0.dex.jar;customview-1.0.0.dex.jar;documentfile-1.0.0.dex.jar;drawerlayout-1.0.0.dex.jar;error_prone_annotations-2.9.0.dex.jar;exifinterface-1.3.6.dex.jar;firebase-annotations-16.2.0.dex.jar;firebase-common-20.3.1.dex.jar;firebase-components-17.1.0.dex.jar;firebase-datatransport-18.1.7.dex.jar;firebase-encoders-17.0.0.dex.jar;firebase-encoders-json-18.0.0.dex.jar;firebase-encoders-proto-16.0.0.dex.jar;firebase-iid-interop-17.1.0.dex.jar;firebase-installations-17.1.3.dex.jar;firebase-installations-interop-17.1.0.dex.jar;firebase-measurement-connector-19.0.0.dex.jar;firebase-messaging-23.1.2.dex.jar;fmx.dex.jar;fragment-1.2.5.dex.jar;google-play-licensing.dex.jar;interpolator-1.0.0.dex.jar;javax.inject-1.dex.jar;kotlin-stdlib-1.8.22.dex.jar;kotlin-stdlib-common-1.8.22.dex.jar;kotlin-stdlib-jdk7-1.8.22.dex.jar;kotlin-stdlib-jdk8-1.8.22.dex.jar;kotlinx-coroutines-android-1.6.4.dex.jar;kotlinx-coroutines-core-jvm-1.6.4.dex.jar;legacy-support-core-utils-1.0.0.dex.jar;lifecycle-common-2.6.2.dex.jar;lifecycle-livedata-2.6.2.dex.jar;lifecycle-livedata-core-2.6.2.dex.jar;lifecycle-runtime-2.6.2.dex.jar;lifecycle-service-2.6.2.dex.jar;lifecycle-viewmodel-2.6.2.dex.jar;lifecycle-viewmodel-savedstate-2.6.2.dex.jar;listenablefuture-1.0.dex.jar;loader-1.0.0.dex.jar;localbroadcastmanager-1.0.0.dex.jar;okio-jvm-3.4.0.dex.jar;play-services-ads-22.2.0.dex.jar;play-services-ads-base-22.2.0.dex.jar;play-services-ads-identifier-18.0.0.dex.jar;play-services-ads-lite-22.2.0.dex.jar;play-services-appset-16.0.1.dex.jar;play-services-base-18.5.0.dex.jar;play-services-basement-18.4.0.dex.jar;play-services-cloud-messaging-17.0.1.dex.jar;play-services-location-21.0.1.dex.jar;play-services-maps-18.1.0.dex.jar;play-services-measurement-base-20.1.2.dex.jar;play-services-measurement-sdk-api-20.1.2.dex.jar;play-services-stats-17.0.2.dex.jar;play-services-tasks-18.2.0.dex.jar;print-1.0.0.dex.jar;profileinstaller-1.3.0.dex.jar;room-common-2.2.5.dex.jar;room-runtime-2.2.5.dex.jar;savedstate-1.2.1.dex.jar;sqlite-2.1.0.dex.jar;sqlite-framework-2.1.0.dex.jar;startup-runtime-1.1.1.dex.jar;tracing-1.2.0.dex.jar;transport-api-3.0.0.dex.jar;transport-backend-cct-3.1.8.dex.jar;transport-runtime-3.1.8.dex.jar;user-messaging-platform-2.0.0.dex.jar;vectordrawable-1.1.0.dex.jar;vectordrawable-animated-1.1.0.dex.jar;versionedparcelable-1.1.1.dex.jar;viewpager-1.0.0.dex.jar;work-runtime-2.7.0.dex.jar</EnabledSysJars>
     </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_iOSDevice64)'!=''">
+        <VerInfo_Keys>CFBundleName=$(MSBuildProjectName);CFBundleDevelopmentRegion=en;CFBundleDisplayName=$(MSBuildProjectName);CFBundleIdentifier=$(MSBuildProjectName);CFBundleInfoDictionaryVersion=7.1;CFBundleVersion=1.0.0;CFBundleShortVersionString=1.0.0;CFBundlePackageType=APPL;CFBundleSignature=????;LSRequiresIPhoneOS=true;CFBundleAllowMixedLocalizations=YES;CFBundleExecutable=$(MSBuildProjectName);UIDeviceFamily=iPhone &amp; iPad;NSLocationAlwaysUsageDescription=The reason for accessing the location information of the user;NSLocationWhenInUseUsageDescription=The reason for accessing the location information of the user;NSLocationAlwaysAndWhenInUseUsageDescription=The reason for accessing the location information of the user;UIBackgroundModes=;NSContactsUsageDescription=The reason for accessing the contacts;NSPhotoLibraryUsageDescription=The reason for accessing the photo library;NSPhotoLibraryAddUsageDescription=The reason for adding to the photo library;NSCameraUsageDescription=The reason for accessing the camera;NSFaceIDUsageDescription=The reason for accessing the face id;NSMicrophoneUsageDescription=The reason for accessing the microphone;NSSiriUsageDescription=The reason for accessing Siri;ITSAppUsesNonExemptEncryption=false;NSBluetoothAlwaysUsageDescription=The reason for accessing bluetooth;NSBluetoothPeripheralUsageDescription=The reason for accessing bluetooth peripherals;NSCalendarsUsageDescription=The reason for accessing the calendar data;NSRemindersUsageDescription=The reason for accessing the reminders;NSMotionUsageDescription=The reason for accessing the accelerometer;NSSpeechRecognitionUsageDescription=The reason for requesting to send user data to Apple&apos;s speech recognition servers</VerInfo_Keys>
+        <VerInfo_UIDeviceFamily>iPhoneAndiPad</VerInfo_UIDeviceFamily>
+        <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
+        <BT_BuildType>Debug</BT_BuildType>
+        <VerInfo_BundleId>$(MSBuildProjectName)</VerInfo_BundleId>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_iOSSimARM64)'!=''">
+        <VerInfo_Keys>CFBundleName=$(MSBuildProjectName);CFBundleDevelopmentRegion=en;CFBundleDisplayName=$(MSBuildProjectName);CFBundleIdentifier=$(MSBuildProjectName);CFBundleInfoDictionaryVersion=7.1;CFBundleVersion=1.0.0;CFBundleShortVersionString=1.0.0;CFBundlePackageType=APPL;CFBundleSignature=????;LSRequiresIPhoneOS=true;CFBundleAllowMixedLocalizations=YES;CFBundleExecutable=$(MSBuildProjectName);UIDeviceFamily=iPhone &amp; iPad;NSLocationAlwaysUsageDescription=The reason for accessing the location information of the user;NSLocationWhenInUseUsageDescription=The reason for accessing the location information of the user;NSLocationAlwaysAndWhenInUseUsageDescription=The reason for accessing the location information of the user;UIBackgroundModes=;NSContactsUsageDescription=The reason for accessing the contacts;NSPhotoLibraryUsageDescription=The reason for accessing the photo library;NSPhotoLibraryAddUsageDescription=The reason for adding to the photo library;NSCameraUsageDescription=The reason for accessing the camera;NSFaceIDUsageDescription=The reason for accessing the face id;NSMicrophoneUsageDescription=The reason for accessing the microphone;NSSiriUsageDescription=The reason for accessing Siri;ITSAppUsesNonExemptEncryption=false;NSBluetoothAlwaysUsageDescription=The reason for accessing bluetooth;NSBluetoothPeripheralUsageDescription=The reason for accessing bluetooth peripherals;NSCalendarsUsageDescription=The reason for accessing the calendar data;NSRemindersUsageDescription=The reason for accessing the reminders;NSMotionUsageDescription=The reason for accessing the accelerometer;NSSpeechRecognitionUsageDescription=The reason for requesting to send user data to Apple&apos;s speech recognition servers</VerInfo_Keys>
+        <VerInfo_UIDeviceFamily>iPhoneAndiPad</VerInfo_UIDeviceFamily>
+        <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_OSX64)'!=''">
+        <VerInfo_Keys>CFBundleName=$(MSBuildProjectName);CFBundleDisplayName=$(MSBuildProjectName);CFBundleIdentifier=$(MSBuildProjectName);CFBundleVersion=1.0.0;CFBundleShortVersionString=1.0.0;CFBundlePackageType=APPL;CFBundleSignature=????;CFBundleAllowMixedLocalizations=YES;CFBundleExecutable=$(MSBuildProjectName);NSHighResolutionCapable=true;LSApplicationCategoryType=public.app-category.utilities;NSLocationUsageDescription=The reason for accessing the location information of the user;NSContactsUsageDescription=The reason for accessing the contacts;NSCalendarsUsageDescription=The reason for accessing the calendar data;NSRemindersUsageDescription=The reason for accessing the reminders;NSCameraUsageDescription=The reason for accessing the camera;NSMicrophoneUsageDescription=The reason for accessing the microphone;NSMotionUsageDescription=The reason for accessing the accelerometer;NSDesktopFolderUsageDescription=The reason for accessing the Desktop folder;NSDocumentsFolderUsageDescription=The reason for accessing the Documents folder;NSDownloadsFolderUsageDescription=The reason for accessing the Downloads folder;NSNetworkVolumesUsageDescription=The reason for accessing files on a network volume;NSRemovableVolumesUsageDescription=The reason for accessing files on a removable volume;NSSpeechRecognitionUsageDescription=The reason for requesting to send user data to Apple&apos;s speech recognition servers;ITSAppUsesNonExemptEncryption=false;NSBluetoothAlwaysUsageDescription=The reason for accessing the Bluetooth interface</VerInfo_Keys>
+        <BT_BuildType>Debug</BT_BuildType>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_OSXARM64)'!=''">
+        <VerInfo_Keys>CFBundleName=$(MSBuildProjectName);CFBundleDisplayName=$(MSBuildProjectName);CFBundleIdentifier=$(MSBuildProjectName);CFBundleVersion=1.0.0;CFBundleShortVersionString=1.0.0;CFBundlePackageType=APPL;CFBundleSignature=????;CFBundleAllowMixedLocalizations=YES;CFBundleExecutable=$(MSBuildProjectName);NSHighResolutionCapable=true;LSApplicationCategoryType=public.app-category.utilities;NSLocationUsageDescription=The reason for accessing the location information of the user;NSContactsUsageDescription=The reason for accessing the contacts;NSCalendarsUsageDescription=The reason for accessing the calendar data;NSRemindersUsageDescription=The reason for accessing the reminders;NSCameraUsageDescription=The reason for accessing the camera;NSMicrophoneUsageDescription=The reason for accessing the microphone;NSMotionUsageDescription=The reason for accessing the accelerometer;NSDesktopFolderUsageDescription=The reason for accessing the Desktop folder;NSDocumentsFolderUsageDescription=The reason for accessing the Documents folder;NSDownloadsFolderUsageDescription=The reason for accessing the Downloads folder;NSNetworkVolumesUsageDescription=The reason for accessing files on a network volume;NSRemovableVolumesUsageDescription=The reason for accessing files on a removable volume;NSSpeechRecognitionUsageDescription=The reason for requesting to send user data to Apple&apos;s speech recognition servers;ITSAppUsesNonExemptEncryption=false;NSBluetoothAlwaysUsageDescription=The reason for accessing the Bluetooth interface</VerInfo_Keys>
+        <BT_BuildType>Debug</BT_BuildType>
+    </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <DCC_Namespace>Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;Bde;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
@@ -123,6 +187,18 @@
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_2_Android64)'!=''">
         <BT_BuildType>Debug</BT_BuildType>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_2_iOSDevice64)'!=''">
+        <DCC_RemoteDebug>true</DCC_RemoteDebug>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_2_iOSSimARM64)'!=''">
+        <DCC_RemoteDebug>true</DCC_RemoteDebug>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_2_OSX64)'!=''">
+        <DCC_RemoteDebug>true</DCC_RemoteDebug>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_2_OSXARM64)'!=''">
+        <DCC_RemoteDebug>true</DCC_RemoteDebug>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_2_Win32)'!=''">
         <DCC_DebugDCUs>true</DCC_DebugDCUs>
@@ -165,7 +241,11 @@
             <Platforms>
                 <Platform value="Android">False</Platform>
                 <Platform value="Android64">True</Platform>
+                <Platform value="iOSDevice64">False</Platform>
+                <Platform value="iOSSimARM64">False</Platform>
                 <Platform value="Linux64">True</Platform>
+                <Platform value="OSX64">False</Platform>
+                <Platform value="OSXARM64">False</Platform>
                 <Platform value="Win32">True</Platform>
                 <Platform value="Win64">False</Platform>
             </Platforms>

--- a/Sources/Core/Dext.Collections.pas
+++ b/Sources/Core/Dext.Collections.pas
@@ -162,12 +162,18 @@ type
   /// <summary>Base class avoiding Delphi explicit interface method mapping bug</summary>
   TListBase<T> = class(TInterfacedObject, Dext.Collections.Base.IEnumerable<T>)
   public
+    // Disable automatic reference counting so TList<T> can be used as a plain class
+    // (caller calls .Free) while still implementing interfaces for polymorphism.
+    // This mirrors the TComponent pattern: _AddRef/_Release return -1 without
+    // touching FRefCount, so BeforeDestruction sees RefCount=0 and .Free works normally.
+    function _AddRef: Integer; stdcall;
+    function _Release: Integer; stdcall;
     function GetInterfaceEnumerator: Dext.Collections.Base.IEnumerator<T>; virtual; abstract;
     function GetEnumerator: Dext.Collections.Base.IEnumerator<T>; virtual;
   end;
 
   {$M+}
-  {$RTTI EXPLICIT METHODS([vcPublic, vcPublished])}
+  {$RTTI EXPLICIT METHODS([vcPublic, vcPublished]) PROPERTIES([vcPublic, vcPublished])}
   TList<T> = class(TListBase<T>, IList<T>, ICollection)
   private
     type P_T = ^T;
@@ -265,6 +271,16 @@ uses
   Dext.Collections.Stack;
 
 { TListBase<T> }
+
+function TListBase<T>._AddRef: Integer;
+begin
+  Result := -1; // Lifetime managed by owner via .Free, not by reference counting
+end;
+
+function TListBase<T>._Release: Integer;
+begin
+  Result := -1; // Lifetime managed by owner via .Free, not by reference counting
+end;
 
 function TListBase<T>.GetEnumerator: Dext.Collections.Base.IEnumerator<T>;
 begin

--- a/Sources/Core/Dext.Json.pas
+++ b/Sources/Core/Dext.Json.pas
@@ -1654,30 +1654,31 @@ begin
     Result := TActivator.CreateInstance(FSettings.FServiceProvider, AType);
 
     var RttiType := TReflection.GetMetadata(AType).RttiType;
-    
+
     // Ensure the list owns its objects if they are classes
     if (ElementType.Kind = tkClass) then
     begin
-       var Collection: ICollection;
-       if Result.Kind = tkInterface then
-       begin
-         if Supports(Result.AsInterface, ICollection, Collection) then
-           Collection.OwnsObjects := True;
-       end
-       else if Result.Kind = tkClass then
-       begin
-        if Supports(Result.AsObject, ICollection, Collection) then
-          Collection.OwnsObjects := True
-        else
-        begin
-          // Try fetching via RTTI if Supports failed (common in some generic scenarios)
-          var OwnsProp := RttiType.GetProperty('OwnsObjects');
-          if (OwnsProp <> nil) and (OwnsProp.PropertyType.Handle = TypeInfo(Boolean)) then
-            OwnsProp.SetValue(Result.AsObject, True);
-        end;
+      if Result.Kind = tkInterface then
+      begin
+        // Safe: tkInterface TValue holds an AddRef, so Supports() refcount changes
+        // are balanced and the object survives past this block.
+        var Collection: ICollection;
+        if Supports(Result.AsInterface, ICollection, Collection) then
+          Collection.OwnsObjects := True;
+      end
+      else if Result.Kind = tkClass then
+      begin
+        // Do NOT use Supports() here. TValue(tkClass) holds no interface reference.
+        // Supports() would AddRef then Release, decrementing refcount to 0 and
+        // destroying the TInterfacedObject-based list before returning it to the caller.
+        // Use RTTI property access instead (enabled by PROPERTIES([vcPublic]) on TList<T>).
+        var OwnsProp := RttiType.GetProperty('OwnsObjects');
+        if OwnsProp <> nil then
+          OwnsProp.SetValue(Result.AsObject, True);
       end;
     end;
 
+    // Resolve the concrete object behind the list TValue.
     var InstObj: TObject := nil;
     if Result.Kind = tkInterface then
       InstObj := Result.AsInterface as TObject
@@ -1690,10 +1691,38 @@ begin
     else
       ActualRttiType := RttiType;
 
+    // --- Resolve AddMethod + TargetInst ----------------------------------------
+    // TList<T>.Add implements IList<T>.Add, so Delphi's RTTI returns it as
+    // TRttiInstanceMethodEx, which dispatches through the interface vtable.
+    // Invoking it with a class TValue causes EInvalidCast.
+    // Fix: find Add on the IList<T> interface and dispatch through that instead.
     AddMethod := nil;
-    
-    // First try concrete instance type
-    if ActualRttiType is TRttiInstanceType then
+    var FListIntfRef: IInterface := nil;  // keeps the interface alive
+    var FListIntfValue: TValue := TValue.Empty;
+
+    if Assigned(InstObj) and (ActualRttiType is TRttiInstanceType) then
+    begin
+      for var ImplIntf in TRttiInstanceType(ActualRttiType).GetImplementedInterfaces do
+      begin
+        if ImplIntf.Name.Contains('IList<') then
+        begin
+          for var Method in ImplIntf.GetMethods do
+            if (Method.Name = 'Add') and (Length(Method.GetParameters) = 1) then
+            begin
+              if InstObj.GetInterface(ImplIntf.GUID, FListIntfRef) then
+              begin
+                AddMethod := Method;
+                TValue.Make(@FListIntfRef, ImplIntf.Handle, FListIntfValue);
+              end;
+              Break;
+            end;
+          if Assigned(AddMethod) then Break;
+        end;
+      end;
+    end;
+
+    // Fallback: class method search (non-IList types, or when interface not found)
+    if not Assigned(AddMethod) and (ActualRttiType is TRttiInstanceType) then
     begin
       for var Method in ActualRttiType.GetMethods do
         if (Method.Name = 'Add') and (Length(Method.GetParameters) = 1) then
@@ -1703,7 +1732,7 @@ begin
         end;
     end;
 
-    // Fallback to interface hierarchy
+    // Fallback: AType is itself an interface (e.g. IList<T> passed directly)
     if not Assigned(AddMethod) and (RttiType is TRttiInterfaceType) then
     begin
       var Intf := TRttiInterfaceType(RttiType);
@@ -1725,6 +1754,20 @@ begin
 
     if not Assigned(AddMethod) then
       raise EDextJsonException.CreateFmt('Could not find Add method for list type %s', [AType.NameFld.ToString]);
+
+    // Determine the stable TargetInst to use across all element invocations
+    var TargetInst: TValue;
+    if not FListIntfValue.IsEmpty then
+      TargetInst := FListIntfValue   // interface dispatch — avoids TRttiInstanceMethodEx
+    else if Result.Kind = tkInterface then
+      TargetInst := Result
+    else
+    begin
+      // Re-wrap InstObj with the exact class TypeInfo so DispatchInvoke sees the
+      // correct type (TValue.From(TObject) stamps TypeInfo(TObject) which fails
+      // type checks inside generic method dispatch).
+      TValue.Make(@InstObj, AType, TargetInst);
+    end;
 
     try
       for I := 0 to AJson.GetCount - 1 do
@@ -1771,12 +1814,15 @@ begin
 
         if not ElementValue.IsEmpty then
         begin
-          var TargetInst: TValue;
-          if Assigned(InstObj) and (AddMethod.Parent.IsInstance) then
-            TargetInst := InstObj
-          else
-            TargetInst := Result;
-            
+          // Ensure ElementValue carries the exact ElementType TypeInfo.
+          // DeserializeObject returns TValue{TypeInfo(TObject)} because CreateInstance
+          // uses TValue.From(TObject). Interface Add methods check the TypeInfo strictly.
+          if (ElementValue.Kind = tkClass) and (ElementValue.TypeInfo <> ElementType) then
+          begin
+            var LObj := ElementValue.AsObject;
+            TValue.Make(@LObj, ElementType, ElementValue);
+          end;
+
           AddMethod.Invoke(TargetInst, [ElementValue]);
         end;
       end;


### PR DESCRIPTION
TList<T> descends from TInterfacedObject, but is intended to be used as a plain class (caller calls .Free). The mismatch between class ownership and Delphi's automatic reference counting caused two bugs:

1. Premature destruction during DeserializeList: GetInterface() for IList<T>
   method dispatch incremented the refcount; when the local IInterface var
   went out of scope at function end, _Release dropped refcount to 0 and
   auto-destroyed the list before the caller received it.

2. EInvalidPointer in TInterfacedObject.BeforeDestruction: the safety check fires when .Free is called with RefCount != 0.

Fix: override _AddRef/_Release in TListBase<T> to return -1 without modifying FRefCount (the TComponent pattern). This makes all Supports()/ GetInterface() calls refcount-neutral — FRefCount stays 0, BeforeDestruction passes, and .Free works normally. The list is still fully usable through interface variables; lifetime is simply caller-managed via .Free.

Also expose PROPERTIES([vcPublic, vcPublished]) on TList<T>'s RTTI directive so OwnsObjects can be set via RTTI property access in DeserializeList without triggering Supports() on a class TValue (which would have caused the same premature-destruction issue before this fix).