### PR TITLE
Ajuste da classe TOAuth2ClientCredentialsProvider

### DIFF
--- a/Sources/Net/Dext.Net.Authentication.pas
+++ b/Sources/Net/Dext.Net.Authentication.pas
@@ -35,7 +35,8 @@ uses
   System.Net.HttpClient,
   System.Net.URLClient,
   System.NetEncoding,
-  System.SyncObjs;
+  System.SyncObjs,
+  System.JSON;
 
 type
   /// <summary>Base interface for HTTP authentication providers.</summary>
@@ -107,6 +108,9 @@ type
   end;
 
 implementation
+uses
+  Dext.Net.RestClient, //-->Referência circular;
+  Dext.Net.RestRequest;
 
 { TBearerAuthProvider }
 
@@ -175,70 +179,49 @@ end;
 
 procedure TOAuth2ClientCredentialsProvider.RefreshToken;
 var
-  HttpClient: THTTPClient;
-  Response: IHTTPResponse;
-  Body: TStringStream;
-  JsonStr: string;
-  TokenStart, TokenEnd: Integer;
-  ExpiresStart, ExpiresEnd: Integer;
-  ExpiresIn: Integer;
-  BodyContent: string;
+  LBody: TStringStream;
+  LBodyContent: string;
+  LJson: TJSONObject;
+  LExpiresIn: Integer;
+  LRestClient: IRestResponse;
 begin
-  HttpClient := THTTPClient.Create;
+  LBodyContent :=
+    'grant_type=client_credentials' +
+    '&client_id=' + TNetEncoding.URL.Encode(FClientId) +
+    '&client_secret=' + TNetEncoding.URL.Encode(FClientSecret);
+
+  if FScope <> '' then
+    LBodyContent := LBodyContent + '&scope=' + TNetEncoding.URL.Encode(FScope);
+
+  LBody := TStringStream.Create(LBodyContent, TEncoding.UTF8);
   try
-    HttpClient.ContentType := 'application/x-www-form-urlencoded';
-
-    BodyContent := 'grant_type=client_credentials' +
-      '&client_id=' + TNetEncoding.URL.Encode(FClientId) +
-      '&client_secret=' + TNetEncoding.URL.Encode(FClientSecret);
-    if FScope <> '' then
-      BodyContent := BodyContent + '&scope=' + TNetEncoding.URL.Encode(FScope);
-
-    Body := TStringStream.Create(BodyContent, TEncoding.UTF8);
-    try
-      Response := HttpClient.Post(FTokenUrl, Body, nil,
-        [TNetHeader.Create('Content-Type', 'application/x-www-form-urlencoded')]) as IHTTPResponse;
-
-      if (Response.StatusCode < 200) or (Response.StatusCode >= 300) then
-        raise Exception.CreateFmt(
-          'OAuth2 token request failed (HTTP %d): %s',
-          [Response.StatusCode, Response.ContentAsString]);
-
-      // Lightweight JSON parsing (avoids dependency on Dext.Json for this low-level unit)
-      JsonStr := Response.ContentAsString;
-
-      // Extract access_token
-      TokenStart := Pos('"access_token"', JsonStr);
-      if TokenStart = 0 then
-        raise Exception.Create('OAuth2 response missing access_token');
-      TokenStart := Pos('"', JsonStr, TokenStart + Length('"access_token"'));
-      TokenStart := Pos('"', JsonStr, TokenStart + 1) + 1;
-      TokenEnd := Pos('"', JsonStr, TokenStart);
-      FCachedToken := Copy(JsonStr, TokenStart, TokenEnd - TokenStart);
-
-      // Extract expires_in (default 3600 if not present)
-      ExpiresIn := 3600;
-      ExpiresStart := Pos('"expires_in"', JsonStr);
-      if ExpiresStart > 0 then
-      begin
-        ExpiresStart := Pos(':', JsonStr, ExpiresStart) + 1;
-        // Skip whitespace
-        while (ExpiresStart <= Length(JsonStr)) and (JsonStr[ExpiresStart] = ' ') do
-          Inc(ExpiresStart);
-        ExpiresEnd := ExpiresStart;
-        while (ExpiresEnd <= Length(JsonStr)) and CharInSet(JsonStr[ExpiresEnd], ['0'..'9']) do
-          Inc(ExpiresEnd);
-        ExpiresIn := StrToIntDef(Copy(JsonStr, ExpiresStart, ExpiresEnd - ExpiresStart), 3600);
-      end;
-
-      // Set expiration with 30-second safety margin
-      FExpiresAt := IncSecond(Now, ExpiresIn - 30);
-    finally
-      Body.Free;
-    end;
+    LRestClient := RestClient
+      .ContentType(TDextContentType.ctFormUrlEncoded)
+      .Post(FTokenUrl, LBody)
+      .Await;
   finally
-    HttpClient.Free;
+    LBody.Free;
   end;
+
+  if (LRestClient.StatusCode < 200) or (LRestClient.StatusCode >= 300) then
+    raise Exception.CreateFmt(
+      'OAuth2 token request failed (HTTP %d): %s',
+      [LRestClient.StatusCode, LRestClient.ContentString]);
+
+  LJson := TJSONObject.ParseJSONValue(LRestClient.ContentString) as TJSONObject;
+  try
+    if LJson = nil then
+      raise Exception.Create('Invalid token response.');
+
+    FCachedToken := LJson.GetValue<string>('access_token','');
+
+    LExpiresIn := LJson.GetValue<Integer>('expires_in',3600);
+    // Set expiration with 30-second safety margin
+    FExpiresAt := IncSecond(Now, LExpiresIn - 30);
+  finally
+    LJson.Free;
+  end;
+
 end;
 
 function TOAuth2ClientCredentialsProvider.GetHeaderValue: string;


### PR DESCRIPTION
Ajuste da classe TOAuth2ClientCredentialsProvider, o método RefreshToken não estava fazendo o parser correto do JSON.
Foi utilizado a própria api do Dex para chamada do endpoint.
Verificar o uso de referências circular
