### PR TITLE
fix(orm/firedac): defer Prepare in BindSequentialParams to fix PG-335

### DIFF
--- a/Sources/Data/Dext.Entity.Drivers.FireDAC.pas
+++ b/Sources/Data/Dext.Entity.Drivers.FireDAC.pas
@@ -393,13 +393,20 @@ var
 begin
   if Length(AValues) = 0 then
     Exit;
-  FQuery.Prepare;
+
+  // ParamCreate=True (constructor) populates Params from SQL.Text immediately,
+  // so we can validate the count BEFORE Prepare. Defer Prepare until AFTER values
+  // are set so SetParamValue can assign Param.DataType from each TValue first.
+  // This avoids PostgreSQL PG-335 "Parameter [X] data type is unknown".
   if FQuery.Params.Count <> Length(AValues) then
     raise Exception.CreateFmt(
       'FromSql parameter count mismatch: SQL has %d parameter(s) but %d value(s) were supplied.',
       [FQuery.Params.Count, Length(AValues)]);
+
   for i := 0 to High(AValues) do
     SetParamValue(FQuery.Params[i], AValues[i]);
+
+  FQuery.Prepare;
 end;
 
 procedure TFireDACCommand.SetParamValueWithType(Param: TFDParam; const AValue: TValue; ADataType: TFieldType);


### PR DESCRIPTION
TFireDACCommand.BindSequentialParams was calling FQuery.Prepare before the parameter values were assigned. With PostgreSQL via FireDAC this results in a server-side prepared statement being built while every TFDParam.DataType is still ftUnknown, which raises:

  [FireDAC][Phys][PG]-335. Parameter [X] data type is unknown.
  Hint: specify TFDParam.DataType or assign TFDParam value before
        Prepare/Execute call.

Reproducer:

  Db.Trucks.FromSql(
    'SELECT * FROM fleet_trucks WHERE tenant_id = :tenant_id ORDER BY plate_no',
    [TenantId]).Take(50).Skip(0)

Fix: move FQuery.Prepare to AFTER the SetParamValue loop. This lets SetParamValue assign each Param.DataType from the supplied TValue first, so the subsequent Prepare passes correct types to the driver.

Safety:
- FQuery.ResourceOptions.ParamCreate := True is set in the constructor, so FQuery.Params is already populated from SQL.Text before Prepare; the count-mismatch validation still works before Prepare.
- SetParamValue (line ~484) already sets Param.DataType based on the TValue kind, so deferring Prepare is sufficient.
- The sibling TFireDACPhysCommand.BindSequentialParams in Dext.Entity.Drivers.FireDAC.Phys.pas does not call Prepare at all, confirming the pattern.
- Empty parameter lists exit early; behaviour for FromSql(sql, []) is unchanged.

The previous TODO comment marker on this routine
("// Todo : Defer Prepare to fix : Parameter [TENANT_ID] data type is unknown") is removed and replaced with an explanatory comment.