### PR TITLE
fix(entity): create and bind command in TSqlQueryIterator.MoveNextCore

### DIFF
--- a/Sources/Data/Dext.Entity.DbSet.pas
+++ b/Sources/Data/Dext.Entity.DbSet.pas
@@ -430,6 +430,8 @@ begin
   begin
     SW := TStopwatch.StartNew;
     try
+      Cmd := FDbSet.FContext.Connection.CreateCommand(FSql);
+      Cmd.BindSequentialParams(FParams);
       FReader := Cmd.ExecuteQuery;
       FInitialized := True;
       TDiagnosticSource.Instance.Write('SQL.Query', TJSONObject.Create(TJSONPair.Create('sql', FSql)), 'SQL', SW.ElapsedMilliseconds);


### PR DESCRIPTION
FromSql/raw SQL iteration called ExecuteQuery on an uninitialized IDbCommand, causing AV. Mirror TStreamingViewIterator: CreateCommand(FSql) and BindSequentialParams before ExecuteQuery.