### PR TITLE
docs: update documentation for V1 RC2 and add modern stack comparison

### DIFF
--- a/Docs/Book.pt-br/05-orm/mapeamento-aninhado.md
+++ b/Docs/Book.pt-br/05-orm/mapeamento-aninhado.md
@@ -1,16 +1,23 @@
-# Multi-Mapping (Objetos Aninhados)
+# Multi-Mapping (Objetos Aninhados) & Motor de Hidratação
 
-O Dext suporta **Multi-Mapping** (semelhante ao multi-mapping do Dapper), permitindo que você hidrate grafos de objetos complexos a partir de uma única consulta SQL com múltiplos joins. Isso é alcançado usando o atributo `[Nested]`.
+O Dext suporta **Multi-Mapping** (semelhante ao multi-mapping do Dapper), permitindo que você hidrate grafos de objetos complexos e multiníveis a partir de uma única consulta SQL plana com múltiplos joins. Isso é alcançado usando o atributo `[Nested]`.
+
+Ao contrário de outros ORMs ou micro-mappers que exigem lambdas complexos ou strings manuais de divisão, o Dext implementa um **motor de hidratação recursivo e altamente otimizado orientado por convenção**.
+
+---
 
 ## O Atributo [Nested]
 
 O atributo `[Nested]` informa ao ORM que uma propriedade representa um objeto aninhado que deve ser hidratado a partir das colunas do conjunto de resultados atual, em vez de ser carregado via uma consulta separada (Lazy Loading) ou um join `Include`.
 
-### Exemplo
+### Exemplo Básico
 
 ```pascal
 type
   TAddress = class
+  private
+    FStreet: string;
+    FCity: string;
   public
     property Street: string read FStreet write FStreet;
     property City: string read FCity write FCity;
@@ -18,6 +25,10 @@ type
 
   [Table('Users')]
   TUser = class
+  private
+    FId: Integer;
+    FName: string;
+    FAddress: TAddress;
   public
     [PK, AutoInc]
     property Id: Integer read FId write FId;
@@ -28,41 +39,97 @@ type
   end;
 ```
 
-## Lógica de Hidratação
+---
 
-Quando você executa uma consulta para `TUser`, o Dext espera que o conjunto de resultados contenha colunas tanto para o Usuário quanto para o Endereço.
+## Lógica de Hidratação sob o Capô
+
+Quando você executa uma consulta, o Dext lê a lista plana de nomes de colunas retornados pelo banco de dados.
+
+Em vez de exigir uma string de configuração manual do tipo `splitOn` do Dapper (.NET) (ex: `splitOn: 'Id'`), os motores do `TReflection` e `TDbSet` do Dext funcionam via **Roteamento de Caminho Baseado em Convenção**:
+
+1. **Escaneamento de Caminho (Path)**: O hidratador encontra colunas com separadores como `_` ou `.` (ex: `Address_Street`, `Address_City` ou `Address.Street`).
+2. **Auto-Instanciação**: O hidratador verifica o prefixo `Address`. Se a propriedade existir na entidade alvo (`TUser`), for do tipo classe e estiver atualmente como `nil`, o hidratador **a instancia automaticamente** em tempo de execução usando o cache otimizado e thread-safe do `TActivator`.
+3. **Escrita Direta em Campos**: Durante a hidratação, o Dext ignora os property setters lentos. Ele escreve diretamente nos campos privados da classe (ex: `FStreet`, `FCity`) resolvidos pelo cache da RTTI, evitando efeitos colaterais ou overhead de rastreamento no *Change Tracker* (Dirty Tracking).
 
 ```pascal
-// SQL gerado ou manual
-// SELECT Id, Name, Street, City FROM Users
+// Executando uma consulta SQL pura com tabelas joined
+var Users := Db.Users.FromSql(
+  'SELECT u.Id, u.Name, a.Street AS Address_Street, a.City AS Address_City ' +
+  'FROM Users u INNER JOIN Addresses a ON u.AddressId = a.Id'
+).ToList;
 
-var Users := Db.Users.ToList;
-// Cada objeto User terá sua propriedade Address automaticamente instanciada e populada.
+// Resultado: Cada objeto TUser é criado, seu objeto FAddress interno é
+// automaticamente alocado e os campos aninhados são completamente hidratados.
 ```
 
-## Multi-Mapping Avançado
+---
 
-Você pode usar o `[Nested]` com um prefixo se suas colunas seguirem convenções de nomenclatura específicas:
+## Multi-Mapping Avançado com Prefixos
+
+Você pode especificar um prefixo personalizado no atributo `[Nested]` para mapear colunas que não correspondam exatamente ao nome da propriedade:
 
 ```pascal
 type
   TUser = class
+  private
+    FAddress: TAddress;
   public
     [Nested('addr_')]
     property Address: TAddress read FAddress write FAddress;
   end;
 
-// Espera colunas: addr_Street, addr_City
+// O hidratador agora espera colunas que começam com: addr_Street, addr_City
 ```
+
+---
+
+## Aninhamento Recursivo com Profundidade Infinita
+
+Como o método `TReflection.SetValueByPath` do Dext é totalmente recursivo, ele suporta o mapeamento de árvores de objetos profundas. O motor de hidratação percorrerá e alocará automaticamente as classes aninhadas em qualquer profundidade, desde que caminhos de colunas correspondentes sejam encontrados no resultado da consulta.
+
+### Exemplo de Aninhamento Profundo
+
+```pascal
+type
+  TCountry = class
+  private
+    FName: string;
+  public
+    property Name: string read FName write FName;
+  end;
+
+  TAddress = class
+  private
+    FCity: string;
+    FCountry: TCountry;
+  public
+    property City: string read FCity write FCity;
+    
+    [Nested]
+    property Country: TCountry read FCountry write FCountry;
+  end;
+
+  TUser = class
+  private
+    FAddress: TAddress;
+  public
+    [Nested]
+    property Address: TAddress read FAddress write FAddress;
+  end;
+```
+
+**Colunas para consultar**:
+* `Address_City`
+* `Address_Country_Name` (ou `Address.Country.Name`)
+
+Quando o hidratador do Dext processar a coluna `Address_Country_Name`, ele a dividirá em segmentos (`Address` -> `Country` -> `Name`). Ele instanciará automaticamente `FAddress` (se for `nil`), depois instanciará `FCountry` (se for `nil`) e, finalmente, definirá o campo `Name` do país.
+
+---
 
 ## Quando usar Multi-Mapping vs Include
 
-*   **Use `Include`**: Para relacionamentos padrão (1:1, 1:N) onde a entidade relacionada tem sua própria tabela e ID. Este é o modo "ORM Padrão".
+*   **Use `Include`**: Para relacionamentos de banco de dados padrão (1:1, 1:N) onde a entidade relacionada é uma entidade rastreada pelo banco, com seu próprio ciclo de vida independente e chaves primárias.
 *   **Use `[Nested]`**:
-    *   Para **Value Objects** (padrão DDD) que não possuem identidade própria e são armazenados na mesma tabela que o proprietário.
-    *   Para otimizar manualmente joins complexos ao usar `FromSql`.
-    *   Quando você deseja evitar o overhead de rastrear múltiplas entidades separadas e quer apenas uma hidratação plana e única.
-
-## Aninhamento Recursivo
-
-O Dext suporta aninhamento recursivo. Você pode ter uma propriedade `[Nested]` dentro de outra classe `[Nested]`, e o motor de hidratação percorrerá a árvore enquanto colunas correspondentes forem encontradas no conjunto de resultados.
+    *   Para **Value Objects** (padrão DDD) que não possuem identidade própria no banco de dados e são armazenados na mesma tabela que o proprietário.
+    *   Para otimizar manualmente joins complexos ao executar consultas SQL puras via `FromSql`.
+    *   Para ignorar completamente o overhead de rastreamento de entidades e ler DTOs/projeções de leitura complexos em uma única viagem plana ao banco de dados.

--- a/Docs/Book/05-orm/nested-mapping.md
+++ b/Docs/Book/05-orm/nested-mapping.md
@@ -1,16 +1,23 @@
-# Multi-Mapping (Nested Objects)
+# Multi-Mapping (Nested Objects) & Hydration Engine
 
-Dext supports **Multi-Mapping** (similar to Dapper's multi-mapping), allowing you to hydrate complex object graphs from a single SQL query with multiple joins. This is achieved using the `[Nested]` attribute.
+Dext supports **Multi-Mapping** (similar to Dapper's multi-mapping), allowing you to hydrate complex, multi-level object graphs from a single flat SQL query with multiple joins. This is achieved using the `[Nested]` attribute.
+
+Unlike other ORMs or micro-mappers that require complex lambda functions or manual splitting strings, Dext implements a **convention-driven, highly optimized recursive hydration engine**.
+
+---
 
 ## The [Nested] Attribute
 
 The `[Nested]` attribute tells the ORM that a property represents a nested object that should be hydrated from the columns of the current result set, rather than being loaded via a separate query (Lazy Loading) or an `Include` join.
 
-### Example
+### Basic Example
 
 ```pascal
 type
   TAddress = class
+  private
+    FStreet: string;
+    FCity: string;
   public
     property Street: string read FStreet write FStreet;
     property City: string read FCity write FCity;
@@ -18,6 +25,10 @@ type
 
   [Table('Users')]
   TUser = class
+  private
+    FId: Integer;
+    FName: string;
+    FAddress: TAddress;
   public
     [PK, AutoInc]
     property Id: Integer read FId write FId;
@@ -28,41 +39,97 @@ type
   end;
 ```
 
-## Hydration Logic
+---
 
-When you execute a query for `TUser`, Dext expects the result set to contain columns for both the User and the Address.
+## Hydration Logic Under the Hood
+
+When you execute a query, Dext reads the flat list of column names returned by the database. 
+
+Instead of requiring a manual C# Dapper-style `splitOn` string configuration (e.g. `splitOn: 'Id'`), Dext's `TReflection` and `TDbSet` engines work via **Convention-Based Path Routing**:
+
+1. **Path Scanning**: The hydrator encounters columns with separators like `_` or `.` (e.g. `Address_Street`, `Address_City` or `Address.Street`).
+2. **Auto-Instantiation**: The hydrator checks the prefix `Address`. If the property exists on the target entity (`TUser`), is class-typed, and currently `nil`, the hydrator **automatically instantiates it** on-the-fly using the optimized, thread-safe `TActivator` cache.
+3. **Direct Field Writing**: During hydration, Dext bypasses slow property setters. It writes directly to the private backing fields (e.g. `FStreet`, `FCity`) resolved via RTTI cache, preventing side-effects or dirty-tracking overhead on the change tracker.
 
 ```pascal
-// SQL generated or manual
-// SELECT Id, Name, Street, City FROM Users
+// Executing a flat raw SQL query with joined tables
+var Users := Db.Users.FromSql(
+  'SELECT u.Id, u.Name, a.Street AS Address_Street, a.City AS Address_City ' +
+  'FROM Users u INNER JOIN Addresses a ON u.AddressId = a.Id'
+).ToList;
 
-var Users := Db.Users.ToList;
-// Each User object will have its Address property automatically instantiated and populated.
+// Result: Each TUser object is created, its FAddress object is automatically
+// allocated, and the nested fields are fully hydrated.
 ```
 
-## Advanced Multi-Mapping
+---
 
-You can use `[Nested]` with a prefix if your columns have specific naming conventions:
+## Advanced Multi-Mapping with Prefixes
+
+You can specify a custom prefix in the `[Nested]` attribute to map columns that don't match the property name exactly:
 
 ```pascal
 type
   TUser = class
+  private
+    FAddress: TAddress;
   public
     [Nested('addr_')]
     property Address: TAddress read FAddress write FAddress;
   end;
 
-// Expects columns: addr_Street, addr_City
+// The hydrator now expects columns starting with: addr_Street, addr_City
 ```
+
+---
+
+## Recursive Nesting to Infinite Depth
+
+Because Dext's `TReflection.SetValueByPath` is fully recursive, it supports mapping deep object trees. The hydration engine will traverse and automatically allocate nested classes to any depth as long as matching column paths are found in the query result.
+
+### Deep Nesting Example
+
+```pascal
+type
+  TCountry = class
+  private
+    FName: string;
+  public
+    property Name: string read FName write FName;
+  end;
+
+  TAddress = class
+  private
+    FCity: string;
+    FCountry: TCountry;
+  public
+    property City: string read FCity write FCity;
+    
+    [Nested]
+    property Country: TCountry read FCountry write FCountry;
+  end;
+
+  TUser = class
+  private
+    FAddress: TAddress;
+  public
+    [Nested]
+    property Address: TAddress read FAddress write FAddress;
+  end;
+```
+
+**Columns to query**:
+* `Address_City`
+* `Address_Country_Name` (or `Address.Country.Name`)
+
+When Dext hydrator processes the column `Address_Country_Name`, it splits it into segments (`Address` -> `Country` -> `Name`). It will automatically instantiate `FAddress` (if `nil`), then instantiate `FCountry` (if `nil`), and finally set the `Name` field of the country instance.
+
+---
 
 ## When to use Multi-Mapping vs Include
 
-*   **Use `Include`**: For standard relationships (1:1, 1:N) where the related entity has its own table and ID. This is the "Standard ORM" way.
+*   **Use `Include`**: For standard database relationships (1:1, 1:N) where the related entity is a tracked DB entity with its own independent lifecycle and primary keys.
 *   **Use `[Nested]`**:
-    *   For **Value Objects** (DDD pattern) that don't have their own identity and are stored in the same table as the owner.
-    *   To manually optimize complex joins when using `FromSql`.
-    *   When you want to avoid the overhead of tracking multiple separate entities and just want a single flat hydration.
-
-## Recursive Nesting
-
-Dext supports recursive nesting. You can have a `[Nested]` property inside another `[Nested]` class, and the hydration engine will traverse the tree as long as matching columns are found in the result set.
+    *   For **Value Objects** (DDD pattern) that don't have their own database identity and are stored in the same table as the owner.
+    *   To manually optimize complex joins when executing raw SQL queries via `FromSql`.
+    *   To completely bypass entity tracking overhead and pull complex, read-only DTOs/projections in a single flat database trip.

--- a/Docs/Comparison/Dext_ORM_Capabilities.md
+++ b/Docs/Comparison/Dext_ORM_Capabilities.md
@@ -1,0 +1,605 @@
+# Dext ORM — Complete Capabilities Reference
+
+> **Dext is engineered with a vision of "Inspiration, Not Limitation."**
+> While Entity Framework Core serves as a brilliant architectural reference for modern enterprise persistence, Dext is not a rigid, stock port. It adapts proven, high-performance patterns from .NET, Java/Spring Boot, Go, and Flutter/Dart, combining them with exclusive native innovations designed specifically for the Delphi compiler and visual VCL/FMX RAD legacies.
+> 
+> *Last Updated: May 2026*
+
+---
+
+## At a Glance
+ 
+| Metric | Value |
+|:---|:---|
+| **Supported Databases** | 7 natively (PostgreSQL, SQL Server, MySQL, SQLite, Oracle, Firebird, InterBase) built on the **FireDAC Phys Driver layer** — easily expandable to all database engines supported by FireDAC (DB2, MongoDB, Teradata, etc.). |
+| **ORM Architecture** | DbContext / Unit of Work / Change Tracking / Identity Map |
+| **Query Language** | Type-safe ergonomic DSL via `Prop<T>` AST |
+| **Exclusive Features** | Database as API, EntityDataSet & Active Architecture, Smart Properties AST, JSON Column Queries, native MCP Server |
+| **Testing** | 5-database CI matrix (PostgreSQL, SQL Server, MySQL, SQLite, Firebird — structurally covering InterBase as well) |
+| **Production Evidence** | AWS/Azure — ~800,000 requests/day in fiscal management systems |
+
+---
+
+## 1. Core Architecture
+
+### DbContext — Unit of Work
+
+The Dext ORM follows the same Unit of Work + Repository pattern as Entity Framework Core.
+
+**EF Core:**
+```csharp
+public class AppDbContext : DbContext
+{
+    public DbSet<Product> Products { get; set; }
+    public DbSet<Order> Orders { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder options)
+        => options.UseNpgsql(connectionString);
+}
+
+using var db = new AppDbContext();
+db.Products.Add(new Product { Name = "Widget", Price = 9.99m });
+await db.SaveChangesAsync();
+```
+
+**Dext (Current syntax with manual getters):**
+```pascal
+type
+  TAppDbContext = class(TDbContext)
+  private
+    function GetProducts: IDbSet<TProduct>;
+    function GetOrders: IDbSet<TOrder>;
+  public
+    property Products: IDbSet<TProduct> read GetProducts;
+    property Orders: IDbSet<TOrder> read GetOrders;
+  end;
+
+function TAppDbContext.GetProducts: IDbSet<TProduct>;
+begin
+  Result := Entity<TProduct>; // Herdado da classe base TDbContext
+end;
+
+function TAppDbContext.GetOrders: IDbSet<TOrder>;
+begin
+  Result := Entity<TOrder>;
+end;
+
+var Db := TAppDbContext.Create(
+  DbOptions.UsePostgreSQL(ConnectionString)
+);
+Db.Products.Add(TProduct.Create('Widget', 9.99));
+Db.SaveChanges;
+```
+
+> [!NOTE]
+> **Roadmap Evolution ([S30](../../DextRepository/Docs/Specs/S30-DbContext-AutoHydration.md))**: In the upcoming Wave 3 stability release, Dext will introduce **Automatic DbContext Hydration** to eliminate even these single-line getters. Properties will map directly to private fields (e.g., `property Products: IDbSet<TProduct> read FProducts;`), and the framework will automatically inject the corresponding repositories during context initialization using the optimized RTTI cache.
+
+Both follow the same pattern. The API surface is intentionally close.
+
+---
+
+## 2. Change Tracking
+
+Dext's Change Tracking uses the same 4-state model as EF Core:
+
+| State | Description |
+|:---|:---|
+| `Added` | Entity was added via `Add()`, not yet saved |
+| `Modified` | Tracked entity had its properties changed |
+| `Deleted` | Entity marked for deletion via `Remove()` |
+| `Unchanged` | Entity loaded from DB, no changes detected |
+
+**Identity Map**: Like EF Core, Dext maintains an in-memory map ensuring that two queries for the same PK return the same object instance — preventing ghost writes and inconsistent state.
+
+---
+
+## 3. Query Engine — Type-Safe, No Magic Strings
+
+### EF Core approach (Strongly-Typed LINQ):
+
+```csharp
+// Fully compile-time type-safe via C# Native LINQ
+var products = await db.Products
+    .Where(p => p.Price > 100 && p.Name.Contains("Widget"))
+    .OrderByDescending(p => p.Price)
+    .Skip(20)
+    .Take(10)
+    .ToListAsync();
+```
+
+### Dext approach (Type-Safe AST via Smart Properties ou TEntityType<T> metadata):
+
+```pascal
+// Achieves the exact same level of compile-time type safety in Delphi.
+// Overloaded operators generate a secure AST without legacy "FieldByName" magic strings.
+var P := Prototype.Entity<TProduct>;
+var Products := Db.Products
+  .Where((P.Price > 100) and P.Name.Contains('Widget'))
+  .OrderBy(P.Price.Desc)
+  .Skip(20)
+  .Take(10)
+  .ToList;
+```
+
+#### Dual-Mode Architecture & Metadata Cache
+
+The `Prop<T>` record is an engineering marvel designed to work seamlessly in **dual mode**:
+- **Runtime Mode**: Operates as a standard field value, storing the type `T` value in memory.
+- **Query/DSL Mode**: Overloaded operators (`>`, `<`, `=`, `and`, `or`, `Contains`, `Like`, `In`, `IsNull`...) automatically generate `IExpression` AST nodes. 
+
+Dext gives the developer two elegant patterns to resolve entity companion metadata:
+1. **Smart Properties (Unified Domain Entity)**: By embedding `Prop<T>` (or built-in aliases IntType, StringType, BooleanType, etc.) directly inside the entity (e.g. `TProduct`), the class becomes the single source of truth for both data and metadata, keeping the domain highly cohesive.
+2. **Separated Companion Type (`TEntityType<T>`)**: If the developer prefers to work with raw primitive Pascal types (e.g. standard `Integer`, `String`, `Boolean`), Dext allows creating a companion class (e.g. `TProductType`) carrying the AST.
+
+To make usage elegant, developers can define a simple class function on the entity returning the metadata:
+```pascal
+// Option A: Smart Properties (Cohesive Domain)
+class function TProduct.Prototype: TProduct;
+begin
+  Result := Prototype.Entity<TProduct>;
+end;
+
+// Option B: Pure Primitive Domain + Companion Type
+class function TProduct.Prototype: TEntityType<TProduct>;
+begin
+  Result := TProductType;
+end;
+```
+
+**Under the hood**: The metadata extraction footprint is exactly identical. Both approaches leverage Dext's highly optimized, thread-safe RTTI metadata cache. RTTI scanning is executed only once per type, populating the cache and resolving the AST mapping without runtime execution or memory overhead.
+
+**This same AST is used by:**
+1. The ORM SQL Compiler (generates database queries).
+2. The in-memory `TExpressionEvaluator` (filters standard `TList<T>` collections locally).
+3. The `Database as API` engine (translates URL filters like `?price_gt=100` to AST nodes automatically).
+
+---
+
+## 4. Relationships & Loading Strategies
+
+### Eager Loading
+
+**EF Core:**
+```csharp
+var orders = await db.Orders
+    .Include(o => o.Customer)
+    .ThenInclude(c => c.Address)
+    .ToListAsync();
+```
+
+**Dext:**
+```pascal
+var Orders := Db.Orders
+  .Include(O.Customer)
+  .ThenInclude(C.Address)
+  .ToList;
+```
+
+### Lazy Loading
+
+EF Core achieves lazy loading either via transparent virtual proxies (requiring virtual navigation properties) or via `ILazyLoader` injection. 
+
+Dext offers both worlds. It supports transparent proxy interception (same as EF Core's virtual proxies) **and** a highly elegant, explicit generic **`Lazy<T>` wrapper** pattern. The `Lazy<T>` wrapper keeps entities as 100% pure POCOs without needing virtual methods or complex class overrides:
+
+```pascal
+type
+  [Table('Comments')]
+  TComment = class
+  private
+    FId: Integer;
+    FText: string;
+    FAuthorId: Integer;
+    FAuthor: Lazy<TAuthor>;
+  public
+    [PK, AutoInc]
+    property Id: Integer read FId write FId;
+    property Text: string read FText write FText;
+    
+    [Column('author_id')]
+    property AuthorId: Integer read FAuthorId write FAuthorId;
+    
+    [BelongsTo]
+    [ForeignKey('author_id')]
+    property Author: Lazy<TAuthor> read FAuthor write FAuthor;
+  end;
+```
+
+When you access `Comment.Author.Value`, the Dext framework dynamically resolves and executes the database query on demand, using thread-safe double-checked locking. This offers a highly structured, self-documenting architectural contract directly inside the entity definition.
+
+### Multi-Mapping (Dapper-style) & Recursive Hydration
+
+While basic ORMs struggle with flat query results representing joined tables, Dext features a **zero-boilerplate, high-performance recursive hydrator** similar to Dapper's multi-mapping (`splitOn`), but with significantly more automation.
+
+By declaring a relationship field with the `[Nested]` attribute (or mapping it fluently), you activate Dext's **recursive path mapper**.
+
+```pascal
+type
+  TOrderLine = class
+  private
+    FProductId: Integer;
+    FQuantity: Integer;
+    FProduct: TProduct;
+  public
+    property ProductId: Integer read FProductId write FProductId;
+    property Quantity: Integer read FQuantity write FQuantity;
+
+    [Nested]
+    property Product: TProduct read FProduct write FProduct;
+  end;
+```
+
+#### How It Works Under the Hood (No Manual `splitOn` Required)
+
+In Dapper (.NET), mapping a joined row requires specifying a manual `splitOn` string (e.g. `'Id'`) so the framework knows where to segment the flat column list. 
+
+Dext eliminates this configuration step by utilizing **convention-based path routing** at the compiler/RTTI level:
+
+1. **Path-Name Recognition**: The hydrator scans the returned database column list. If it encounters a column with a separator like `_` or `.` (e.g. `Product_Id`, `Product_Name`, `Product_Price` or `Product.Name`), it extracts the prefix (`Product`).
+2. **Auto-Instantiation (Lazy Allocation)**: If the target property (`Product`) is class-typed and currently `nil`, the hydrator **automatically instantiates it** on-the-fly using the optimized `TActivator` metadata cache.
+3. **Recursive Value Binding**: It then routes the remaining path segments recursively (e.g., binding `Name` and `Price` directly to `FProduct.FName` and `FProduct.FPrice`).
+4. **Infinite Depth Mapping**: Because Dext's `TReflection.SetValueByPath` is recursive, it can automatically map multi-level hierarchies (e.g. `Order_Customer_Address_City`) to any depth with zero manual configuration.
+
+#### Performance & Safety
+* **Zero GC Pressure**: Path parsing uses light stack-allocated buffers and in-place string indexing.
+* **Property Interception**: Bypasses slow property setters by writing directly to the backing fields (resolved via RTTI cache) during hydration, preventing side-effects or dirty-tracking overhead.
+
+---
+
+## 5. Migrations System
+
+Dext uses code-first migrations with chronological snapshots — same conceptual model as EF Core:
+
+```
+dotnet ef migrations add InitialCreate    →  dext migrations add InitialCreate
+dotnet ef database update                 →  dext database update
+```
+
+**Additional capability**: Dext detects table and column renames via attributes, generating `RENAME TABLE` / `RENAME COLUMN` SQL instead of `DROP + CREATE`.
+
+---
+
+## 6. Soft Delete — `[SoftDelete]` Attribute
+
+EF Core requires manual Global Query Filter setup for soft delete. Dext makes it declarative:
+
+**EF Core (manual setup):**
+```csharp
+// Model configuration
+modelBuilder.Entity<Task>().HasQueryFilter(t => !t.IsDeleted);
+
+// Override SaveChanges
+public override Task<int> SaveChangesAsync(...)
+{
+    foreach (var entry in ChangeTracker.Entries<Task>())
+        if (entry.State == EntityState.Deleted)
+        {
+            entry.State = EntityState.Modified;
+            entry.Entity.IsDeleted = true;
+        }
+    return base.SaveChangesAsync(...);
+}
+```
+
+**Dext (fully declarative with optional timestamp tracking):**
+```pascal
+type
+  [SoftDelete('IsDeleted')]
+  TTask = class
+  private
+    FName: StringType;
+    FIsDeleted: BoolType;
+    FDeletedAt: DateTimeType;
+  public
+    property Name: StringType read FName write FName;
+    property IsDeleted: BoolType read FIsDeleted write FIsDeleted;
+
+    [DeletedAt]
+    property DeletedAt: DateTimeType read FDeletedAt write FDeletedAt;
+  end;
+```
+
+That's it. Dext automatically:
+- Transforms `Remove()` into `UPDATE SET IsDeleted = TRUE` (and automatically stamps the current date/time on the `DeletedAt` property if decorated with the `[DeletedAt]` attribute).
+- Filters deleted records out of all queries by default.
+- Exposes `IgnoreQueryFilters`, `OnlyDeleted`, `HardDelete`, and `Restore`.
+- Cleans the Identity Map after soft-deletion.
+
+Supports custom values: `[SoftDelete('Status', 99, 0)]` — uses integer/enum status codes.
+
+---
+
+## 7. JSON Column Queries — `[JsonColumn]`
+
+**EF Core (PostgreSQL):**
+```csharp
+// EF Core 7+ with PostgreSQL JSON support
+var admins = db.Users
+    .Where(u => EF.Functions.JsonExists(u.Settings, "role"))
+    .ToList();
+```
+
+**Dext (cross-database):**
+```pascal
+var U: TUserType;
+var Admins := Db.Users
+  .Where(U.Settings.Json('role') = 'admin')
+  .ToList;
+```
+
+Cross-database implementation:
+- **PostgreSQL**: `settings #>> '{role}'` (JSONB indexed)
+- **MySQL**: `JSON_UNQUOTE(JSON_EXTRACT(settings, '$.role'))`
+- **SQLite**: `json_extract(settings, '$.role')`
+- **SQL Server**: `JSON_VALUE(settings, '$.role')`
+
+Nested paths work too: `U.Settings.Json('profile.details.level') = 5`
+
+---
+
+## 8. Multi-Tenancy — Built-in
+
+Dext has a dedicated `Dext.MultiTenancy` module with **three isolation strategies**:
+
+| Strategy | How It Works | Best For |
+|:---|:---|:---|
+| **Shared Database** | `TenantId` column discriminator — automatic filter | Small tenants, cost efficiency |
+| **Schema Isolation** | PostgreSQL `search_path` switching per request | Medium tenants, logical isolation |
+| **Database per Tenant** | Dynamic connection string per tenant | Enterprise, strict data isolation |
+
+```pascal
+Services.AddMultiTenancy
+  .UseSharedDatabase  // or .UseSchemaIsolation or .UseDatabasePerTenant
+  .WithTenantFromHeader('X-Tenant-Id');
+```
+
+---
+
+## 9. Inheritance Mapping
+
+**Table-Per-Hierarchy (TPH)** — full support with polymorphic hydration:
+
+```pascal
+type
+  [Discriminator('Type')]
+  TVehicle = class
+    Name: StringType;
+    [DiscriminatorValue('car')]
+    // ...
+  end;
+
+  TCar = class(TVehicle)
+    Doors: IntType;
+  end;
+
+  TTruck = class(TVehicle)
+    Payload: FloatType;
+  end;
+```
+
+---
+
+## 10. Stored Procedures — Declarative Command Pattern
+
+Executing Stored Procedures in modern enterprise systems is a common hot path, but it is notoriously painful in traditional ORMs.
+
+### The Contrast
+
+#### EF Core (Manual Parameter Binding & Rigid Mapping)
+C# does not support dynamic object inference or dynamic query result mapping out-of-the-box in EF Core.
+* If the procedure returns custom aggregates, you **must declare a DTO** and explicitly register it as a keyless entity in the `DbContext` (`modelBuilder.Entity<T>().HasNoKey()`).
+* If the procedure has `OUT` or `INOUT` parameters, or returns multiple result sets, EF Core **forces you to drop down to pure ADO.NET boilerplate** (`DbCommand`, `DbDataReader`), instantiating manual `SqlParameter` objects and reading data row-by-row.
+
+```csharp
+// EF Core: Prone to magic string errors and requires manual parameter setup
+var minPriceParam = new SqlParameter("@MinPrice", 100);
+var result = await db.Database.ExecuteSqlRawAsync(
+    "EXEC GetTopProducts @MinPrice", minPriceParam);
+```
+
+#### Dext (Declarative Command Pattern)
+Dext wraps Stored Procedures using a cohesive **Command/CQRS Pattern**. While it requires defining a class, this class serves as a **compile-time checked architectural contract** that encapsulates all inputs, outputs, and projections.
+
+```pascal
+type
+  [StoredProcedure('GetTopProducts')]
+  TGetTopProducts = class
+  private
+    FMinPrice: Currency;
+    FResults: IList<TProduct>;
+  public
+    [DbParam('MinPrice')]
+    property MinPrice: Currency read FMinPrice write FMinPrice;
+
+    // The query projection is auto-hydrated from the procedure's result set
+    property Results: IList<TProduct> read FResults write FResults;
+  end;
+
+// Execution: Zero database boilerplate, zero loose parameter arrays
+var Command := TGetTopProducts.Create;
+Command.MinPrice := 100;
+Db.Execute(Command); 
+```
+
+### Key Architectural Advantages of the Dext Approach
+
+1. **Zero ADO.NET/FireDAC Leaks**: You never write low-level code to bind parameters, set database types, or open/close connection streams. Dext handles connection lifetime, parameter direction, and memory cleanup automatically.
+2. **Cohesive Strongly-Typed Contract**: Inputs (`[DbParam]`), outputs (`out` parameters), and return datasets are structurally bound to the command object. This eliminates unsafe runtime arrays and type casting.
+3. **CQRS Ready**: Perfectly aligns with *Command Query Responsibility Segregation* patterns. Each complex database operation is treated as an isolated, testable, and self-documenting command unit.
+4. **Rich Projection Hydration**: The returned rows are automatically parsed and mapped to rich entity graphs or lightweight DTO lists using the optimized, RTTI-cached hydrator.
+
+---
+
+## 11. Exclusive Capabilities (Not in EF Core)
+
+### 11.1 Database as API
+
+**The most powerful feature of the Dext ORM.** Generate a full CRUD REST API from a single attribute — no controllers, no services, no repositories:
+
+```pascal
+type
+  [Table, DataApi('/api/products')]
+  TProduct = class
+    Id: IntType;
+    Name: StringType;
+    Price: CurrencyType;
+  end;
+
+// In startup:
+App.MapDataApis; // Done.
+```
+
+This generates **5 endpoints automatically**:
+
+| Method | Route | Description |
+|:---|:---|:---|
+| `GET` | `/api/products` | List with pagination, sorting, and 11 filter operators |
+| `GET` | `/api/products/{id}` | PK lookup (simple or composite) |
+| `POST` | `/api/products` | Create — returns 201 |
+| `PUT` | `/api/products/{id}` | Full update |
+| `DELETE` | `/api/products/{id}` | Delete |
+
+**URL Filter System (11 operators):**
+```
+GET /api/products?price_gt=100&name_cont=widget&_orderby=price+desc&_limit=20&_offset=0
+```
+
+Operators: `_eq`, `_neq`, `_gt`, `_gte`, `_lt`, `_lte`, `_cont` (LIKE %x%), `_sw`, `_ew`, `_in`, `_null`
+
+**Granular Security:**
+```pascal
+App.MapDataApis.Configure<TProduct>(
+  DataApiOptions
+    .RequireAuth
+    .RequireWriteRole(['admin'])
+    .Allow([amGet, amGetList]) // Read-only for non-admins
+    .UseSnakeCase
+    .UseSwagger
+);
+```
+
+---
+
+### 11.2 EntityDataSet — ORM ↔ VCL/FMX Bridge
+
+Connect legacy Delphi components (DBGrid, FastReport, TDBEdit) to rich Smart Property domains or standard POCO entity collections — with zero architecture compromise:
+
+```pascal
+EntityDataSet1.Collection := Db.Products.ToList; // Direct list (supports both POCO & Smart Properties)
+```
+
+**Live IDE Preview**: In design-time, provide a `TFDConnection` and `DataProvider`, and Dext generates dynamic SQL and displays real data in the DBGrid *without compiling the project*.
+
+This has **no equivalent in the .NET ecosystem** — Windows Forms DataAdapter requires manual mapping, and there is no Visual Studio designer that previews ORM data live.
+
+---
+
+### 11.3 In-Memory Expression Evaluator
+
+The same AST generated by `Prop<T>` can be evaluated against in-memory collections — without touching the database:
+
+```pascal
+var Filter := TExpressionEvaluator.Create;
+
+// Same expression used for SQL query...
+var SqlResult := Db.Products.Where(P.Price > 100).ToList;
+
+// ...also filters an in-memory list:
+var InMemoryResult := Filter.Evaluate(LocalCache, P.Price > 100);
+```
+
+EF Core does not expose an in-memory evaluator for the same expression tree used for SQL generation.
+
+---
+
+## 12. Performance Characteristics
+
+| Benchmark | Dext | Notes |
+|:---|:---|:---|
+| **Route matching** | 10,000 routes in 47ms, zero heap allocations | Span<T>-based routing |
+| **Dictionary lookup** | 6.6x faster than RTL | AVX2/SSE2 SIMD + Open Addressing |
+| **Compile time** | 60% reduction vs standard generics | Binary Code Folding |
+| **SSR memory** | O(1) for any record count | Flyweight streaming iterator |
+| **JSON parsing** | Zero-allocation UTF-8 via TByteSpan | Direct field offset injection |
+
+---
+
+## 13. Multi-Database Test Matrix
+
+The Dext ORM persistence engine is validated against a **real 5-database CI matrix** on every release:
+
+| Database | Version Tested | Notes |
+|:---|:---|:---|
+| **PostgreSQL** | 14, 15, 16 | JSONB, UUID, `search_path` for schemas |
+| **SQL Server** | 2019, 2022 | Window functions, TRY_CAST |
+| **MySQL** | 8.0 | JSON_EXTRACT, LIMIT/OFFSET |
+| **SQLite** | 3.x | In-process; json_extract |
+| **Firebird** | 3.0, 4.0 | Legacy paging (ROWS/TO), SEQUENCE |
+
+Oracle is supported in production but not included in the automated CI matrix.
+
+## 14. High-Performance Engineering & Architecture Deep Dive
+
+While functional capabilities are crucial, Dext's ultimate differentiator is **how these features are implemented** to achieve industrial-grade efficiency:
+* **Binary Code Folding**: Prevents "Generic Bloom" in Delphi, reducing compile times by up to 60% and shrinking binary sizes.
+* **SIMD-Accelerated Collections**: Vectorized AVX2/SSE2 lookups making `TRawDictionary` up to 6.6x faster than standard RTL dictionaries.
+* **In-Memory Expression Evaluator**: Direct reuse of the ORM's `Prop<T>` AST to evaluate complex queries against standard in-memory lists with zero database trips.
+
+For a comprehensive technical deep-dive into Dext's zero-allocation design, compiler optimizations, and low-level performance benchmarks, refer to the [Dext Framework Ecosystem Overview](https://github.com/cesarliws/dext/blob/main/Docs/Dext_Ecosystem_Overview.md).
+
+---
+
+## 15. ORM Quick-Reference Summary
+
+The table below covers the core ORM capabilities at a glance. For the full framework-wide comparison including web, DI, testing, and exclusive features, see the **[Feature Comparison Reference](./Feature_Comparison_Dext_vs_DotNet.md)**.
+
+| ORM Capability | EF Core | Dext ORM | Dext Highlight |
+|:---|:---:|:---:|:---|
+| **DbContext / Unit of Work** | Yes | Yes | `TDbContext` - same UoW + Identity Map pattern |
+| **Change Tracking (4 states)** | Yes | Yes | `Added / Modified / Deleted / Unchanged` |
+| **Code-First Migrations** | Yes | Yes | Snapshot-based, chronological, with rename detection |
+| **Lazy / Eager Loading** | Yes | Yes | `Include()` / `ThenInclude()` - same API |
+| **Soft Delete** | Partial (manual filter) | Yes | `[SoftDelete]` + `[DeletedAt]` out of the box |
+| **Multi-Tenancy** | Partial (query filter) | Yes | 3 strategies: Shared DB, Schema, DB-per-Tenant |
+| **Pessimistic Locking** | No (raw SQL only) | Yes | `FOR UPDATE` integrated in the query engine |
+| **JSON Column Queries** | Yes | Yes | `[JsonColumn]` + `.Json('path')` - cross-DB |
+| **Inheritance TPH** | Yes | Yes | Polymorphic hydration via discriminator |
+| **Inheritance TPT / TPC** | Yes | Partial | Roadmap |
+| **Value Converters** | Yes | Yes | `TValueConverterRegistry` - 20+ built-in |
+| **Stored Procedures** | Yes | Yes | `[StoredProcedure]` + `[DbParam]` - fully declarative |
+| **Multi-Mapping (Dapper-style)** | No | Yes | `[Nested]` - recursive hydration via `_` / `.` separators |
+| **Multi-Database Support** | Yes (NuGet) | Yes (7 native) | PostgreSQL, SQL Server, MySQL, SQLite, Oracle, Firebird, InterBase |
+| **Type-Safe Query DSL** | Yes (LINQ) | Yes (`Prop<T>` AST) | Same AST reused for SQL, in-memory filter, and URL parsing |
+| **Database as API** | No | Yes | `[DataApi]` - full CRUD REST API in 1 attribute |
+| **EntityDataSet (VCL/FMX)** | No | Yes | POCO to DBGrid/FastReport bridge with design-time preview |
+| **In-Memory Expression Evaluator** | No | Yes | Same `Prop<T>` AST filters in-memory `TList<T>` |
+| **URL to Expression Parser** | No | Yes | `?price_gt=100` automatically converted to AST node |
+
+
+## 16. Global Inspiration, Community Evolution: Beyond the Stock Paradigm
+
+A central tenet of the Dext design philosophy is **"Inspired by the best, optimized for Delphi, driven by the community."** We do not view .NET or EF Core as rigid templates to copy line-for-line, nor do we limit our horizon to replication. Instead, we use them as baseline benchmarks while integrating the best paradigms from the entire global software engineering landscape.
+
+### 1. Unified Out-of-the-Box Capabilities (The Third-Party Advantage)
+When developers evaluate .NET, they often look at what is available in the entire NuGet ecosystem, not just the stock BCL (Base Class Library). Dext has taken a highly proactive approach by **natively implementing the most popular, standard, and critical third-party C# patterns** directly inside our core framework. This eliminates the dependency hell of managing external packages:
+* **Object Mapping**: Natively built-in as `Dext.Mapper` (`TMapper`), inspired by the widely-used **AutoMapper** NuGet package.
+* **Specification Pattern**: Natively built-in as `Dext.Specifications`, inspired by **Ardalis.Specification**.
+* **Enterprise Event Bus & Pipeline Behaviors**: Natively built-in as `Dext.Events`, inspired by the industry-standard **MediatR** package.
+* **Testing & Mocks**: Natively built-in assertion engines, TestCase combinations, and `TAutoMocker`, inspired by **FluentAssertions**, **NUnit**, and **Moq**.
+
+### 2. A Polyglot Architecture: Borrowing from the Best
+Dext actively incorporates architectural breakthroughs and developer-friendly patterns from multiple major ecosystems:
+* **Go (Golang)**: We adapted the ultra-lightweight, high-throughput **Channel pattern** (`TChannel<T>`) and the deterministic **Defer pattern** (`IDeferred`/`TDeferredAction`) to bring clean, zero-leak resource management and powerful backpressure-aware concurrency to Delphi.
+* **Flutter & Dart**: We drew inspiration from Dart's compile-time safety paradigms, asynchronous ergonomics, and modern UI-reactive bindings to optimize how our visual VCL/FMX `EntityDataSet` behaves under active design-time changes.
+* **Java & Spring Boot**: We studied Spring Boot's clean IoC/DI container ergonomics and declarative attribute bindings to craft Dext's highly intuitive dependency injection and annotation-based routing mechanisms.
+* **Python & JavaScript/TypeScript**: We looked at the extreme developer ergonomics and simple setups of fast web frameworks like FastAPI and Hono to implement our native **HTMX auto-detection** and zero-boilerplate **Database as API** (`[DataApi]`) configurations.
+
+### 3. Open to Continuous, Community-Driven Growth
+Software frameworks are living systems. If a developer notices that a specific, highly-specialized feature "N" is missing from Dext's stock offering, we do not view this as a permanent constraint:
+* **Adaptive Feature Roadmap**: Our design architecture is intentionally modular and decoupled. Adding new capabilities, database dialects, custom converters, or middleware handlers is simple and clean.
+* **Open to Contributions**: We are committed to evolving Dext in close collaboration with the enterprise Delphi community. If your production environment requires a specialized architectural pattern or a specific data-access driver, the Dext team and community are fully equipped to build, review, and integrate it.
+* **Modernizing Delphi Together**: Dext is engineered to prove that Delphi developers do not have to compromise. You can have compiled, zero-dependency, ultra-fast native binaries while enjoying the most modern, elegant, and powerful software architecture patterns on the planet.
+
+---
+
+*Dext Framework — ORM Capabilities Reference | May 2026*
+

--- a/Docs/Comparison/Dext_ORM_Capabilities.pt-br.md
+++ b/Docs/Comparison/Dext_ORM_Capabilities.pt-br.md
@@ -1,0 +1,605 @@
+# Dext ORM — Referência Completa de Recursos
+
+> **O Dext é projetado com a visão de "Inspiração, Não Limitação".**
+> Embora o Entity Framework Core sirva como uma brilhante referência arquitetônica para persistência corporativa moderna, o Dext não é uma mera porta de entrada rígida ou clonagem simplista. Ele adapta padrões comprovados de alto desempenho do .NET, Java/Spring Boot, Go e Flutter/Dart, combinando-os com inovações nativas exclusivas projetadas especificamente para o compilador Delphi e os legados visuais VCL/FMX RAD.
+> 
+> *Última Atualização: Maio de 2026*
+
+---
+
+## Visão Geral
+ 
+| Métrica | Valor |
+|:---|:---|
+| **Bancos de Dados Suportados** | 7 nativamente (PostgreSQL, SQL Server, MySQL, SQLite, Oracle, Firebird, InterBase) construídos sobre a **camada de drivers FireDAC Phys** — facilmente expansível para todos os motores de banco de dados suportados pelo FireDAC (DB2, MongoDB, Teradata, etc.). |
+| **Arquitetura ORM** | DbContext / Unit of Work / Rastreamento de Mudanças (Change Tracking) / Identity Map |
+| **Linguagem de Consulta** | DSL ergonômica e fortemente tipada via AST `Prop<T>` |
+| **Recursos Exclusivos** | Database as API, EntityDataSet & Active Architecture, AST de Smart Properties, Consultas em Colunas JSON, Servidor MCP nativo |
+| **Testes** | Matriz de CI com 5 bancos de dados (PostgreSQL, SQL Server, MySQL, SQLite, Firebird — cobrindo estruturalmente também o InterBase) |
+| **Evidência em Produção** | AWS/Azure — ~800.000 requisições/dia em sistemas de gestão fiscal |
+
+---
+
+## 1. Arquitetura Central
+
+### DbContext — Unit of Work
+
+O Dext ORM segue o mesmo padrão Unit of Work + Repository que o Entity Framework Core.
+
+**EF Core:**
+```csharp
+public class AppDbContext : DbContext
+{
+    public DbSet<Product> Products { get; set; }
+    public DbSet<Order> Orders { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder options)
+        => options.UseNpgsql(connectionString);
+}
+
+using var db = new AppDbContext();
+db.Products.Add(new Product { Name = "Widget", Price = 9.99m });
+await db.SaveChangesAsync();
+```
+
+**Dext (Sintaxe atual com getters manuais):**
+```pascal
+type
+  TAppDbContext = class(TDbContext)
+  private
+    function GetProducts: IDbSet<TProduct>;
+    function GetOrders: IDbSet<TOrder>;
+  public
+    property Products: IDbSet<TProduct> read GetProducts;
+    property Orders: IDbSet<TOrder> read GetOrders;
+  end;
+
+function TAppDbContext.GetProducts: IDbSet<TProduct>;
+begin
+  Result := Entity<TProduct>; // Herdado da classe base TDbContext
+end;
+
+function TAppDbContext.GetOrders: IDbSet<TOrder>;
+begin
+  Result := Entity<TOrder>;
+end;
+
+var Db := TAppDbContext.Create(
+  DbOptions.UsePostgreSQL(ConnectionString)
+);
+Db.Products.Add(TProduct.Create('Widget', 9.99));
+Db.SaveChanges;
+```
+
+> [!NOTE]
+> **Evolução do Roadmap ([S30](../../DextRepository/Docs/Specs/S30-DbContext-AutoHydration.md))**: No próximo lançamento de estabilidade da Wave 3, o Dext introduzirá a **Hidratação Automática de DbContext** para eliminar até mesmo esses getters de linha única. As propriedades serão mapeadas diretamente para campos privados (por exemplo, `property Products: IDbSet<TProduct> read FProducts;`), e o framework injetará automaticamente os repositórios correspondentes durante a inicialização do contexto usando o cache de RTTI otimizado.
+
+Ambos seguem o mesmo padrão. A superfície de API é intencionalmente próxima.
+
+---
+
+## 2. Rastreamento de Mudanças (Change Tracking)
+
+O Change Tracking do Dext usa o mesmo modelo de 4 estados do EF Core:
+
+| Estado | Descrição |
+|:---|:---|
+| `Added` | A entidade foi adicionada via `Add()`, mas ainda não foi salva |
+| `Modified` | A entidade rastreada teve suas propriedades alteradas |
+| `Deleted` | A entidade foi marcada para exclusão via `Remove()` |
+| `Unchanged` | A entidade foi carregada do banco de dados e nenhuma alteração foi detectada |
+
+**Identity Map**: Assim como o EF Core, o Dext mantém um mapa em memória garantindo que duas consultas para a mesma Chave Primária (PK) retornem a mesma instância de objeto — evitando escritas fantasmas e estados inconsistentes.
+
+---
+
+## 3. Motor de Consulta — Fortemente Tipado, Sem Strings Mágicas
+
+### Abordagem do EF Core (LINQ Fortemente Tipado):
+
+```csharp
+// Totalmente type-safe em tempo de compilação via C# Native LINQ
+var products = await db.Products
+    .Where(p => p.Price > 100 && p.Name.Contains("Widget"))
+    .OrderByDescending(p => p.Price)
+    .Skip(20)
+    .Take(10)
+    .ToListAsync();
+```
+
+### Abordagem do Dext (AST Fortemente Tipada via Smart Properties ou metadados TEntityType<T>):
+
+```pascal
+// Atinge exatamente o mesmo nível de type safety em tempo de compilação no Delphi.
+// Operadores sobrecarregados geram uma AST segura sem as strings mágicas do antigo "FieldByName".
+var P := Prototype.Entity<TProduct>;
+var Products := Db.Products
+  .Where((P.Price > 100) and P.Name.Contains('Widget'))
+  .OrderBy(P.Price.Desc)
+  .Skip(20)
+  .Take(10)
+  .ToList;
+```
+
+#### Arquitetura Dual-Mode & Cache de Metadados
+
+O record `Prop<T>` é uma obra de engenharia projetada para funcionar perfeitamente em **modo dual**:
+- **Modo de Execução (Runtime Mode)**: Opera como um valor de campo padrão, armazenando o valor do tipo `T` em memória.
+- **Modo de Consulta/DSL (Query/DSL Mode)**: Operadores sobrecarregados (`>`, `<`, `=`, `and`, `or`, `Contains`, `Like`, `In`, `IsNull`...) geram automaticamente nós de AST do tipo `IExpression`. 
+
+O Dext oferece ao desenvolvedor dois padrões elegantes para resolver os metadados complementares das entidades:
+1. **Smart Properties (Entidade de Domínio Unificada)**: Ao incorporar `Prop<T>` (ou apelidos embutidos como IntType, StringType, BooleanType, etc.) diretamente dentro da entidade (ex.: `TProduct`), a classe torna-se a fonte única de verdade tanto para dados quanto para metadados, mantendo o domínio altamente coeso.
+2. **Tipo Complementar Separado (`TEntityType<T>`)**: Se o desenvolvedor preferir trabalhar com tipos Pascal primitivos e puros (ex.: `Integer`, `String`, `Boolean` padrão), o Dext permite criar uma classe complementar (ex.: `TProductType`) carregando a AST.
+
+Para tornar o uso elegante, os desenvolvedores podem definir uma função de classe simples na entidade que retorna os metadados:
+```pascal
+// Opção A: Smart Properties (Domínio Coeso)
+class function TProduct.Prototype: TProduct;
+begin
+  Result := Prototype.Entity<TProduct>;
+end;
+
+// Opção B: Domínio Primitivo Puro + Classe Complementar
+class function TProduct.Prototype: TEntityType<TProduct>;
+begin
+  Result := TProductType;
+end;
+```
+
+**Por baixo dos panos**: O consumo e a performance da extração de metadados são exatamente idênticos. Ambas as abordagens aproveitam o cache de metadados de RTTI do Dext, que é altamente otimizado e thread-safe. A varredura de RTTI é executada apenas uma vez por tipo, populando o cache e resolvendo o mapeamento da AST sem overhead de execução ou de memória em tempo de execução.
+
+**Esta mesma AST é utilizada por:**
+1. O Compilador SQL do ORM (gera consultas de banco de dados).
+2. O `TExpressionEvaluator` em memória (filtra coleções `TList<T>` padrão localmente).
+3. O motor de `Database as API` (traduz filtros de URL como `?price_gt=100` em nós de AST automaticamente).
+
+---
+
+## 4. Relacionamentos & Estratégias de Carregamento
+
+### Carregamento Imediato (Eager Loading)
+
+**EF Core:**
+```csharp
+var orders = await db.Orders
+    .Include(o => o.Customer)
+    .ThenInclude(c => c.Address)
+    .ToListAsync();
+```
+
+**Dext:**
+```pascal
+var Orders := Db.Orders
+  .Include(O.Customer)
+  .ThenInclude(C.Address)
+  .ToList;
+```
+
+### Carregamento Preguiçoso (Lazy Loading)
+
+O EF Core realiza o carregamento preguiçoso por meio de proxies virtuais transparentes (exigindo propriedades de navegação virtuais) ou por meio da injeção de `ILazyLoader`. 
+
+O Dext oferece o melhor dos dois mundos. Ele suporta a interceptação transparente por proxy (o mesmo que os proxies virtuais do EF Core) **e** um padrão genérico altamente elegante do tipo **`Lazy<T>` wrapper**. O wrapper `Lazy<T>` mantém as entidades como POCOs 100% puras, sem a necessidade de métodos virtuais ou substituições complexas de classe:
+
+```pascal
+type
+  [Table('Comments')]
+  TComment = class
+  private
+    FId: Integer;
+    FText: string;
+    FAuthorId: Integer;
+    FAuthor: Lazy<TAuthor>;
+  public
+    [PK, AutoInc]
+    property Id: Integer read FId write FId;
+    property Text: string read FText write FText;
+    
+    [Column('author_id')]
+    property AuthorId: Integer read FAuthorId write FAuthorId;
+    
+    [BelongsTo]
+    [ForeignKey('author_id')]
+    property Author: Lazy<TAuthor> read FAuthor write FAuthor;
+  end;
+```
+
+Quando você acessa `Comment.Author.Value`, o framework Dext resolve e executa dinamicamente a consulta no banco de dados sob demanda, usando o travamento por verificação dupla (double-checked locking) thread-safe. Isso oferece um contrato arquitetônico altamente estruturado e auto-documentado diretamente na definição da entidade.
+
+### Multi-Mapeamento (Estilo Dapper) & Hidratação Recursiva
+
+Enquanto ORMs básicos sofrem com resultados de consultas planos que representam tabelas unidas (joins), o Dext apresenta um **hidratador recursivo de alto desempenho e zero boilerplate**, semelhante ao multi-mapping do Dapper (`splitOn`), mas com significativamente mais automação.
+
+Ao declarar um campo de relacionamento com o atributo `[Nested]` (ou mapeá-lo fluentemente), você altera o **mapeador de caminho recursivo** do Dext.
+
+```pascal
+type
+  TOrderLine = class
+  private
+    FProductId: Integer;
+    FQuantity: Integer;
+    FProduct: TProduct;
+  public
+    property ProductId: Integer read FProductId write FProductId;
+    property Quantity: Integer read FQuantity write FQuantity;
+
+    [Nested]
+    property Product: TProduct read FProduct write FProduct;
+  end;
+```
+
+#### Como Funciona por Baixo dos Panos (Sem Necessidade de `splitOn` Manual)
+
+No Dapper (.NET), mapear uma linha resultante de um join exige a especificação de uma string de divisão manual `splitOn` (por exemplo, `'Id'`) para que o framework saiba onde segmentar a lista de colunas planas. 
+
+O Dext elimina essa etapa de configuração ao utilizar **roteamento de caminho baseado em convenção** no nível do compilador/RTTI:
+
+1. **Reconhecimento de Caminho por Nome**: O hidratador varre a lista de colunas retornada pelo banco de dados. Se encontrar uma coluna com um separador como `_` ou `.` (ex.: `Product_Id`, `Product_Name`, `Product_Price` ou `Product.Name`), ele extrai o prefixo (`Product`).
+2. **Auto-Instanciação (Alocação Preguiçosa)**: Se a propriedade de destino (`Product`) for do tipo classe e estiver atualmente como `nil`, o hidratador **automaticamente a instancia** em tempo de execução usando o cache de metadados otimizado `TActivator`.
+3. **Vinculação de Valor Recursiva**: Ele então roteia os segmentos de caminho restantes recursivamente (ex.: vinculando `Name` e `Price` diretamente a `FProduct.FName` e `FProduct.FPrice`).
+4. **Mapeamento de Profundidade Infinita**: Como o `TReflection.SetValueByPath` do Dext é recursivo, ele pode mapear automaticamente hierarquias de múltiplos níveis (ex.: `Order_Customer_Address_City`) a qualquer profundidade com zero configuração manual.
+
+#### Desempenho & Segurança
+* **Zero Pressão sobre o Garbage Collector (GC)**: O parsing de caminho usa buffers leves alocados na stack e indexação de string in-place.
+* **Interceptação de Propriedades**: Ignora setters de propriedades lentos escrevendo diretamente nos campos de suporte (resolvidos via cache de RTTI) durante a hidratação, evitando efeitos colaterais ou overhead de rastreamento de sujeira (dirty-tracking).
+
+---
+
+## 5. Sistema de Migrações
+
+O Dext usa migrações code-first com snapshots cronológicos — o mesmo modelo conceitual do EF Core:
+
+```
+dotnet ef migrations add InitialCreate    →  dext migrations add InitialCreate
+dotnet ef database update                 →  dext database update
+```
+
+**Capacidade Adicional**: O Dext detecta renomeações de tabelas e colunas via atributos, gerando SQL do tipo `RENAME TABLE` / `RENAME COLUMN` em vez de `DROP + CREATE`.
+
+---
+
+## 6. Exclusão Lógica — Atributo `[SoftDelete]`
+
+O EF Core exige a configuração manual de Filtro Global de Consulta (Global Query Filter) para a exclusão lógica (soft delete). O Dext torna isso declarativo:
+
+**EF Core (configuração manual):**
+```csharp
+// Configuração do modelo
+modelBuilder.Entity<Task>().HasQueryFilter(t => !t.IsDeleted);
+
+// Sobrescrever SaveChanges
+public override Task<int> SaveChangesAsync(...)
+{
+    foreach (var entry in ChangeTracker.Entries<Task>())
+        if (entry.State == EntityState.Deleted)
+        {
+            entry.State = EntityState.Modified;
+            entry.Entity.IsDeleted = true;
+        }
+    return base.SaveChangesAsync(...);
+}
+```
+
+**Dext (totalmente declarativo com rastreamento opcional de data/hora):**
+```pascal
+type
+  [SoftDelete('IsDeleted')]
+  TTask = class
+  private
+    FName: StringType;
+    FIsDeleted: BoolType;
+    FDeletedAt: DateTimeType;
+  public
+    property Name: StringType read FName write FName;
+    property IsDeleted: BoolType read FIsDeleted write FIsDeleted;
+
+    [DeletedAt]
+    property DeletedAt: DateTimeType read FDeletedAt write FDeletedAt;
+  end;
+```
+
+E pronto. O Dext faz isso automaticamente:
+- Transforma `Remove()` em `UPDATE SET IsDeleted = TRUE` (e marca automaticamente a data/hora atual na propriedade `DeletedAt` se decorada com o atributo `[DeletedAt]`).
+- Filtra registros excluídos de todas as consultas por padrão.
+- Expõe métodos como `IgnoreQueryFilters`, `OnlyDeleted`, `HardDelete` e `Restore`.
+- Limpa o Identity Map após a exclusão lógica.
+
+Suporta valores customizados: `[SoftDelete('Status', 99, 0)]` — usa códigos de status inteiros/enums.
+
+---
+
+## 7. Consultas em Colunas JSON — `[JsonColumn]`
+
+**EF Core (PostgreSQL):**
+```csharp
+// EF Core 7+ com suporte a JSON do PostgreSQL
+var admins = db.Users
+    .Where(u => EF.Functions.JsonExists(u.Settings, "role"))
+    .ToList();
+```
+
+**Dext (multi-banco de dados):**
+```pascal
+var U: TUserType;
+var Admins := Db.Users
+  .Where(U.Settings.Json('role') = 'admin')
+  .ToList;
+```
+
+Implementação compatível com diversos bancos:
+- **PostgreSQL**: `settings #>> '{role}'` (JSONB indexado)
+- **MySQL**: `JSON_UNQUOTE(JSON_EXTRACT(settings, '$.role'))`
+- **SQLite**: `json_extract(settings, '$.role')`
+- **SQL Server**: `JSON_VALUE(settings, '$.role')`
+
+Caminhos aninhados também funcionam: `U.Settings.Json('profile.details.level') = 5`
+
+---
+
+## 8. Multi-Tenancy — Integrado
+
+O Dext possui um módulo dedicado `Dext.MultiTenancy` com **três estratégias de isolamento**:
+
+| Estratégia | Como Funciona | Recomendado Para |
+|:---|:---|:---|
+| **Shared Database (Banco Compartilhado)** | Coluna discriminadora `TenantId` — filtro automático | Tenants pequenos, eficiência de custo |
+| **Schema Isolation (Esquema Isolado)** | Alternância do `search_path` no PostgreSQL por requisição | Tenants médios, isolamento lógico |
+| **Database per Tenant (Banco por Tenant)** | String de conexão dinâmica por tenant | Clientes corporativos, isolamento estrito de dados |
+
+```pascal
+Services.AddMultiTenancy
+  .UseSharedDatabase  // ou .UseSchemaIsolation ou .UseDatabasePerTenant
+  .WithTenantFromHeader('X-Tenant-Id');
+```
+
+---
+
+## 9. Mapeamento de Herança
+
+**Tabela por Hierarquia (TPH — Table-Per-Hierarchy)** — suporte completo com hidratação polimórfica:
+
+```pascal
+type
+  [Discriminator('Type')]
+  TVehicle = class
+    Name: StringType;
+    [DiscriminatorValue('car')]
+    // ...
+  end;
+
+  TCar = class(TVehicle)
+    Doors: IntType;
+  end;
+
+  TTruck = class(TVehicle)
+    Payload: FloatType;
+  end;
+```
+
+---
+
+## 10. Stored Procedures — Padrão de Comando Declarativo
+
+A execução de Stored Procedures em sistemas corporativos modernos é um caminho crítico e comum, mas é notoriamente dolorosa em ORMs tradicionais.
+
+### O Contraste
+
+#### EF Core (Vinculação Manual de Parâmetros & Mapeamento Rígido)
+O C# não oferece suporte nativo à inferência dinâmica de objetos ou mapeamento dinâmico de resultados de consultas nativamente no EF Core.
+* Se a procedure retorna agregados customizados, você **deve declarar um DTO** e registrá-lo explicitamente como uma entidade sem chave no `DbContext` (`modelBuilder.Entity<T>().HasNoKey()`).
+* Se a procedure possui parâmetros `OUT` ou `INOUT`, ou retorna múltiplos conjuntos de resultados, o EF Core **obriga você a recorrer ao boilerplate tradicional do ADO.NET** (`DbCommand`, `DbDataReader`), instanciando objetos manuais de `SqlParameter` e lendo os dados linha por linha.
+
+```csharp
+// EF Core: Propenso a erros de strings mágicas e exige configuração manual de parâmetros
+var minPriceParam = new SqlParameter("@MinPrice", 100);
+var result = await db.Database.ExecuteSqlRawAsync(
+    "EXEC GetTopProducts @MinPrice", minPriceParam);
+```
+
+#### Dext (Padrão de Comando Declarativo)
+O Dext encapsula Stored Procedures usando um **Padrão de Comando/CQRS** coeso. Embora exija a definição de uma classe, essa classe atua como um **contrato arquitetônico verificado em tempo de compilação** que encapsula todas as entradas, saídas e projeções.
+
+```pascal
+type
+  [StoredProcedure('GetTopProducts')]
+  TGetTopProducts = class
+  private
+    FMinPrice: Currency;
+    FResults: IList<TProduct>;
+  public
+    [DbParam('MinPrice')]
+    property MinPrice: Currency read FMinPrice write FMinPrice;
+
+    // A projeção da consulta é auto-hidratada a partir do conjunto de resultados da procedure
+    property Results: IList<TProduct> read FResults write FResults;
+  end;
+
+// Execução: Zero boilerplate de banco de dados, zero arrays de parâmetros soltos
+var Command := TGetTopProducts.Create;
+Command.MinPrice := 100;
+Db.Execute(Command); 
+```
+
+### Principais Vantagens Arquitetônicas da Abordagem do Dext
+
+1. **Zero Vazamentos de ADO.NET/FireDAC**: Você nunca escreve código de baixo nível para vincular parâmetros, definir tipos de dados ou abrir/fechar streams de conexão. O Dext gerencia o ciclo de vida da conexão, direção dos parâmetros e desalocação de memória automaticamente.
+2. **Contrato Coeso e Fortemente Tipado**: Entradas (`[DbParam]`), saídas (parâmetros `out`) e datasets de retorno são estruturalmente vinculados ao objeto de comando. Isso elimina arrays de tempo de execução inseguros e castings manuais de tipo.
+3. **Pronto para CQRS**: Alinha-se perfeitamente com padrões de *Segregação de Responsabilidade de Comando e Consulta* (CQRS). Cada operação complexa de banco de dados é tratada como uma unidade de comando isolada, testável e auto-documentada.
+4. **Hidratação Rica de Projeções**: As linhas retornadas são automaticamente convertidas e mapeadas para ricos grafos de entidades ou listas leves de DTOs usando o hidratador otimizado com cache de RTTI.
+
+---
+
+## 11. Recursos Exclusivos (Não Disponíveis no EF Core)
+
+### 11.1 Database as API
+
+**O recurso mais poderoso do Dext ORM.** Gere uma API REST CRUD completa a partir de um único atributo — sem controllers, sem services, sem repositories:
+
+```pascal
+type
+  [Table, DataApi('/api/products')]
+  TProduct = class
+    Id: IntType;
+    Name: StringType;
+    Price: CurrencyType;
+  end;
+
+// Na inicialização (startup):
+App.MapDataApis; // Pronto.
+```
+
+Isso gera **5 endpoints automaticamente**:
+
+| Método | Rota | Descrição |
+|:---|:---|:---|
+| `GET` | `/api/products` | Lista com paginação, ordenação e 11 operadores de filtragem |
+| `GET` | `/api/products/{id}` | Busca por Chave Primária (simples ou composta) |
+| `POST` | `/api/products` | Criação — retorna status 201 |
+| `PUT` | `/api/products/{id}` | Atualização completa |
+| `DELETE` | `/api/products/{id}` | Exclusão |
+
+**Sistema de Filtros via URL (11 operadores):**
+```
+GET /api/products?price_gt=100&name_cont=widget&_orderby=price+desc&_limit=20&_offset=0
+```
+
+Operadores suportados: `_eq`, `_neq`, `_gt`, `_gte`, `_lt`, `_lte`, `_cont` (LIKE %x%), `_sw`, `_ew`, `_in`, `_null`
+
+**Segurança Granular:**
+```pascal
+App.MapDataApis.Configure<TProduct>(
+  DataApiOptions
+    .RequireAuth
+    .RequireWriteRole(['admin'])
+    .Allow([amGet, amGetList]) // Somente leitura para não-admins
+    .UseSnakeCase
+    .UseSwagger
+);
+```
+
+---
+
+### 11.2 EntityDataSet — A Ponte ORM ↔ VCL/FMX
+
+Conecte componentes legados do Delphi (DBGrid, FastReport, TDBEdit) a domínios ricos de Smart Properties ou coleções padrão de entidades POCO — com zero comprometimento da arquitetura:
+
+```pascal
+EntityDataSet1.Collection := Db.Products.ToList; // Lista direta (suporta tanto POCO quanto Smart Properties)
+```
+
+**Visualização em Tempo de Design (Live IDE Preview)**: Em tempo de design, forneça uma `TFDConnection` e um `DataProvider`, e o Dext gerará SQL dinâmico exibindo dados reais no DBGrid *sem a necessidade de compilar o projeto*.
+
+Isso não possui **equivalente no ecossistema .NET** — o DataAdapter do Windows Forms exige mapeamento manual, e não há designer do Visual Studio que visualize dados do ORM em tempo real diretamente na IDE.
+
+---
+
+### 11.3 Avaliador de Expressões em Memória
+
+A mesma AST gerada por `Prop<T>` pode ser avaliada contra coleções em memória — sem interagir com o banco de dados:
+
+```pascal
+var Filter := TExpressionEvaluator.Create;
+
+// A mesma expressão usada para a consulta SQL...
+var SqlResult := Db.Products.Where(P.Price > 100).ToList;
+
+// ...também filtra uma lista local em memória:
+var InMemoryResult := Filter.Evaluate(LocalCache, P.Price > 100);
+```
+
+O EF Core não expõe um avaliador em memória para a mesma árvore de expressão utilizada na geração de consultas SQL.
+
+---
+
+## 12. Características de Desempenho
+
+| Benchmark | Dext | Notas |
+|:---|:---|:---|
+| **Roteamento de rotas** | 10.000 rotas em 47ms, zero alocações de heap | Roteamento baseado em `Span<T>` |
+| **Busca em Dicionários** | 6.6x mais rápida que a RTL | AVX2/SSE2 SIMD + Open Addressing |
+| **Tempo de compilação** | Redução de 60% vs genéricos padrão | Binary Code Folding |
+| **Memória SSR** | O(1) para qualquer quantidade de registros | Iterador de streaming Flyweight |
+| **Parsing de JSON** | UTF-8 com zero alocação via `TByteSpan` | Injeção direta por offset de campo |
+
+---
+
+## 13. Matriz de Testes Multi-Banco de Dados
+
+O mecanismo de persistência do Dext ORM é validado contra uma **matriz de testes de CI com 5 bancos de dados reais** a cada release:
+
+| Banco de Dados | Versão Testada | Notas |
+|:---|:---|:---|
+| **PostgreSQL** | 14, 15, 16 | JSONB, UUID, `search_path` para esquemas |
+| **SQL Server** | 2019, 2022 | Funções de janela, TRY_CAST |
+| **MySQL** | 8.0 | JSON_EXTRACT, LIMIT/OFFSET |
+| **SQLite** | 3.x | In-process; json_extract |
+| **Firebird** | 3.0, 4.0 | Paginação legada (ROWS/TO), SEQUENCE |
+
+O banco Oracle é suportado em produção, mas não está incluído na matriz de testes automatizados do CI.
+
+## 14. Engenharia de Alto Desempenho & Mergulho Arquitetônico
+
+Embora as capacidades funcionais sejam cruciais, o grande diferencial do Dext é **como esses recursos são implementados** para alcançar eficiência de nível industrial:
+* **Binary Code Folding**: Evita a "explosão de genéricos" no Delphi, reduzindo o tempo de compilação em até 60% e encolhendo o tamanho dos binários.
+* **Coleções Aceleradas por SIMD**: Buscas vetorizadas via AVX2/SSE2 que tornam o `TRawDictionary` até 6.6x mais rápido que os dicionários padrão da RTL.
+* **Avaliador de Expressões em Memória**: Reutilização direta da AST `Prop<T>` do ORM para avaliar consultas complexas contra listas padrão em memória com zero chamadas ao banco de dados.
+
+Para um mergulho técnico completo no design de alocação zero do Dext, otimizações de compilador e benchmarks detalhados de baixo nível, consulte o [Visão Geral do Ecossistema Dext Framework](https://github.com/cesarliws/dext/blob/main/Docs/Dext_Ecosystem_Overview.md).
+
+---
+
+## 15. Tabela de Referência Rápida do ORM
+
+A tabela abaixo resume os principais recursos do ORM. Para a comparação completa do framework, incluindo web, DI, testes e recursos exclusivos, consulte a **[Comparação de Recursos →](./Feature_Comparison_Dext_vs_DotNet.pt-br.md)**.
+
+| Recurso do ORM | EF Core | Dext ORM | Destaque do Dext |
+|:---|:---:|:---:|:---|
+| **DbContext / Unit of Work** | Sim | Sim | `TDbContext` - mesmo padrão de UoW + Identity Map |
+| **Change Tracking (4 estados)** | Sim | Sim | `Added / Modified / Deleted / Unchanged` |
+| **Migrações Code-First** | Sim | Sim | Baseadas em snapshots cronológicos, com detecção de renomeação |
+| **Lazy / Eager Loading** | Sim | Sim | Mesma API com `Include()` / `ThenInclude()` |
+| **Soft Delete (Exclusão Lógica)** | Parcial (filtro manual) | Sim | Suporte integrado via `[SoftDelete]` + `[DeletedAt]` |
+| **Multi-Tenancy** | Parcial (filtro de consulta) | Sim | 3 estratégias: Banco Compartilhado, Esquema ou Banco por Tenant |
+| **Bloqueio Pessimista** | Não (apenas SQL puro) | Sim | `FOR UPDATE` integrado diretamente no motor de consulta |
+| **Consultas em Colunas JSON** | Sim | Sim | Mapeamento multi-banco via `[JsonColumn]` + `.Json('caminho')` |
+| **Herança TPH** | Sim | Sim | Hidratação polimórfica via discriminador |
+| **Herança TPT / TPC** | Sim | Parcial | Mapeado no roadmap |
+| **Conversores de Valor** | Sim | Sim | `TValueConverterRegistry` - mais de 20 conversores embutidos |
+| **Stored Procedures** | Sim | Sim | Totalmente declarativas via `[StoredProcedure]` + `[DbParam]` |
+| **Multi-Mapeamento (estilo Dapper)** | Não | Sim | Atributo `[Nested]` - hidratação recursiva via separadores `_` ou `.` |
+| **Suporte Multi-Banco** | Sim (NuGet) | Sim (7 nativos) | PostgreSQL, SQL Server, MySQL, SQLite, Oracle, Firebird, InterBase |
+| **DSL de Consulta Type-Safe** | Sim (LINQ) | Sim (AST `Prop<T>`) | Mesma AST reutilizada para SQL, filtros locais e rotas HTTP |
+| **Database as API** | Não | Sim | `[DataApi]` - API REST CRUD completa com apenas 1 atributo |
+| **EntityDataSet (VCL/FMX)** | Não | Sim | Ponte entre POCO e DBGrid/FastReport com pré-visualização na IDE |
+| **Avaliador de Expressão em Memória** | Não | Sim | A mesma AST de `Prop<T>` filtra listas `TList<T>` locais |
+| **Parser de URL para Expressão** | Não | Sim | Converte automaticamente `?price_gt=100` in nó de AST |
+
+---
+
+## 16. Inspiração Global, Evolução Guiada pela Comunidade: Indo Além dos Paradigmas Padrão
+
+Um princípio central do design do Dext é **"Inspirado no melhor, otimizado para o Delphi, impulsionado pela comunidade."** Nós não enxergamos o .NET ou o EF Core como modelos rígidos a serem copiados linha a linha, nem limitamos nosso horizonte à mera replicação. Em vez disso, nós os usamos como referências de mercado enquanto integramos os melhores paradigmas de todo o ecossistema global de engenharia de software.
+
+### 1. Recursos Unificados Prontos para Uso (A Vantagem das Soluções Integradas)
+Quando desenvolvedores avaliam o .NET, eles geralmente consideram o que está disponível em todo o ecossistema do NuGet, e não apenas na biblioteca padrão BCL (Base Class Library). O Dext adotou uma abordagem proativa ao **implementar de forma nativa os padrões mais populares, consagrados e críticos do C#** diretamente no núcleo do nosso framework. Isso elimina o gerenciamento complexo e dependências de pacotes externos:
+* **Mapeamento de Objetos**: Integrado nativamente como `Dext.Mapper` (`TMapper`), inspirado no amplamente utilizado **AutoMapper** do ecossistema .NET.
+* **Padrão de Especificação (Specification Pattern)**: Integrado nativamente como `Dext.Specifications`, inspirado no **Ardalis.Specification**.
+* **Barramento de Eventos Corporativo & Pipeline Behaviors**: Integrado nativamente como `Dext.Events`, inspirado no padrão de mercado **MediatR**.
+* **Testes & Mocks**: Motores de asserção integrados nativamente, combinações de casos de teste (`TestCase`) e `TAutoMocker`, inspirados em frameworks como **FluentAssertions**, **NUnit** e **Moq**.
+
+### 2. Uma Arquitetura Poliglota: Adotando as Melhores Ideias
+O Dext incorpora ativamente avanços arquitetônicos e padrões de alta produtividade de múltiplos ecossistemas consolidados:
+* **Go (Golang)**: Adaptamos o padrão ultra-leve e de alta vazão de **Channels** (`TChannel<T>`) e o padrão determinístico **Defer** (`IDeferred`/`TDeferredAction`) para trazer gerenciamento de recursos limpo, livre de vazamentos e concorrência robusta ciente de contrapressão (backpressure) para o Delphi.
+* **Flutter & Dart**: Buscamos inspiração nos paradigmas de segurança em tempo de compilação do Dart, ergonomia assíncrona e bindings reativos de UI para otimizar como nosso visual VCL/FMX `TEntityDataSet` se comporta sob alterações ativas em tempo de design.
+* **Java & Spring Boot**: Estudamos a ergonomia do container de IoC/DI do Spring Boot e os mapeamentos declarativos por anotações para construir os mecanismos de injeção de dependência altamente intuitivos e rotas baseadas em atributos do Dext.
+* **Python & JavaScript/TypeScript**: Analisamos a extrema facilidade de configuração e a ergonomia de frameworks web ágeis como FastAPI e Hono para implementar nossa detecção automática de **HTMX** e configurações do tipo **Database as API** (`[DataApi]`) com zero boilerplate.
+
+### 3. Aberto à Evolução Contínua Conduzida pela Comunidade
+Frameworks de software são sistemas vivos. Se um desenvolvedor perceber que um recurso altamente especializado "N" está ausente no ecossistema atual do Dext, não enxergamos isso como uma limitação permanente:
+* **Roadmap de Evolução Adaptável**: Nossa arquitetura é intencionalmente modular e desacoplada. Adicionar novos recursos, dialetos de banco de dados, conversores personalizados ou middlewares de tratamento é um processo simples e limpo.
+* **Aberto a Contribuições**: Estamos comprometidos em evoluir o Dext em estreita colaboração com a comunidade Delphi corporativa. Se o seu ambiente de produção exigir um padrão arquitetônico especializado ou um driver de acesso a dados específico, a equipe do Dext e a comunidade estão totalmente preparadas para construir, revisar e integrar essa solução.
+* **Modernizando o Delphi Juntos**: O Dext é projetado para provar que os desenvolvedores Delphi não precisam fazer concessões dolorosas. Você pode ter binários nativos de compilação rápida, sem dependências externas e ultra-rápidos, enquanto desfruta dos padrões de arquitetura de software mais modernos, elegantes e poderosos do planeta.
+
+---
+
+*Dext Framework — Referência de Recursos do ORM | Maio de 2026*

--- a/Docs/Comparison/Dext_vs_DotNet_Narrative.md
+++ b/Docs/Comparison/Dext_vs_DotNet_Narrative.md
@@ -1,0 +1,177 @@
+# Dext vs .NET: A Visionary Architecture Comparison
+
+*How Dext bridges modern backend paradigms, enterprise engineering standards, and native compilation in a single, high-performance Delphi ecosystem.*
+
+---
+
+## The Perception Gap & Modern Frameworks
+
+Modern backend engineering is frequently evaluated through the lens of dominant ecosystems like .NET and JVM. Developers looking at Object Pascal / Delphi from the outside often assume the ecosystem lacks the cohesive, unified, and highly structured architectures found in ASP.NET Core or Entity Framework Core. 
+
+This document exists to close that perception gap. By providing concrete technical comparisons, code samples, and architectural benchmarks, we demonstrate that Dext is not only a fully peer-level enterprise framework, but one that actively pioneers new concepts specifically engineered for compiled native environments.
+
+
+---
+
+## Part 1: The Legitimate Inspiration
+
+Dext was intentionally designed to bring the patterns of ASP.NET Core and Entity Framework Core to the Delphi world. The inspiration is not hidden — it's the design philosophy.
+
+The same patterns are here:
+- `DbContext` / Unit of Work / Change Tracking
+- `IOptions<T>` / `IOptionsMonitor<T>` for typed configuration
+- `IHostedService` / `TBackgroundService` for background tasks
+- `ILogger<T>` / `ILoggerFactory`
+- `Minimal APIs` with `app.MapGet(...)` / `app.MapPost(...)`
+- `[FromBody]`, `[FromQuery]`, `[FromRoute]`, `[FromHeader]` model binding
+- `IHealthCheck` with Healthy / Degraded / Unhealthy states
+- `ProblemDetails` RFC 9457 for error responses
+
+If you write .NET, you already know how to use Dext. The learning surface is intentionally minimal.
+
+---
+
+## Part 2: What We Share (Parity)
+
+Dext achieves full functional parity with the .NET ecosystem across more than 60 features — spanning ORM/data access, the web framework, the core DI and configuration system, and the testing infrastructure. And critically: several of the most important patterns that in .NET require separate third-party NuGet packages (AutoMapper, MediatR, FluentAssertions, Moq, Ardalis.Specification) are shipped natively inside Dext as first-class citizens.
+
+For the full itemized comparison, see the **[Feature Comparison Reference →](./Feature_Comparison_Dext_vs_DotNet.md)**. It covers 60+ parity features in structured tables (Block A), 17 Dext-exclusive features (Block B), honest gaps (Block C), and platform differences that don't apply to Delphi by design (Block D).
+
+If you're coming from .NET: you already know how to use Dext. The API naming, the attribute patterns, and the architectural layers are intentionally familiar.
+
+---
+
+## Part 3: Where Dext Goes Beyond
+
+This is the section that surprises people coming from .NET. These are features that **exist in Dext but not in the .NET ecosystem** (or require expensive third-party packages that aren't officially supported).
+
+### Database as API — Runtime, Not Scaffold
+
+This is Dext's most distinctive feature. Annotate an entity, and the framework generates a complete CRUD REST API at runtime — no code generation, no scaffolding, no controllers:
+
+```pascal
+type
+  [DataApi('/api/products')]
+  TProduct = class
+    Id: IntType;
+    Name: StringType;
+    Price: CurrencyType;
+  end;
+```
+
+One line at startup: `App.MapDataApis`.
+
+Five endpoints generated. Pagination, sorting, 11 filter operators via URL QueryString, JWT validation, role-based access control, and automatic OpenAPI documentation.
+
+In .NET, to reach the same point you need: a scaffolded controller, a service layer, a repository, a DTO, manual filter parsing, and a Swagger annotation pass. That is days of work vs. one line.
+
+### Smart Properties — Ergonomics and DX Unified in Delphi
+
+In C#, the ability to write type-safe, magic-string-free queries is provided natively by the language through lambda expressions and `Expression<Func<T, bool>>`. The C# compiler generates the expression tree transparently — no library required:
+
+```csharp
+// C# — the compiler generates the AST automatically
+db.Products.Where(p => p.Price > 100 && p.Name.Contains("Widget"))
+```
+
+Delphi has no equivalent language mechanism. While excellent libraries like Spring4D offer lightweight RTTI-based expression support and other tools utilize structured string-based builders, Dext focuses deeply on **Developer Experience (DX)**. 
+
+By combining Delphi's modern language capabilities—implicit record operations, operator overloading, and generic metadata caching—Dext introduces a **type-safe fluent DSL** inspired by LINQ ergonomics. Dext's `Prop<T>` generates a unified **Abstract Syntax Tree (AST)** that spans three separate execution environments:
+
+```pascal
+var P := Prototype.Entity<TProduct>; 
+
+// 1. ORM — compiles the AST to a raw SQL WHERE clause
+Db.Products.Where(P.Price > 100 and P.Name.Contains('Widget'))
+
+// 2. In-memory — the TExpressionEvaluator filters a TList<T> locally
+Filter.Evaluate(LocalCache, P.Price > 100 and P.Name.Contains('Widget'))
+
+// 3. HTTP Routing — parsed automatically from ?price_gt=100&name_cont=widget
+// The DataApi engine converts URL QueryString operators to AST nodes on the fly
+```
+
+This represents a clean, highly cohesive model: define the business query once, and let the same AST handle physical queries, memory cache filtering, and URL parsing dynamically.
+
+**A note on the development process.** When the first prototype of `Prop<T>` was being designed, the AI coding assistant involved in development refused to help implement it — stating that building an expression tree system with operator overloading and implicit type conversions in Object Pascal was simply not possible. Even after the reasoning was explained in detail, the response was another assertion of impossibility.
+
+The only way forward was to build a working proof-of-concept first, alone, and then present the running code as evidence. Once the prototype existed, collaboration resumed. The lesson: the boundary between "this is impossible in Delphi" and "this has never been done in Delphi" is not always where it appears to be. `Prop<T>` is a concrete example of that gap.
+
+### Visual Telemetry Dashboard — Built-In (Work In Progress)
+
+The built-in telemetry dashboard is an actively developed and improving feature that collects logs, SQL profiling, Gantt spans, and system metrics asynchronously with zero execution blocking. While it is still a work-in-progress, it offers rapid, zero-setup insights for teams without heavy DevOps infrastructure (like Prometheus/Grafana clusters).
+
+### EntityDataSet & Active Architecture — The RAD Modernization Revolution
+
+This represents an exciting paradigm shift for legacy Delphi modernization. The `EntityDataSet` acts as the bridge connecting clean architecture domains to visual components (like DBGrids, DBCtrl grids, and FastReport) with zero architectural compromise.
+
+In design-time, Dext parses raw `.pas` domain units to generate fields dynamically and runs real SQL preview queries so you can work visually. But at runtime, all database connections vanish; the dataset consumes pure POCO in-memory entity lists (`TList<T>`).
+
+This powers **Active Architecture** (a pattern moving beyond traditional "Clean RAD"). By combining visual datasets with an elegant, non-redundant MVVM pattern (where the ViewModel manages UI states and async operations while components bind directly to rich domain entities via `TEntityDataSet`), developers can finally modernize massive legacy ERPs. You can eliminate tight database coupling and visual event handlers while keeping the high-productivity design form workflow that Delphi is famous for.
+
+### native MCP Server — AI-Native Framework
+
+Dext includes a native, zero-dependency implementation of the **Model Context Protocol** (MCP 2025-03-26), enabling Dext applications to expose tools, resources, and prompts directly to AI agents (Claude Desktop, Cursor, Antigravity).
+
+```pascal
+type
+  [MCPTool('search_products')]
+  [MCPParam('query', 'Search term')]
+  TSearchProductsTool = class
+    function Execute(const AQuery: string): TList<TProduct>;
+  end;
+```
+
+### FireDAC ConnectionDef Support
+
+Dext natively supports direct integration with FireDAC's global connection definition manager (`UseConnectionDef`). Rather than just another way to pass connection strings, it automatically analyzes active local/server definition profiles to resolve the correct dialect, database drivers, and physical pooling setups at runtime, enabling seamless, zero-config context switching between development and production.
+
+---
+
+## Part 4: Honest Gaps
+
+Transparency matters. Here is where .NET has a more complete implementation:
+
+- **OpenTelemetry exporter compatibility**: Dext has `TDiagnosticSource` and CorrelationId tracking, but does not yet export to OTLP format for Grafana Cloud or Datadog. This is on the Wave 3 roadmap.
+- **HybridCache (L1 + L2 unified)**: .NET 9 introduced a unified cache that merges in-memory and distributed Redis caches. Dext's native, high-performance Redis client is currently in active development (~80% complete) on the roadmap.
+- **SignalR / Websockets / Hubs**: Dext currently provides basic event broadcasting via SSE. Full WebSocket-based SignalR equivalent messaging is planned on the roadmap.
+- **gRPC & Protobuf Support**: Native high-speed binary communication utilizing IOCP/EPOLL engines and transparent Code-First interface mapping is mapped as a Wave 3 roadmap item.
+- **Named Query Filters**: EF Core 10 allows multiple named per-entity filters. Dext has a single global filter per entity. Roadmap item.
+
+---
+
+## Part 5: Platform Differences (Not Gaps)
+
+Some .NET features simply don't apply to Delphi by design. Blazor runs in a browser runtime — Delphi compiles to native AOT binaries by default (no JIT, no cold start). EF Compiled Models exist to reduce JIT warm-up time — in Delphi, all model metadata is compiled ahead-of-time. Source Generators are a C# language feature — Dext achieves the same validation results via RTTI attributes at runtime.
+
+For the full context breakdown, see **[Block D of the Feature Comparison →](./Feature_Comparison_Dext_vs_DotNet.md#block-d--context-differences-not-applicable-to-delphi)**.
+
+---
+
+## The Numbers
+
+- **Features at parity with .NET**: 60+
+- **Features Dext has that .NET doesn't**: 17 (including Database as API, Smart Properties AST, EntityDataSet, native MCP Server, built-in Telemetry Dashboard [WIP])
+- **3rd-party packages replaced by built-in features**: AutoMapper, MediatR, FluentAssertions, Moq, Verify, Ardalis.Specification, xUnit, NUnit (test attributes)
+- **Production scale**: ~800,000 requests/day on AWS and Azure
+- **Codebase size**: 200,000+ lines of pure Pascal code with a 5-database CI test matrix
+
+---
+
+## Conclusion: Global Architecture for Modern Delphi
+
+This comparison is a testament to the power of cross-pollinated technical paradigms. 
+
+For years, the .NET ecosystem has served as an excellent benchmark for backend productivity, showing how unified structures enable teams to deliver robust software quickly. Historically, building web services in Delphi meant assembling fragmented, disconnected libraries, writing verbose manual mappers, and managing ad-hoc wrappers.
+
+Dext was built to change that landscape. By drawing inspiration from the elegant, proven structures of ASP.NET Core and Entity Framework Core, Dext delivers a unified, highly productive, and elegant web experience directly to Delphi—without the memory overhead or cold starts of a managed JIT runtime. 
+
+Furthermore, Dext's commitment to importing the best features of other languages—such as Go's concurrency models, Dart/Flutter's visual-reactive mechanics, and Spring Boot's IoC paradigms—ensures that the framework remains on the cutting edge of global software architecture. Dext is an industrial-grade engineering ecosystem engineered to continuously evolve alongside the real-world production needs of the modern Delphi community.
+
+---
+
+*For the full technical feature table: see [`Feature_Comparison_Dext_vs_DotNet.md`](./Feature_Comparison_Dext_vs_DotNet.md)*  
+*For a detailed ORM breakdown: see [`Dext_ORM_Capabilities.md`](./Dext_ORM_Capabilities.md)*
+
+*Dext Framework | May 2026*
+

--- a/Docs/Comparison/Dext_vs_DotNet_Narrative.pt-br.md
+++ b/Docs/Comparison/Dext_vs_DotNet_Narrative.pt-br.md
@@ -1,0 +1,175 @@
+# Dext vs .NET: Uma Comparação de Arquitetura Visionária
+
+*Como o Dext une paradigmas modernos de backend, padrões de engenharia corporativa e compilação nativa em um único ecossistema Delphi de alto desempenho.*
+
+---
+
+## O Abismo de Percepção & Frameworks Modernos
+
+A engenharia de backend moderna é frequentemente avaliada sob a ótica de ecossistemas dominantes como o .NET e a JVM. Desenvolvedores que olham para o Object Pascal / Delphi de fora muitas vezes presumem que o ecossistema carece das arquiteturas coesas, unificadas e altamente estruturadas encontradas no ASP.NET Core ou no Entity Framework Core. 
+
+Este documento existe para fechar esse abismo de percepção. Ao fornecer comparações técnicas concretas, exemplos de código e benchmarks arquitetônicos, demonstramos que o Dext não é apenas um framework corporativo equivalente, mas um projeto que atua de forma pioneira na introdução de novos conceitos desenvolvidos especificamente para ambientes nativos compilados.
+
+---
+
+## Parte 1: A Inspiração Legítima
+
+O Dext foi planejado intencionalmente para trazer os padrões do ASP.NET Core e do Entity Framework Core para o universo Delphi. Essa inspiração não é oculta — ela é a própria filosofia de design do projeto.
+
+Os mesmos padrões consagrados estão aqui:
+- `DbContext` / Unit of Work / Rastreamento de Mudanças (Change Tracking)
+- `IOptions<T>` / `IOptionsMonitor<T>` para configurações tipadas
+- `IHostedService` / `TBackgroundService` para tarefas em segundo plano (background tasks)
+- `ILogger<T>` / `ILoggerFactory`
+- `Minimal APIs` com `app.MapGet(...)` / `app.MapPost(...)`
+- Vinculação de modelos (model binding) via `[FromBody]`, `[FromQuery]`, `[FromRoute]`, `[FromHeader]`
+- `IHealthCheck` com estados Saudável (Healthy), Degradado (Degraded) e Inseguro (Unhealthy)
+- `ProblemDetails` RFC 9457 para respostas de erro padronizadas
+
+Se você desenvolve em .NET, você já sabe usar o Dext. A curva de aprendizado é intencionalmente mínima.
+
+---
+
+## Parte 2: O Que Compartilhamos (Paridade)
+
+O Dext atinge paridade funcional total com o ecossistema .NET em mais de 60 recursos — abrangendo ORM/acesso a dados, o framework web, o sistema central de injeção de dependência (DI) e configuração, e a infraestrutura de testes. E um ponto crítico: vários dos padrões mais importantes que no .NET exigiriam pacotes NuGet de terceiros separados (AutoMapper, MediatR, FluentAssertions, Moq, Ardalis.Specification) já vêm embutidos nativamente no Dext como componentes de primeira classe.
+
+Para a comparação detalhada item por item, consulte a **[Referência de Comparação de Recursos →](./Feature_Comparison_Dext_vs_DotNet.pt-br.md)**. Ela cobre mais de 60 recursos em tabelas estruturadas (Bloco A), 17 recursos exclusivos do Dext (Bloco B), lacunas honestas (Bloco C) e diferenças de plataforma que não se aplicam ao Delphi por design (Bloco D).
+
+Se você vem do .NET, a nomenclatura das APIs, os padrões de atributos e as camadas arquitetônicas são intencionalmente familiares.
+
+---
+
+## Parte 3: Onde o Dext Vai Além
+
+Esta é a seção que surpreende desenvolvedores vindos do .NET. Estes são recursos que **existem no Dext, mas não no ecossistema .NET** (ou que exigem pacotes complexos de terceiros sem suporte oficial).
+
+### Database as API — Em Tempo de Execução, Sem Scaffolding
+
+Este é o recurso mais exclusivo do Dext. Anote uma entidade e o framework gera uma API REST CRUD completa em tempo de execução — sem geração de código em disco, sem scaffolding, sem controllers:
+
+```pascal
+type
+  [DataApi('/api/products')]
+  TProduct = class
+    Id: IntType;
+    Name: StringType;
+    Price: CurrencyType;
+  end;
+```
+
+Uma única linha na inicialização: `App.MapDataApis`.
+
+Cinco endpoints gerados automaticamente. Paginação, ordenação, 11 operadores de filtro via URL QueryString, validação de JWT, controle de acesso baseado em regras (RBAC) e documentação OpenAPI gerada dinamicamente.
+
+No .NET, para alcançar o mesmo resultado, você precisaria de: um controller scaffoldado, uma camada de serviço, um repositório, um DTO, análise manual de filtros de URL e anotações para o Swagger. Isso representa dias de trabalho comparados a uma única linha de código.
+
+### Smart Properties — Ergonomia e DX Unificados no Delphi
+
+No C#, a capacidade de escrever consultas fortemente tipadas e livres de strings mágicas é fornecida nativamente pela linguagem através de expressões lambda e `Expression<Func<T, bool>>`. O compilador do C# gera a árvore de expressão de forma transparente:
+
+```csharp
+// C# — o compilador gera a AST automaticamente
+db.Products.Where(p => p.Price > 100 && p.Name.Contains("Widget"))
+```
+
+O Delphi não possui um mecanismo de linguagem equivalente nativo. Embora existam excelentes bibliotecas como o Spring4D (com suporte a expressões leves via RTTI) e outros builders baseados em strings estruturadas, o Dext focou profundamente na **Experiência do Desenvolvedor (DX)**.
+
+Combinando os recursos modernos da linguagem Delphi — como operações de record implícitas, sobrecarga de operadores e cache de metadados genéricos —, o Dext introduz uma **DSL fluida e fortemente tipada** inspirada na ergonomia do LINQ. O `Prop<T>` do Dext gera uma **Árvore de Sintaxe Abstrata (AST)** unificada que atende a três ambientes de execução distintos:
+
+```pascal
+var P := Prototype.Entity<TProduct>; 
+
+// 1. ORM — compila a AST em uma cláusula WHERE SQL nativa
+Db.Products.Where(P.Price > 100 and P.Name.Contains('Widget'))
+
+// 2. Em memória — o TExpressionEvaluator filtra uma TList<T> localmente
+Filter.Evaluate(LocalCache, P.Price > 100 and P.Name.Contains('Widget'))
+
+// 3. Roteamento HTTP — interpretado automaticamente a partir de ?price_gt=100&name_cont=widget
+// O motor de DataApi converte os operadores da URL QueryString em nós de AST em tempo real
+```
+
+Isso representa um modelo limpo e altamente coeso: defina a consulta de negócio uma única vez e permita que a mesma AST gerencie consultas físicas, filtragem de cache em memória e parsing de URLs dinamicamente.
+
+**Uma nota sobre o processo de desenvolvimento.** Quando o primeiro protótipo do `Prop<T>` estava sendo desenhado, o assistente de IA envolvido no desenvolvimento recusou-se a ajudar na implementação — afirmando que construir um sistema de árvore de expressão com sobrecarga de operadores e conversões implícitas de tipo em Object Pascal era simplesmente impossível. Mesmo depois que a lógica foi explicada em detalhes, a resposta foi outra afirmação de impossibilidade.
+
+O único caminho viável foi construir uma prova de conceito funcional de forma independente e, em seguida, apresentar o código em execução como evidência. Assim que o protótipo existiu, a colaboração foi retomada. A lição: a fronteira entre "isso é impossível em Delphi" e "isso nunca foi feito em Delphi" nem sempre está onde parece estar. O `Prop<T>` é um exemplo prático desse abismo.
+
+### Visual Telemetry Dashboard — Nativo (Em Desenvolvimento)
+
+O painel de telemetria embutido é um recurso ativamente desenvolvido que coleta logs, profiling de SQL, spans de Gantt e métricas de sistema de forma assíncrona, com zero bloqueio de execução. Embora ainda seja um trabalho em andamento, ele oferece insights rápidos e sem configuração para equipes que não possuem infraestrutura pesada de DevOps (como clusters Prometheus/Grafana).
+
+### EntityDataSet & Active Architecture — A Revolução na Modernização RAD
+
+Este componente representa uma transição de paradigma para a modernização de sistemas Delphi legados. O `EntityDataSet` atua como a ponte que conecta domínios de arquitetura limpa a componentes visuais (como DBGrids, DBCtrl grids e FastReport) sem comprometer o design do software.
+
+Em tempo de design (design-time), o Dext analisa as units `.pas` de domínio para gerar os campos dinamicamente e executa prévias de consultas SQL reais para que você possa trabalhar visualmente. Mas em tempo de execução (runtime), todas as conexões diretas com o banco de dados desaparecem; o dataset consome listas puras de entidades POCO em memória (`TList<T>`).
+
+Isso viabiliza a **Active Architecture** (um padrão que supera o RAD tradicional). Combinando datasets visuais com um padrão MVVM elegante e sem redundâncias (onde a ViewModel gerencia estados de UI e operações assíncronas enquanto os componentes se vinculam a ricas entidades de domínio via `TEntityDataSet`), os desenvolvedores podem finalmente modernizar sistemas ERP legados massivos. Você elimina o acoplamento direto com o banco de dados e os manipuladores de eventos visuais sem perder o fluxo de design visual altamente produtivo pelo qual o Delphi é reconhecido.
+
+### Servidor MCP Nativo — Framework Nativo para IA
+
+O Dext inclui uma implementação nativa e sem dependências externas do **Model Context Protocol** (MCP 2025-03-26), permitindo que aplicações Dext exponham ferramentas, recursos e prompts diretamente para agentes de IA (Claude Desktop, Cursor, Antigravity).
+
+```pascal
+type
+  [MCPTool('search_products')]
+  [MCPParam('query', 'Termo de busca')]
+  TSearchProductsTool = class
+    function Execute(const AQuery: string): TList<TProduct>;
+  end;
+```
+
+### Suporte a ConnectionDef do FireDAC
+
+O Dext suporta nativamente a integração direta com o gerenciador global de definições de conexão do FireDAC (`UseConnectionDef`). Longe de ser apenas mais uma forma de passar strings de conexão, o sistema analisa automaticamente os perfis de definição ativos (locais ou de servidor) para resolver o dialeto correto, drivers de banco de dados e configurações de pooling físico em tempo de execução, permitindo uma troca de contexto transparente entre desenvolvimento e produção.
+
+---
+
+## Parte 4: Lacunas Honestidades (Gaps)
+
+Transparência é fundamental. Aqui estão os pontos onde o ecossistema .NET possui uma implementação mais madura:
+
+- **Compatibilidade com exportadores OpenTelemetry**: O Dext possui `TDiagnosticSource` e rastreamento de CorrelationId, mas ainda não exporta no formato OTLP nativo para Grafana Cloud ou Datadog. Este recurso está mapeado no roadmap para a Wave 3.
+- **HybridCache (L1 + L2 Unificados)**: O .NET 9 introduziu um cache unificado que mescla cache em memória e caches distribuídos via Redis. O cliente nativo Redis de alto desempenho do Dext está atualmente em desenvolvimento ativo (~80% concluído) no roadmap.
+- **SignalR / Websockets / Hubs**: Atualmente, o Dext fornece transmissão básica de eventos via SSE. A comunicação completa via WebSockets equivalente ao SignalR está planejada no roadmap.
+- **Suporte a gRPC & Protobuf**: A comunicação binária nativa de alta velocidade utilizando motores de rede IOCP/EPOLL e mapeamento transparente Code-First está planejada como um item do roadmap da Wave 3.
+- **Named Query Filters**: O EF Core 10 permite múltiplos filtros nomeados por entidade. O Dext atualmente possui um único filtro global por entidade. Item mapeado no roadmap.
+
+---
+
+## Parte 5: Diferenças de Plataforma (Não são Lacunas)
+
+Alguns recursos do .NET simplesmente não se aplicam ao Delphi por design. O Blazor roda em um ambiente de navegador web — o Delphi compila para binários nativos AOT por padrão (sem JIT, sem warm-up/cold start). Os "Compiled Models" do EF existem para reduzir o tempo de aquecimento do JIT — no Delphi, todos os metadados do modelo já são resolvidos em tempo de compilação. Os Source Generators são um recurso de linguagem do C# — o Dext atinge os mesmos resultados de validação via atributos de RTTI em tempo de execução.
+
+Para a análise de contexto completa, consulte o **[Bloco D da Comparação de Recursos →](./Feature_Comparison_Dext_vs_DotNet.pt-br.md#bloco-d--diferencas-de-contexto-nao-aplicaveis-ao-delphi)**.
+
+---
+
+## Os Números
+
+- **Recursos em paridade com o .NET**: 60+
+- **Recursos que o Dext possui e o .NET não**: 17 (incluindo Database as API, Smart Properties AST, EntityDataSet, Servidor MCP nativo, Painel de Telemetria integrado [em progresso])
+- **Pacotes de terceiros substituídos por recursos nativos**: AutoMapper, MediatR, FluentAssertions, Moq, Verify, Ardalis.Specification, xUnit, NUnit (atributos de teste)
+- **Escala em produção**: ~800.000 requisições/dia na AWS e Azure
+- **Tamanho da base de código**: 200.000+ linhas de código Pascal puro com matriz de testes em CI com 5 bancos de dados reais
+
+---
+
+## Conclusão: Arquitetura Global para o Delphi Moderno
+
+Esta comparação comprova a força da polinização cruzada de paradigmas técnicos.
+
+Por anos, o ecossistema .NET serviu como uma excelente referência de produtividade em backend, demonstrando como estruturas unificadas permitem que as equipes entreguem softwares robustos rapidamente. Historicamente, construir serviços web em Delphi significava montar bibliotecas fragmentadas e desconectadas, escrever mapeadores manuais verbosos e gerenciar wrappers ad-hoc.
+
+O Dext foi construído para mudar essa realidade. Inspirando-se nas estruturas elegantes e comprovadas do ASP.NET Core e do Entity Framework Core, o Dext entrega uma experiência web unificada, altamente produtiva e elegante diretamente no Delphi — sem o consumo excessivo de memória ou cold starts de um ambiente gerenciado sob JIT.
+
+Ademais, o compromisso do Dext em importar os melhores recursos de outras linguagens — como os modelos de concorrência do Go, a mecânica visual-reativa do Dart/Flutter e os paradigmas de IoC do Spring Boot — garante que o framework permaneça na vanguarda da arquitetura de software global. O Dext é um ecossistema de engenharia corporativo projetado para evoluir continuamente junto com as reais necessidades de produção da comunidade Delphi moderna.
+
+---
+
+*Para a tabela de recursos técnicos completa: consulte [`Feature_Comparison_Dext_vs_DotNet.pt-br.md`](./Feature_Comparison_Dext_vs_DotNet.pt-br.md)*  
+*Para o detalhamento do ORM: consulte [`Dext_ORM_Capabilities.pt-br.md`](./Dext_ORM_Capabilities.pt-br.md)*
+
+*Dext Framework | Maio de 2026*

--- a/Docs/Comparison/Feature_Comparison_Dext_vs_DotNet.md
+++ b/Docs/Comparison/Feature_Comparison_Dext_vs_DotNet.md
@@ -1,0 +1,217 @@
+# Dext Framework vs .NET / EF Core — Feature Comparison Matrix
+
+> **Purpose**: This document provides a comprehensive, objective comparison between the Dext Framework for Delphi and the equivalent ecosystem of ASP.NET Core + Entity Framework Core for .NET. It is intended to help developers understand what Dext offers, where it has parity, where it goes beyond, and where differences exist due to platform context.
+>
+> *Last Updated: May 2026*
+
+---
+
+## How to Read This Document
+
+This comparison is structured into four logical blocks:
+
+| Block | Meaning |
+|---|---|
+| **A — Full Parity** | Dext implements the functional equivalent of the .NET feature |
+| **B — Dext Exclusive** | Features Dext has that .NET does not (or requires expensive 3rd party packages) |
+| **C — Partial / Roadmap** | .NET has this; Dext has it partially or it is planned |
+| **D — Context Difference** | Features of .NET that do not apply to Delphi by design |
+
+---
+
+## Block A — Full Feature Parity
+
+> [!NOTE]
+> All features listed here are fully implemented in Dext. The naming convention and API surface are intentionally kept close to the .NET counterparts to lower the learning curve for developers migrating from the .NET ecosystem.
+
+### A.1 ORM / Data Access
+
+| Feature | EF Core | Dext Equivalent | Notes |
+|:---|:---|:---|:---|
+| **DbContext (Unit of Work)** | `DbContext` | `TDbContext` | Full Unit of Work pattern |
+| **Change Tracking** | Automatic (Added / Modified / Deleted / Unchanged) | Automatic — same 4 states | Identity Map for instance uniqueness by PK |
+| **SaveChanges** | `SaveChanges()` / `SaveChangesAsync()` | `SaveChanges()` | Persists all tracked changes in a transaction |
+| **Generic Repository** | `DbSet<T>` | `DbSet<T>` | Operations: `Add`, `Update`, `Remove`, `Find`, `Where`, `Include`, `ToList` |
+| **Code-First Migrations** | `dotnet ef migrations add` | Automated Migrations System | Also via CLI. Chronological snapshots with table/column rename detection. **IDE Expert with wizard planned.** |
+| **Lazy Loading** | Proxy-based (`UseLazyLoadingProxies`) | Proxy Objects (transparent interception) | Same architecture |
+| **Eager Loading** | `Include()` / `ThenInclude()` | `Include()` / `ThenInclude()` | Same API surface |
+| **Soft Delete** | Global Query Filters (manual) | `[SoftDelete]` / `[DeletedAt]` attributes | Fully declarative. HardDelete, Restore, OnlyDeleted, IgnoreQueryFilters. `[DeletedAt]` automatically stamps the deletion datetime. |
+| **Multi-tenancy** | Manual / EF Query Filters | `Dext.MultiTenancy` | 3 strategies: Shared DB (TenantId), Schema Isolation, DB per Tenant |
+| **Pessimistic Locking** | Not built-in (raw SQL) | `FOR UPDATE` native | Built-in in the query engine |
+| **Inheritance: TPH** | Table-Per-Hierarchy | TPH with discriminator attributes | Polymorphic hydration automatic |
+| **Inheritance: TPT** | Table-Per-Type | Partial support | |
+| **Value Converters** | `HasConversion<T>()` | `TValueConverterRegistry` | 20+ built-in converters (Enum, GUID, TUUID, JSONB, TBytes...) |
+| **JSON Column Queries** | `OwnsOne().ToJson()` / `JSON_VALUE` | `[JsonColumn]` + `.Json('path')` | Cross-DB: PostgreSQL JSONB, MySQL JSON_EXTRACT, SQLite json_extract, SQL Server JSON_VALUE |
+| **Stored Procedures** | `FromSqlRaw()` / `ExecuteSqlRaw()` | `[StoredProcedure]` + `[DbParam]` | Fully declarative via attributes |
+| **Specification Pattern** | 3rd party (Ardalis.Specification) | `Dext.Specifications` — **built-in** | `Where`, `OrderBy`, `Include`, `Take`, `Skip` fluent builder |
+| **LINQ-like Query Extensions** | Native LINQ | `Dext.Collections.Extensions` | Unified expression engine, managed records, and implicit operators. Performance optimized via a thread-safe RTTI metadata cache. |
+| **Multi-Database Support** | Separate NuGet packages per provider | **7 drivers unified** | Built directly on FireDAC Phys Driver layer (no database components like TQuery). PostgreSQL, SQL Server, MySQL, SQLite, Oracle, Firebird, InterBase (and easily extensible to all FireDAC physical drivers). |
+| **Multi-Mapping (Dapper-style)** | Not built-in | `[Nested]` attribute | Recursive hydration. Fully supports mapping directly to Views and Stored Procedures, not just tables. |
+| **Connection Pooling** | ADO.NET pooling | Fluent Connection Setup + Pooling Auto-Detection | `UsePostgreSQL`, `UseFirebird`, etc. with auto pooling |
+| **Paging** | `Skip()` / `Take()` | `Skip()` / `Take()` | Same API |
+| **Aggregates** | `Count()`, `Sum()`, `Max()`, `Min()`, `Avg()` | `Count()`, `Sum()`, `Max()`, `Min()`, `Average()` | Same API |
+| **SQL Cache** | EF compiled queries | SQL command reuse cache | Repeated queries reuse generated SQL |
+| **Bulk Operations** | `ExecuteUpdate()` / `ExecuteDelete()` (EF7+) | `AddRange` / `UpdateRange` / `RemoveRange` | Native support for high-performance batch insert, update, and delete in a single batch call. |
+| **Object Mapping (AutoMapper)** | AutoMapper (3rd party) | `TMapper` — **built-in** | `CreateMap<TSource, TDest>`, `ForMember`, `Map<TSource, TDest>`, collection mapping |
+
+### A.2 Web Framework / ASP.NET Core Equivalent
+
+| Feature | ASP.NET Core | Dext Equivalent | Notes |
+|:---|:---|:---|:---|
+| **Minimal APIs** | `app.MapGet(...)` / `app.MapPost(...)` | `app.MapGet(...)` / `app.MapPost(...)` | Same fluent API |
+| **Controller-based APIs** | `[ApiController]` + `ControllerBase` | `[ApiController]` + attribute routing | Same pattern |
+| **Middleware Pipeline** | `app.Use(...)` — Chain of Responsibility | `app.Use(...)` — same architecture | Functional (delegates) and class-based with DI injection |
+| **Model Binding** | `[FromBody]`, `[FromQuery]`, `[FromRoute]`, `[FromHeader]`, `[FromServices]` | Same attributes | Zero-allocation via `TByteSpan` (direct UTF-8 deserialization) |
+| **API Versioning** | `Asp.Versioning` (NuGet) | **Built-in** — 4 readers | `THeaderApiVersionReader`, `TQueryStringApiVersionReader`, `TPathApiVersionReader`, `TCompositeApiVersionReader` |
+| **Rate Limiting** | `Microsoft.AspNetCore.RateLimiting` | **Built-in** — 4 algorithms | Fixed Window, Sliding Window, Token Bucket, Concurrency Limiter |
+| **CORS** | `UseCors()` | CORS middleware — built-in | |
+| **Output Caching** | `IOutputCache` | In-Memory (Redis Client planned) | Redis client is 80% complete and built natively in Dext for maximum performance |
+| **Health Checks** | `IHealthCheck` | Health Checks — built-in | Basic built-in implementation; database and external service integrations on the roadmap |
+| **ProblemDetails (RFC 9457)** | Built-in .NET 8+ | Built-in | Exception handling middleware produces RFC 9457 compliant responses |
+| **OpenAPI / Swagger** | `Microsoft.AspNetCore.OpenApi` | **Built-in** — automatic generation | Registered endpoints auto-appear in Swagger |
+| **SSE (Server-Sent Events)** | `IServerSentEvents` | SSE native | |
+| **SignalR Equivalent (Hubs)** | SignalR | SSE-based Messaging (SignalR planned) | Currently basic SSE broadcast. Full bi-directional Hub interfaces are ready; implementation is planned post-native IOCP/EPOLL engine (avoiding LGPL-3.0 dependencies like Delphi-Cross-Socket). |
+| **Background Services** | `IHostedService` / `BackgroundService` | `IHostedService` + `TBackgroundService` | `Execute(ICancellationToken)` |
+| **Application Lifetime** | `IHostApplicationLifetime` | `IHostApplicationLifetime` | `ApplicationStarted`, `ApplicationStopping`, `ApplicationStopped` |
+| **Template Engine** | Razor | Dext Template Engine | AST-based, zero-dependency, layout inheritance, macros, filters |
+| **Template Engine Alt** | Razor Pages | Web Stencils (Delphi 12.2+) | Native Delphi alternative |
+| **Multipart / File Upload** | `IFormFile` | `IFormFile` | Same abstraction |
+| **GZip Compression** | `UseResponseCompression` | Built-in middleware | High-performance GZip middleware |
+| **Developer Exception Page** | `UseDeveloperExceptionPage()` | `DeveloperExceptionPage` middleware | |
+
+### A.3 Core Framework
+
+| Feature | .NET | Dext Equivalent | Notes |
+|:---|:---|:---|:---|
+| **Dependency Injection** | `Microsoft.Extensions.DI` | `TDextServices` | `AddSingleton`, `AddTransient`, `AddScoped`, `AddSingletonFactory` |
+| **DI Lifecycles** | Singleton / Transient / Scoped | Singleton / Transient / Scoped | `CreateScope` for isolated child provider |
+| **Auto-Collections (DI)** | `IEnumerable<T>` injection | `IList<T>`, `IEnumerable<T>`, `IDictionary<K,V>` | Resolved automatically |
+| **DI Attributes** | `[FromServices]` | `[Inject]`, `[ServiceConstructor]` | Field/property/constructor injection |
+| **Configuration System** | `IConfiguration` / `appsettings.json` | `TDextConfiguration` | JSON, YAML, ENV, CLI args, InMemory — same multi-provider design |
+| **Options Pattern** | `IOptions<T>`, `IOptionsSnapshot<T>`, `IOptionsMonitor<T>` | `IOptions<T>`, `IOptionsSnapshot<T>`, `IOptionsMonitor<T>` | Same interfaces |
+| **Hot-Reload Configuration** | `IChangeToken` | `IChangeToken` + `OnReload` callback | |
+| **Logging** | `ILogger<T>` / `ILoggerFactory` | `ILoggerFactory` / `ILogger` | Trace, Debug, Information, Warning, Error, Critical |
+| **Async / Await** | `Task<T>` / `async/await` | `TAsyncTask` + Work-Stealing Scheduler | |
+| **Cancellation Token** | `CancellationToken` | `ICancellationToken` | `WaitForCancellation`, `IsCancellationRequested` |
+| **Nullable<T>** | `Nullable<T>` / `T?` | `Nullable<T>` | `HasValue`, `Value`, `GetValueOrDefault`, implicit operators |
+| **Lazy<T>** | `Lazy<T>` | `Lazy<T>` | Thread-safe double-checked locking; factory-based and pre-computed |
+| **Span<T> / ReadOnlySpan<T>** | `Span<T>` / `ReadOnlySpan<T>` | `TSpan<T>` / `TReadOnlySpan<T>` | Zero-allocation; bounds-checked |
+| **Object Mapping** | AutoMapper (3rd party) | `TMapper` built-in | |
+| **JSON Serialization** | `System.Text.Json` / Newtonsoft | `TDextJson` + Low-level UTF-8 streaming | Pluggable drivers. Includes zero-allocation binary JSON reader/writer using `TSpan` directly on raw bytes without heap allocations. |
+| **Frozen Collections** | `FrozenDictionary<K,V>` (.NET 8+) | `TFrozenDictionary<K,V>` / `TFrozenSet<T>` | Lock-Free reads; immutable after construction |
+| **Channels (Go-inspired)** | `System.Threading.Channels` | `TChannel<T>` | Bounded (backpressure) + Unbounded; ChannelReader/ChannelWriter |
+| **Event Bus / MediatR** | MediatR (3rd party) | `Dext.Events` — **built-in** | Behaviors pipeline (logging, timing, exception); scoped/singleton bus |
+| **Defer Pattern** | `using` / `IDisposable` | `IDeferred` / `TDeferredAction` | Go-inspired; action executed on scope exit |
+
+### A.4 Testing
+
+| Feature | .NET | Dext Equivalent | Notes |
+|:---|:---|:---|:---|
+| **Test Framework** | xUnit / NUnit / MSTest (3rd party) | `Dext.Testing` — **built-in** | |
+| **Attribute-Based Tests** | `[Fact]`, `[Theory]`, `[Test]` | `[Fact]`, `[Test]`, `[Fixture]`, `[TestClass]` | |
+| **Data-Driven Tests** | `[InlineData]`, `[MemberData]` | `[TestCase]`, `[TestCaseSource]`, `[Values]`, `[Range]`, `[Random]` | |
+| **Combinatorial Tests** | Parameterized (manual) | `[Combinatorial]` | All parameter combinations auto-generated |
+| **Lifecycle Hooks** | `[SetUp]`, `[TearDown]`, `[OneTimeSetUp]` | `[Setup]`, `[TearDown]`, `[BeforeAll]`, `[AfterAll]`, `[AssemblyInitialize]` | |
+| **Fluent Assertions** | FluentAssertions (3rd party) | `Dext.Assertions` — **built-in** | `Should(Value)` pattern; structural comparison |
+| **Soft Asserts** | FluentAssertions (3rd party) | `Assert.Multiple(...)` — built-in | Collect multiple failures before failing |
+| **Snapshot Testing** | Verify (3rd party) | Built-in | Disk-based baseline, structural JSON compare, update mode |
+| **Mocking** | Moq / NSubstitute (3rd party) | `Dext.Mocks` — **built-in** | `Mock<T>.Setup.Returns(Val)`, matchers, verification |
+| **Auto-Mocking** | AutoFixture + Moq (3rd party) | `TAutoMocker` — **built-in** | Automated mock injection into DI container |
+| **CI/CD Reports** | 3rd party libraries | Built-in | JUnit XML, xUnit XML, TRX (Azure DevOps), HTML (Dark Theme), JSON, SonarQube |
+
+---
+
+## Block B — Dext Exclusive Features
+
+> [!IMPORTANT]
+> The features in this block exist in Dext but have **no direct equivalent in the .NET ecosystem** (or require expensive 3rd-party solutions that are not officially supported). These are the primary technical differentiators.
+
+| Feature | Dext | .NET / EF Core Status | Impact |
+|:---|:---|:---|:---|
+| **Database as API** | `[DataApi]` attribute + `app.MapDataApis` — generates full CRUD REST API at runtime in **1 line** | No equivalent. Requires Scaffold + Controllers + Repository + Service layer manually | 🔴 Major — eliminates days of boilerplate for standard CRUD operations |
+| **Smart Properties / `Prop<T>`** | Generic record with dual mode: stores value OR generates AST via operator overloading. Type-safe queries **without magic strings**. Same AST used by ORM and URL filter engine | LINQ is native to C#; but AST is not portable between ORM and other subsystems | 🔴 Major — eliminates `nameof()` and expression tree boilerplate |
+| **EntityDataSet (ORM ↔ VCL/FMX Bridge)** | Connects `TList<T>` (both Smart Properties and POCO collections) to DBGrid/FastReport. **Live data preview in the IDE in design-time** without compiling | No equivalent. Windows Forms DataAdapter is not POCO-based; no IDE preview from ORM | 🔴 Major (Delphi-specific advantage) |
+| **SIMD-Accelerated Collections** | `TRawDictionary` with Open Addressing + Linear Probing. AVX2/SSE2 vectorized lookups. **6.6x faster** than standard RTL dictionary | BCL collections use similar techniques, but developers cannot control or tune at this level | 🟡 High — critical path performance |
+| **In-Process `TExpressionEvaluator`** | Evaluates the **same ORM AST** against in-memory objects and dictionaries. Used by `EntityDataSet.Filter` and standalone | EF Core does not expose an in-memory evaluator for the same expression tree used by SQL | 🟡 High — enables truly unified query logic |
+| **`TStringExpressionParser`** | Converts URL QueryString (`?age_gt=18`) directly into `IExpression` AST nodes with automatic type inference | No equivalent. DRF (Python) does this; ASP.NET requires custom filter parsing | 🟡 High — powers `Database as API` URL filter system |
+| **MCP Server Native** | Zero-dependency MCP 2025-03-26 implementation. `[MCPTool]`, `[MCPParam]`, `[MCPResource]`, `[MCPPrompt]` RTTI attributes. HTTP Streamable, SSE, Stdio transports | No official .NET MCP server implementation (ecosystem still nascent in 2026) | 🟡 High — AI-native framework capability |
+| **Flyweight / Streaming SSR** | `TStreamingViewIterator<T>` — renders 10,000+ records with **O(1) memory** during template `@foreach` | `IAsyncEnumerable<T>` + streaming via `yield return` exists but requires manual plumbing | 🟡 High — critical for large-volume SSR without `ToList` |
+| **HTMX Auto-Detection** | Framework automatically detects `HX-Request` headers and suppresses global layout on compatible endpoints | ASP.NET does not have native HTMX integration; requires manual header inspection | 🟢 Medium |
+| **Binary Code Folding** | `TRawList<T>` — typed generics are thin wrappers over a raw memory core. **Up to 60% reduction in compile times** | Not needed in C# (no Generic Bloom problem in the CLR) | 🟢 Medium (Delphi-specific) |
+| **Live IDE Scaffolding Expert** | Dext Design-Time Expert parses `.pas` units and creates `TFields` dynamically **without compiling**. Live table selection with real-time SQL preview | EF Core Scaffold requires compilation and migration; no comparable IDE integration | 🟢 Medium (Delphi-specific advantage) |
+| **AI Skills (Native)** | Modular `.md` skill files teaching AI assistants (Cursor, Antigravity, Copilot, Claude) to generate idiomatic Dext code | Elevates developer efficiency directly inside modern AI editors | 🟢 Medium — DX multiplier |
+| **Visual Telemetry Dashboard (Built-in)** | Embedded Dashboard (WIP) with Gantt span tree, RED metrics graphs (RPS, QPS, latency, errors), SQL profiler, HTTP profiler | Requires Grafana + Prometheus + Jaeger + OpenTelemetry collector as separate infrastructure | 🔴 Major for teams without DevOps infrastructure (significant updates coming soon) |
+| **UUID v7 Native** | `TUUID.NewV7` — time-ordered, RFC 9562 compliant. Automatic endianness swap for PostgreSQL `uuid` | `Guid.NewGuid()` generates v4; v7 requires NuGet package (UUIDNext, etc.) | 🟢 Medium |
+| **FireDAC `ConnectionDef` Support** | `UseConnectionDef('MyConn')` resolves dialect, driver, and pooling from FDManager automatically | Allows zero-config deployment by directly reading global IDE/Server FD connection profiles. | 🟢 Medium (Delphi-specific advantage) |
+| **`.http` File Runner (Built-in)** | Native parser for standard `.http` files. Same file documents the API, is tested in Dashboard, and executed by RestClient | VS Code/.http files are a tooling convention; ASP.NET does not have a built-in runner | 🟢 Medium — DX advantage |
+
+---
+
+## Block C — Partial in Dext / Roadmap Items
+
+> [!NOTE]
+> These are features where .NET has a more complete or different implementation. Dext either has a partial equivalent or the feature is planned.
+
+| Feature | .NET Status | Dext Status | Notes |
+|:---|:---|:---|:---|
+| **OpenTelemetry ActivitySource** | Fully integrated (ActivitySource, Meter, W3C Trace Context) | Partial — `TDiagnosticSource` + CorrelationId tracking | Roadmap: full OTel exporters (OTLP, Console) |
+| **HybridCache (L1 + L2 unified)** | .NET 9+ — unified L1 (in-memory) + L2 (Redis/SQL), stampede protection, tag-based invalidation | Partial — In-Memory and Redis available separately | Roadmap: unified `HybridCache` API |
+| **DbContext Pooling** | `AddDbContextPool<T>` — high-traffic context reuse pool | Not yet implemented | Roadmap: `TPooledDbContextFactory` |
+| **Named Query Filters (multiple)** | EF Core 10 — multiple named filters per entity, selectively enabled/disabled | Partial — single global filter per entity | Roadmap: named filter support |
+| **`ISaveChangesInterceptor` (formal)** | EF Core Interceptors — decoupled pipeline | Partial — auditing is done inside `DbContext` override | Roadmap: formal interceptor interfaces |
+| **`IDbCommandInterceptor` (formal)** | SQL command interception for logging, correlation IDs | Partial — `TDiagnosticSource` captures SQL | Roadmap: formal command interceptor |
+| **Vector Search / Hybrid Search** | EF Core 10 + SQL Server 2025 | Not implemented | Niche requirement — will track adoption |
+
+---
+
+## Block D — Context Differences (Not Applicable to Delphi)
+
+> [!NOTE]
+> These are features of the .NET ecosystem that do not apply to the Dext Framework by design. The difference is architectural and platform-specific, not a gap.
+
+| Feature (.NET) | Why It Doesn't Apply to Dext |
+|:---|:---|
+| **Blazor / WebAssembly** | Delphi compiles to native binaries. UI for desktop apps uses FMX (multi-platform) or VCL (Windows). No browser runtime needed |
+| **JavaScript Interop** | Delphi has no JS runtime. Browser integration, when needed, is via standard REST APIs |
+| **Native AOT compilation** | Delphi has always compiled ahead-of-time to native machine code. This is the default, not a new feature. No warm-up time, no JIT, no runtime |
+| **Passkey / Biometric Identity UI** | Browser-level WebAuthn API — handled at the reverse proxy or front-end layer |
+| **ANCM / IIS Module** | Dext uses the `WebBroker Adapter` for native IIS/ISAPI/CGI integration — already a first-class citizen |
+| **gRPC (proto-buf generated code)** | Delphi has no native gRPC compiler; but **gRPC & Protobuf are on Wave 3 of Dext's Roadmap ([S02](../../DextRepository/Docs/ROADMAP.md#L36))** as a high-performance native IOCP/EPOLL engine with Code-First gRPC mapping for Delphi Interfaces ([S14](../../DextRepository/Docs/ROADMAP.md#L42)). |
+| **Compiled Models (EF Core)** | Delphi compiles the entire model ahead-of-time. There is no warm-up cost for ORM metadata at runtime |
+| **Source Generator Validation** | Delphi does not have Source Generators as a language feature. Dext uses RTTI-based validation (`[Required]`, `[Range]`, etc.) which achieves the same result |
+| **HSTS Middleware** | Typically managed by the reverse proxy (Nginx, Caddy, Traefik). Dext focuses on app-layer concerns |
+| **Static Assets Pipeline (`MapStaticAssets`)** | Relevant for web apps serving front-end bundles. Delphi apps typically serve through a CDN or reverse proxy |
+
+---
+
+## Summary Statistics
+
+| Category | Count |
+|:---|:---|
+| Full Parity Features (Block A) | 60+ |
+| Dext-Exclusive Features (Block B) | 17 |
+| Roadmap Items (Block C) | 7 |
+| Context Differences — Not Applicable (Block D) | 10 |
+
+## Engineering & High-Performance Foundations
+
+To understand how these functional parity points and exclusive features are implemented at a lower level, refer to our comprehensive architectural guide. It covers compiler-level optimizations, memory footprints, and low-level performance benchmarks:
+
+* 👉 **[Dext Framework Ecosystem Overview](https://github.com/cesarliws/dext/blob/main/Docs/Dext_Ecosystem_Overview.md)**: Deep dive into the *Zero-Allocation Web Pipeline*, *Binary Code Folding (Generic Bloom Cure)*, and *SIMD-Accelerated Collections*.
+
+---
+
+## Navigation
+
+This document is a **reference table** — use it to look up specific features or run precise comparisons.
+
+| I want to… | Go to… |
+|:---|:---|
+| Understand *why* Dext was built and get the big picture | [Dext vs .NET — Architecture Narrative](./Dext_vs_DotNet_Narrative.md) |
+| Deep-dive into the ORM with code examples (Delphi vs C#) | [Dext ORM — Complete Capabilities Reference](./Dext_ORM_Capabilities.md) |
+| Understand Apache 2.0 licensing and enterprise compliance | [Open Source Licensing for Enterprise](./Open_Source_Licensing_Enterprise.md) |
+| Read the full Dext ecosystem architecture | [Dext Ecosystem Overview](https://github.com/cesarliws/dext/blob/main/Docs/Dext_Ecosystem_Overview.md) |
+
+---
+
+*Dext Framework — Feature Comparison Reference | May 2026*

--- a/Docs/Comparison/Feature_Comparison_Dext_vs_DotNet.pt-br.md
+++ b/Docs/Comparison/Feature_Comparison_Dext_vs_DotNet.pt-br.md
@@ -1,0 +1,219 @@
+# Dext Framework vs .NET / EF Core — Matriz de Comparação de Recursos
+
+> **Objetivo**: Este documento fornece uma comparação abrangente e objetiva entre o Dext Framework para Delphi e o ecossistema equivalente de ASP.NET Core + Entity Framework Core para .NET. Destina-se a ajudar os desenvolvedores a entender o que o Dext oferece, onde possui paridade, onde vai além e onde existem diferenças devido ao contexto de cada plataforma.
+>
+> *Última Atualização: Maio de 2026*
+
+---
+
+## Como Ler Este Documento
+
+Esta comparação está estruturada em quatro blocos lógicos:
+
+| Bloco | Significado |
+|---|---|
+| **A — Paridade Total** | O Dext implementa o equivalente funcional do recurso em .NET |
+| **B — Exclusivo do Dext** | Recursos que o Dext possui e o .NET não possui (ou exige pacotes de terceiros) |
+| **C — Parcial / Roadmap** | O .NET possui esse recurso; o Dext o possui parcialmente ou está planejado |
+| **D — Diferença de Contexto** | Recursos do .NET que não se aplicam ao Delphi por design |
+
+---
+
+## Bloco A — Paridade Total de Recursos
+
+> [!NOTE]
+> Todos os recursos listados aqui estão totalmente implementados no Dext. A convenção de nomenclatura e a interface das APIs foram mantidas intencionalmente próximas às contrapartes do .NET para reduzir a curva de aprendizado de desenvolvedores que estão migrando do ecossistema .NET.
+
+### A.1 ORM / Acesso a Dados
+
+| Recurso | EF Core | Equivalente Dext | Notas |
+|:---|:---|:---|:---|
+| **DbContext (Unit of Work)** | `DbContext` | `TDbContext` | Padrão Unit of Work (Unidade de Trabalho) completo |
+| **Change Tracking** | Automático (Added / Modified / Deleted / Unchanged) | Automático — mesmos 4 estados | Identity Map para unicidade de instância por PK (Chave Primária) |
+| **SaveChanges** | `SaveChanges()` / `SaveChangesAsync()` | `SaveChanges()` | Persiste todas as alterações rastreadas dentro de uma transação |
+| **Repositório Genérico** | `DbSet<T>` | `DbSet<T>` | Operações: `Add`, `Update`, `Remove`, `Find`, `Where`, `Include`, `ToList` |
+| **Code-First Migrations** | `dotnet ef migrations add` | Sistema de Migrações Automatizado | Também via CLI. Snapshots cronológicos com detecção de renomeação de tabelas/colunas. **Expert no IDE com wizard planejado.** |
+| **Lazy Loading** | Baseado em Proxies (`UseLazyLoadingProxies`) | Objetos Proxy (interceptação transparente) | Mesma arquitetura técnica |
+| **Eager Loading** | `Include()` / `ThenInclude()` | `Include()` / `ThenInclude()` | Mesma interface de API |
+| **Soft Delete** | Filtros de Consulta Globais (manual) | Atributos `[SoftDelete]` / `[DeletedAt]` | Totalmente declarativo. Suporta HardDelete, Restore, OnlyDeleted, IgnoreQueryFilters. O `[DeletedAt]` carimba automaticamente a data/hora da exclusão. |
+| **Multi-tenancy** | Manual / Filtros de Consulta do EF | `Dext.MultiTenancy` | 3 estratégias: DB Compartilhado (TenantId), Isolamento de Esquema (Schema), DB por Tenant |
+| **Bloqueio Pessimista** | Não nativo (apenas via SQL bruto) | `FOR UPDATE` nativo | Integrado diretamente no motor de consulta do ORM |
+| **Herança: TPH** | Tabela por Hierarquia (Table-Per-Hierarchy) | TPH com atributos de discriminador | Hidratação polimórfica automática |
+| **Herança: TPT** | Tabela por Tipo (Table-Per-Type) | Suporte parcial | Planejado no roadmap |
+| **Conversores de Valor** | `HasConversion<T>()` | `TValueConverterRegistry` | Mais de 20 conversores embutidos (Enum, GUID, TUUID, JSONB, TBytes...) |
+| **Consultas em Coluna JSON** | `OwnsOne().ToJson()` / `JSON_VALUE` | `[JsonColumn]` + `.Json('path')` | Cross-DB: PostgreSQL JSONB, MySQL JSON_EXTRACT, SQLite json_extract, SQL Server JSON_VALUE |
+| **Stored Procedures** | `FromSqlRaw()` / `ExecuteSqlRaw()` | `[StoredProcedure]` + `[DbParam]` | Totalmente declarativo via atributos nas classes |
+| **Specification Pattern** | Pacote de terceiros (Ardalis.Specification) | `Dext.Specifications` — **nativo** | Builder fluente com suporte a `Where`, `OrderBy`, `Include`, `Take`, `Skip` |
+| **Query Extensions (Estilo LINQ)** | LINQ Nativo | `Dext.Collections.Extensions` | Motor de expressões unificado, records gerenciados e operadores implícitos. Otimizado por cache de RTTI thread-safe. |
+| **Suporte Multi-Banco** | Pacotes NuGet separados por provedor | **7 drivers unificados de fábrica** | Construído diretamente sobre a camada de FireDAC Phys Drivers (sem componentes visuais como TQuery). PostgreSQL, SQL Server, MySQL, SQLite, Oracle, Firebird, InterBase. |
+| **Multi-Mapping (Estilo Dapper)** | Não nativo | Atributo `[Nested]` | Hidratação recursiva. Suporta mapeamento direto para Views e Stored Procedures, não apenas tabelas. |
+| **Pool de Conexões** | Pooling do ADO.NET | Configuração Fluente + Autodetecção de Pooling | Métodos como `UsePostgreSQL`, `UseFirebird`, etc., com pooling automático |
+| **Paginação** | `Skip()` / `Take()` | `Skip()` / `Take()` | Mesma API |
+| **Agregações** | `Count()`, `Sum()`, `Max()`, `Min()`, `Avg()` | `Count()`, `Sum()`, `Max()`, `Min()`, `Average()` | Mesma API |
+| **Cache de SQL** | Consultas compiladas do EF | Cache de reaproveitamento de comandos SQL | Consultas repetidas reutilizam o SQL gerado anteriormente |
+| **Operações em Lote (Bulk)** | `ExecuteUpdate()` / `ExecuteDelete()` | `AddRange` / `UpdateRange` / `RemoveRange` | Suporte nativo para inserção, atualização e exclusão em lote de alta performance em uma única chamada física. |
+| **Mapeamento de Objetos** | AutoMapper (terceiros) | `TMapper` — **nativo** | `CreateMap<TSource, TDest>`, `ForMember`, `Map<TSource, TDest>`, mapeamento de coleções |
+
+### A.2 Framework Web / Equivalente ao ASP.NET Core
+
+| Recurso | ASP.NET Core | Equivalente Dext | Notas |
+|:---|:---|:---|:---|
+| **Minimal APIs** | `app.MapGet(...)` / `app.MapPost(...)` | `app.MapGet(...)` / `app.MapPost(...)` | Mesma API fluente de roteamento |
+| **APIs Baseadas em Controllers** | `[ApiController]` + `ControllerBase` | `[ApiController]` + roteamento por atributos | Mesmo padrão arquitetônico |
+| **Pipeline de Middlewares** | `app.Use(...)` — Chain of Responsibility | `app.Use(...)` — mesma arquitetura | Suporte a middlewares funcionais (delegates) e baseados em classes com injeção de DI |
+| **Model Binding** | `[FromBody]`, `[FromQuery]`, `[FromRoute]`, `[FromHeader]`, `[FromServices]` | Mesmos atributos | Alocação zero via `TByteSpan` (desserialização UTF-8 direta da rede) |
+| **Versionamento de API** | `Asp.Versioning` (NuGet) | **Nativo** — 4 leitores | `THeaderApiVersionReader`, `TQueryStringApiVersionReader`, `TPathApiVersionReader`, `TCompositeApiVersionReader` |
+| **Controle de Vazão (Rate Limiting)** | `Microsoft.AspNetCore.RateLimiting` | **Nativo** — 4 algoritmos | Fixed Window, Sliding Window, Token Bucket, Concurrency Limiter |
+| **CORS** | `UseCors()` | Middleware de CORS — embutido | |
+| **Cache de Saída** | `IOutputCache` | Em memória (Redis Client planejado) | O cliente nativo Redis do Dext está 80% completo, focando em máxima performance |
+| **Health Checks** | `IHealthCheck` | Health Checks — embutido | Implementação básica integrada; integrações com bancos e serviços externos no roadmap |
+| **ProblemDetails (RFC 9457)** | Nativo no .NET 8+ | Embutido | O middleware de tratamento de exceções gera respostas compatíveis com a RFC 9457 |
+| **OpenAPI / Swagger** | `Microsoft.AspNetCore.OpenApi` | **Nativo** — geração automática | Endpoints registrados aparecem automaticamente no Swagger gerado na inicialização |
+| **SSE (Server-Sent Events)** | `IServerSentEvents` | SSE nativo | Suporte para streaming unidirecional de eventos |
+| **Equivalente ao SignalR (Hubs)** | SignalR | Mensageria baseada em SSE (SignalR completo planejado) | Atualmente transmissão básica via SSE. Interfaces de Hub bidirecionais prontas; implementação completa pós-motor nativo IOCP/EPOLL. |
+| **Serviços em Segundo Plano** | `IHostedService` / `BackgroundService` | `IHostedService` + `TBackgroundService` | Método `Execute(ICancellationToken)` |
+| **Ciclo de Vida da Aplicação** | `IHostApplicationLifetime` | `IHostApplicationLifetime` | Eventos `ApplicationStarted`, `ApplicationStopping`, `ApplicationStopped` |
+| **Motor de Templates** | Razor | Motor de Templates Dext | Baseado em AST, zero dependências, herança de layouts, macros, filtros |
+| **Motor de Templates Alternativo** | Razor Pages | Web Stencils (Delphi 12.2+) | Alternativa nativa do Delphi integrada |
+| **Multipart / Upload de Arquivos** | `IFormFile` | `IFormFile` | Mesma abstração de manipulação de stream |
+| **Compressão GZip** | `UseResponseCompression` | Middleware embutido | Middleware GZip de alta performance |
+| **Developer Exception Page** | `UseDeveloperExceptionPage()` | Middleware `DeveloperExceptionPage` | Detalhes de exceção formatados para o desenvolvedor em ambiente de testes |
+
+### A.3 Recursos Core do Framework
+
+| Recurso | .NET | Equivalente Dext | Notas |
+|:---|:---|:---|:---|
+| **Injeção de Dependência** | `Microsoft.Extensions.DI` | `TDextServices` | `AddSingleton`, `AddTransient`, `AddScoped`, `AddSingletonFactory` |
+| **Ciclos de Vida de DI** | Singleton / Transient / Scoped | Singleton / Transient / Scoped | `CreateScope` para resolução isolada de dependências filhas |
+| **Resolução Automática de Coleções** | Injeção de `IEnumerable<T>` | `IList<T>`, `IEnumerable<T>`, `IDictionary<K,V>` | Resolvidos automaticamente pelo contêiner de DI |
+| **Atributos de DI** | `[FromServices]` | `[Inject]`, `[ServiceConstructor]` | Injeção por campo, propriedade ou construtor |
+| **Sistema de Configuração** | `IConfiguration` / `appsettings.json` | `TDextConfiguration` | Provedores: JSON, YAML, ENV, argumentos CLI, memória — mesmo design extensível |
+| **Options Pattern** | `IOptions<T>`, `IOptionsSnapshot<T>`, `IOptionsMonitor<T>` | `IOptions<T>`, `IOptionsSnapshot<T>`, `IOptionsMonitor<T>` | Mesmas interfaces e comportamentos |
+| **Hot-Reload de Configuração** | `IChangeToken` | `IChangeToken` + callback `OnReload` | Atualização dinâmica de arquivos de configuração |
+| **Logging (Registros)** | `ILogger<T>` / `ILoggerFactory` | `ILoggerFactory` / `ILogger` | Níveis: Trace, Debug, Information, Warning, Error, Critical |
+| **Async / Await** | `Task<T>` / `async/await` | `TAsyncTask` + Work-Stealing Scheduler | Concorrência assíncrona robusta em Object Pascal |
+| **Cancellation Token** | `CancellationToken` | `ICancellationToken` | Métodos `WaitForCancellation`, `IsCancellationRequested` |
+| **Nullable<T>** | `Nullable<T>` / `T?` | `Nullable<T>` | Métodos `HasValue`, `Value`, `GetValueOrDefault` e operadores implícitos |
+| **Lazy<T>** | `Lazy<T>` | `Lazy<T>` | Bloqueio duplo thread-safe (double-checked locking); baseado em factory |
+| **Span<T> / ReadOnlySpan<T>** | `Span<T>` / `ReadOnlySpan<T>` | `TSpan<T>` / `TReadOnlySpan<T>` | Manipulação rápida de memória com alocação zero e verificação de limites |
+| **Mapeamento de Objetos** | AutoMapper (terceiros) | `TMapper` nativo | Integrado ao ecossistema |
+| **Serialização JSON** | `System.Text.Json` / Newtonsoft | `TDextJson` + Streaming de baixo nível UTF-8 | Drivers plugáveis. Leitor/gravador binário de alta performance via `TSpan` sem alocações na heap. |
+| **Frozen Collections** | `FrozenDictionary<K,V>` (.NET 8+) | `TFrozenDictionary<K,V>` / `TFrozenSet<T>` | Leitura livre de locks (lock-free) e coleções imutáveis após construção |
+| **Canais (Channels)** | `System.Threading.Channels` | `TChannel<T>` | Inspirado em Go. Canais Bounded (com backpressure) e Unbounded; ChannelReader/ChannelWriter |
+| **Event Bus / MediatR** | MediatR (terceiros) | `Dext.Events` — **nativo** | Pipeline de Behaviors (logs, tempos, exceções); bus escopado ou singleton |
+| **Padrão Defer** | `using` / `IDisposable` | `IDeferred` / `TDeferredAction` | Inspirado em Go; ação executada automaticamente na saída do escopo do bloco |
+
+### A.4 Infraestrutura de Testes
+
+| Recurso | .NET | Equivalente Dext | Notas |
+|:---|:---|:---|:---|
+| **Framework de Testes** | xUnit / NUnit / MSTest (terceiros) | `Dext.Testing` — **nativo** | Integrado diretamente ao framework |
+| **Testes Baseados em Atributos** | `[Fact]`, `[Theory]`, `[Test]` | `[Fact]`, `[Test]`, `[Fixture]`, `[TestClass]` | |
+| **Testes Baseados em Dados** | `[InlineData]`, `[MemberData]` | `[TestCase]`, `[TestCaseSource]`, `[Values]`, `[Range]`, `[Random]` | |
+| **Testes Combinatórios** | Parametrizado (manual) | `[Combinatorial]` | Todas as combinações de parâmetros são geradas automaticamente |
+| **Ciclos de Vida (Lifecycle Hooks)** | `[SetUp]`, `[TearDown]`, `[OneTimeSetUp]` | `[Setup]`, `[TearDown]`, `[BeforeAll]`, `[AfterAll]`, `[AssemblyInitialize]` | |
+| **Asserções Fluidas** | FluentAssertions (terceiros) | `Dext.Assertions` — **nativo** | Padrão de escrita fluida `Should(Value)`; comparações estruturais complexas |
+| **Asserções Suaves (Soft Asserts)** | FluentAssertions (terceiros) | `Assert.Multiple(...)` — nativo | Coleta múltiplas falhas antes de abortar a execução do teste |
+| **Testes de Snapshot** | Verify (terceiros) | Nativo no Dext | Base de comparação em disco, comparação estrutural de JSON, modo de atualização automática |
+| **Simulações (Mocks)** | Moq / NSubstitute (terceiros) | `Dext.Mocks` — **nativo** | `Mock<T>.Setup.Returns(Val)`, seletores de argumentos (matchers) e verificação |
+| **Auto-Mocking** | AutoFixture + Moq (terceiros) | `TAutoMocker` — **nativo** | Injeção automática de mocks diretamente no contêiner de DI de testes |
+| **Relatórios de CI/CD** | Bibliotecas de terceiros | Integrado | Formatos nativos: JUnit XML, xUnit XML, TRX (Azure DevOps), HTML (Dark Theme), JSON, SonarQube |
+
+---
+
+## Bloco B — Recursos Exclusivos do Dext
+
+> [!IMPORTANT]
+> Os recursos listados neste bloco existem no Dext, mas **não possuem equivalente direto no ecossistema .NET de fábrica** (ou exigem soluções comerciais complexas de terceiros sem suporte oficial). Estes são os principais diferenciais competitivos e tecnológicos do Dext.
+
+| Recurso | Dext | Status no .NET / EF Core | Impacto Prático |
+|:---|:---|:---|:---|
+| **Database as API** | Atributo `[DataApi]` + `app.MapDataApis` — gera uma API REST CRUD completa em tempo de execução com **1 única linha** | Sem equivalente. Exige a escrita manual de Scaffold, Controllers, camada de Serviço, Repositório e DTOs | 🔴 Altíssimo — elimina dias de trabalho repetitivo escrevendo código de CRUD padrão |
+| **Smart Properties / `Prop<T>`** | Record genérico de modo duplo: armazena valores OU gera AST via sobrecarga de operadores. Consultas fortemente tipadas **sem strings mágicas**. Mesma AST interpretada pelo ORM, cache em memória e roteador HTTP | O LINQ é nativo no C#; porém a árvore de expressão gerada (AST) não é portável entre o ORM e outros subsistemas do framework de forma simples | 🔴 Altíssimo — elimina o uso de `nameof()` e a necessidade de boilerplates complexos de Expression Trees |
+| **EntityDataSet (Ponte ORM ↔ VCL/FMX)** | Conecta listas `TList<T>` (baseadas em POCO ou Smart Properties) diretamente a componentes visuais de tela (DBGrid, FastReport, etc.). **Visualização em tempo real de dados reais no próprio IDE no modo de design** sem precisar compilar | Sem equivalente corporativo de fábrica. O DataAdapter do Windows Forms não se integra diretamente a entidades POCO modernas e não gera prévias visuais em tempo de design no IDE a partir do ORM | 🔴 Altíssimo (Diferencial específico e exclusivo para o Delphi corporativo) |
+| **SIMD-Accelerated Collections** | `TRawDictionary` com endereçamento aberto + Linear Probing. Consultas vetorizadas via instruções AVX2/SSE2. **6.6 vezes mais rápido** que o `TDictionary` padrão da RTL | Coleções da biblioteca BCL usam técnicas semelhantes, mas o desenvolvedor não tem controle ou possibilidade de tuning fino nessa camada | 🟡 Alto — performance crítica em fluxos de alta concorrência |
+| **`TExpressionEvaluator` Integrado** | Avalia a **mesma AST do ORM** diretamente contra objetos de memória e dicionários. Utilizado no motor de filtros do `EntityDataSet` ou de forma avulsa | O EF Core não expõe um avaliador em memória acessível para a mesma árvore de expressão utilizada para a geração de queries SQL físicas | 🟡 Alto — unifica de fato as regras de consulta física e lógica de memória em um único lugar |
+| **`TStringExpressionParser`** | Converte parâmetros da URL QueryString (`?age_gt=18`) diretamente em nós de AST do tipo `IExpression` com inferência automática de tipo de dado | Sem equivalente nativo no .NET. Ecossistemas como Django REST (Python) fazem isso; no ASP.NET exige a escrita de rotinas personalizadas | 🟡 Alto — atua como a engrenagem que viabiliza o dinamismo do `Database as API` |
+| **Servidor MCP Nativo** | Implementação sem dependências externas do protocolo Model Context Protocol (MCP 2025-03-26). Atributos RTTI `[MCPTool]`, `[MCPParam]`, `[MCPResource]`. Transportes via HTTP Stream, SSE, Stdio | Sem implementação oficial de servidor MCP pelo time do .NET (ecossistema ainda nascente em 2026) | 🟡 Alto — habilita o framework a interagir nativamente com agentes de IA (AI-Native) |
+| **Flyweight / Streaming SSR** | `TStreamingViewIterator<T>` — renderiza views HTML com mais de 10.000 registros mantendo **consumo de memória constante O(1)** durante laços de repetição `@foreach` | Recursos como `IAsyncEnumerable<T>` e streaming via `yield return` existem, mas exigem encadeamento e arquitetura manual complexa para evitar carregar a lista na heap | 🟡 Alto — essencial para SSR de grande volume de dados |
+| **Detecção Automática de HTMX** | O framework detecta automaticamente os cabeçalhos `HX-Request` nas requisições HTTP e suprime o layout global padrão em respostas de páginas | O ASP.NET não possui integração nativa out-of-the-box para o ecossistema HTMX; exige tratamento manual de cabeçalho nas rotas | 🟢 Médio |
+| **Binary Code Folding** | `TRawList<T>` — as classes genéricas tipadas atuam apenas como cascas finas sobre um núcleo de gerenciamento de memória bruta. **Redução de até 60% no tempo de compilação** | Não aplicável ao C# (o CLR não sofre com o problema de "Generic Bloom" que gera inchaço de binário em Delphi) | 🟢 Médio (Diferencial técnico vital para Delphi) |
+| **Live IDE Scaffolding Expert** | O Dext Design-Time Expert interpreta units `.pas` e cria os componentes visuais `TFields` dinamicamente **sem precisar compilar o projeto**. Permite seleção de tabelas com prévia de SQL em tempo real | O Scaffold do EF Core exige compilação prévia e execução de ferramentas de terminal; não possui integração visual interativa ao IDE | 🟢 Médio (Vantagem para modernização RAD) |
+| **AI Skills Integradas** | Arquivos de habilidades em formato Markdown (`.md`) nativos que ensinam assistentes de IA (Cursor, Antigravity, Copilot, Claude) a gerar códigos Dext corretos de forma idiomática | Aumenta significativamente a produtividade ao utilizar editores de código modernos assistidos por IA | 🟢 Médio — Multiplicador de DX |
+| **Painel de Telemetria Visual Integrado** | Painel web integrado (Em Desenvolvimento) com árvore de spans estilo Gantt, gráficos de métricas RED (RPS, latência, erros), profiler de SQL e requisições HTTP | No .NET, exige a configuração complexa e independente de Grafana + Prometheus + Jaeger + OpenTelemetry Collector | 🔴 Altíssimo para equipes de desenvolvimento sem infraestrutura complexa de DevOps corporativo |
+| **UUID v7 Nativo** | `TUUID.NewV7` — identificadores ordenados no tempo de acordo com a RFC 9562. Troca automática de endianness para tratamento otimizado de campos PostgreSQL `uuid` | O método `Guid.NewGuid()` gera UUID v4; o uso de v7 no .NET exige a dependência de pacotes NuGet adicionais de terceiros (como o UUIDNext) | 🟢 Médio |
+| **Integração com FireDAC `ConnectionDef`** | Método `UseConnectionDef('MyConn')` resolve automaticamente o dialeto SQL, drivers físicos e pooling a partir do FDManager do Delphi | Habilita deploy com configuração zero ao ler diretamente os perfis globais ativos de conexão da IDE ou do Servidor. | 🟢 Médio (Facilidade operacional em Delphi) |
+| **Executável de Arquivos `.http` Integrado** | Analisador nativo para arquivos padrão `.http`. O mesmo arquivo documenta a API no repositório, serve para testes rápidos no Painel e é executado pelo RestClient | A convenção de arquivos `.http` é suportada por plugins de editores (como VS Code); o ASP.NET não possui um executor nativo na engine | 🟢 Médio — Facilidade para documentação viva |
+
+---
+
+## Bloco C — Parcial no Dext / Planejado no Roadmap
+
+> [!NOTE]
+> Estes são recursos onde o ecossistema .NET oferece atualmente uma implementação mais madura, completa ou estruturada de fábrica. O Dext os possui de forma parcial ou eles já estão planejados no roadmap oficial de evolução do framework.
+
+| Recurso | Status no .NET | Status no Dext | Notas |
+|:---|:---|:---|:---|
+| **ActivitySource do OpenTelemetry** | Totalmente integrado (suporte a ActivitySource, Meter e W3C Trace Context out-of-the-box) | Parcial — suporte nativo a `TDiagnosticSource` + rastreamento de CorrelationId | Mapeado no Roadmap: desenvolvimento de exportadores OTel nativos (OTLP, Console) |
+| **HybridCache (L1 + L2 Unificados)** | Introduzido no .NET 9+ — unifica L1 (memória local) + L2 (Redis/SQL) com proteção contra cache stampede e invalidação por tags | Parcial — motores de Cache em Memória e Redis disponíveis separadamente | Mapeado no Roadmap: unificação das camadas sob uma única API de `HybridCache` |
+| **Pool de DbContext** | Método `AddDbContextPool<T>` — pool de reaproveitamento de instâncias do DbContext em tráfego massivo | Não implementado | Mapeado no Roadmap: classe `TPooledDbContextFactory` |
+| **Named Query Filters (múltiplos)** | Introduzido no EF Core 10 — permite aplicar múltiplos filtros globais por entidade, ativando/desativando seletivamente | Parcial — suporte a um único filtro global estático por entidade | Mapeado no Roadmap: suporte a múltiplos filtros nomeados dinâmicos |
+| **Auditoria via Interceptors** | EF Core Interceptors — pipeline totalmente desacoplado por eventos do ciclo de vida | Parcial — auditoria de entidades centralizada via sobrescrita de métodos no `DbContext` | Mapeado no Roadmap: interfaces formais desacopladas para interceptores |
+| **Interceptador de `IDbCommand`** | Intercepção formal de comandos SQL executados para auditoria e injeção de Correlation IDs | Parcial — o motor `TDiagnosticSource` intercepta e coleta a execução física do SQL | Mapeado no Roadmap: interfaces formais de comando e transação |
+| **Busca Vetorial / Busca Híbrida** | Integrado no EF Core 10 + suporte nativo a SQL Server 2025 | Não implementado | Demanda de nicho — o time avalia a adoção de bancos vetoriais pelo mercado Delphi |
+
+---
+
+## Bloco D — Diferenças de Contexto (Não Aplicáveis ao Delphi por Design)
+
+> [!NOTE]
+> Os itens listados neste bloco referem-se a recursos do ecossistema .NET que não fazem sentido ou não se aplicam ao Dext Framework devido a diferenças de arquitetura de baixo nível e de plataforma. Não representam lacunas do Dext, mas sim diferenças estruturais.
+
+| Recurso no .NET | Por que não se aplica ao Dext |
+|:---|:---|
+| **Blazor / WebAssembly** | O Delphi compila nativamente para binários de máquina. Para interfaces visuais desktop, utiliza-se a VCL (Windows) ou FMX (multiplataforma nativa). Não há necessidade de runtime de navegador web |
+| **Interoperabilidade JavaScript** | O Delphi não opera sobre uma engine JS interna. A comunicação e integração com navegadores ou outras plataformas de frontend é realizada por meio de APIs REST padrão da indústria |
+| **Compilação Nativa AOT** | O compilador do Delphi sempre gerou binários nativos AOT (Ahead-of-Time) de fábrica por padrão. Não há compilação JIT (Just-In-Time) e nem tempos de inicialização lentos (cold start) |
+| **UI de Identidade por Biometria / Passkey** | Protocolo de nível de navegador WebAuthn — geralmente tratado nas camadas de proxy reverso ou nos clientes de frontend (SPA, Mobile) |
+| **Módulo do IIS (ANCM)** | O Dext utiliza o `WebBroker Adapter` para integração transparente e nativa a servidores IIS/ISAPI/CGI, atuando como componente nativo de primeira classe |
+| **Compilador gRPC (Geração de Código `.proto`)** | O Delphi não possui um compilador gRPC nativo fornecido pela Embarcadero. **O gRPC e Protobuf estão mapeados na Wave 3 do Roadmap do Dext ([S02](../../DextRepository/Docs/ROADMAP.md#L36))** como um motor nativo baseado em IOCP/EPOLL de alta performance com mapeamento direto Code-First para Interfaces Delphi ([S14](../../DextRepository/Docs/ROADMAP.md#L42)). |
+| **Compiled Models (EF Core)** | Como o Delphi resolve tudo ahead-of-time, os metadados do ORM são processados e otimizados em tempo de compilação. Não há custo de warm-up ao inicializar o ORM em tempo de execução |
+| **Validação via Source Generators** | O Delphi não possui Source Generators como recurso de sintaxe da linguagem. O Dext implementa validações baseadas em RTTI (`[Required]`, `[Range]`, etc.) que atingem o mesmo objetivo com flexibilidade |
+| **Middleware de HSTS** | Geralmente configurado nas camadas de proxy reverso e balanceadores (Nginx, Caddy, Traefik). O Dext foca nos fluxos críticos do nível de aplicação |
+| **Pipeline de Ativos Estáticos (`MapStaticAssets`)** | Relevante para frameworks que servem arquivos de frontend estáticos diretamente da aplicação. Aplicações Delphi em escala produtiva delegam a entrega de arquivos estáticos a CDNs ou proxies reversos |
+
+---
+
+## Estatísticas de Comparação
+
+| Categoria | Quantidade |
+|:---|:---:|
+| Recursos em Paridade Total (Bloco A) | 60+ |
+| Recursos Exclusivos do Dext (Bloco B) | 17 |
+| Itens em Roadmap / Parciais (Bloco C) | 7 |
+| Diferenças de Contexto (Bloco D) | 10 |
+
+---
+
+## Engenharia & Fundações de Alta Performance
+
+Para compreender como estes pontos de paridade funcional e os recursos exclusivos de arquitetura são implementados no nível mais baixo (otimizações do compilador, uso de memória e benchmarks físicos), consulte o nosso guia técnico principal de engenharia:
+
+* 👉 **[Visão Geral do Ecossistema Dext](https://github.com/cesarliws/dext/blob/main/Docs/Dext_Ecosystem_Overview.pt-br.md)**: Estudo detalhado sobre o *Zero-Allocation Web Pipeline*, a técnica de *Binary Code Folding* (que resolve oGeneric Bloom em Delphi) e as *Coleções Otimizadas por SIMD*.
+
+---
+
+## Navegação
+
+Este documento é uma **tabela de referência rápida** — utilize-a para buscar recursos específicos ou realizar comparações pontuais.
+
+| Quero... | Ir para... |
+|:---|:---|
+| Compreender *por que* o Dext foi construído e obter a visão geral narrativa | [Dext vs .NET — Narrativa de Arquitetura](./Dext_vs_DotNet_Narrative.pt-br.md) |
+| Aprofundar-me nas capacidades do ORM com exemplos de código reais (Delphi vs C#) | [Dext ORM — Referência Completa de Recursos](./Dext_ORM_Capabilities.pt-br.md) |
+| Compreender o licenciamento sob Apache 2.0 e conformidade jurídica corporativa | [Licenciamento Open Source para Empresas](./Open_Source_Licensing_Enterprise.pt-br.md) |
+| Ler sobre a engenharia de baixo nível do ecossistema do Dext | [Visão Geral do Ecossistema Dext](https://github.com/cesarliws/dext/blob/main/Docs/Dext_Ecosystem_Overview.pt-br.md) |
+
+---
+
+*Dext Framework — Referência de Comparação de Recursos | Maio de 2026*

--- a/Docs/Comparison/Open_Source_Licensing_Enterprise.md
+++ b/Docs/Comparison/Open_Source_Licensing_Enterprise.md
@@ -1,0 +1,129 @@
+| **Explicit Patent Protection** | ❌ No | ✅ **Yes (Patent Grant)** | ❌ No | 🟡 Partial |
+# Open-Source Licensing in the Enterprise: Why Apache 2.0 Makes Dext Production-Ready for Large Businesses
+
+When software architects and CTOs at enterprise-scale corporations (such as multinational financial institutions, large ERP providers, or major global players) select a technology stack, the evaluation criteria extend far beyond compiler speed and ergonomic DSLs. 
+
+A silent but critical gatekeeper in every modern large enterprise is **Legal Compliance and IP (Intellectual Property) Protection**. 
+
+In high-throughput environments, a single copyleft or legally blind open-source dependency can trigger mandatory legal audits, block production deployments, or even force proprietary systems to open-source their core IP.
+
+---
+
+## 1. The Post-Commit Pipeline Reality: A Real-World Case Study
+
+Consider a typical scenario in a major global technology unit. The engineering team is moving fast, pushing code to repository branches multiple times a day. To enforce security and legal compliance at scale, the company utilizes automated vulnerability and license scanners like **Snyk** integrated directly into the post-commit CI/CD pipeline.
+
+One afternoon, a senior architect is suddenly summoned to a meeting with the corporate legal and compliance team. 
+
+```
+[Developer Push] ──> [CI/CD Pipeline] ──> [Snyk Scan] ──> ❌ BUILD FAILED!
+                                                              │
+                                            [Legal Compliance Vetoes Deployment]
+                                                              │
+                                            [Architect Summoned to Remediation]
+```
+
+### The Friction
+What triggered the alarm? A developer, looking to solve a small utility issue quickly, imported a lightweight open-source helper library. The library seemed perfect, functional, and was labeled "open-source." However, it carried a copyleft license (such as GPL) or was a permissive library built on a copyleft foundation (like a minimal web package relying on an LGPL-3.0 socket transport).
+
+The consequences of this single commit are severe:
+* **Blocked Pipeline**: The Snyk scan automatically broke the build, blocking the entire release pipeline.
+* **IP Risk Audit**: The legal team must audit whether any proprietary intellectual property has been "contaminated" or statically linked to the copyleft code.
+* **Wasted Engineering Hours**: The architectural team is forced to halt development, explain the mistake to non-technical legal officers, and spend days stripping out the library and rewriting the functionality from scratch.
+
+This reality highlights a fundamental truth: **Developer convenience must never compromise legal safety.**
+
+---
+
+## 2. The Open-Source License Spectrum
+
+Open-source licenses generally fall into three categories. Their differences determine whether your business can legally bundle a library into closed-source proprietary software.
+
+```mermaid
+graph TD
+    classDef permissive fill:#d4edda,stroke:#28a745,color:#155724;
+    classDef copyleft fill:#fff3cd,stroke:#ffc107,color:#856404;
+    classDef strong fill:#f8d7da,stroke:#dc3545,color:#721c24;
+
+    A[Open Source Licenses] --> B[Permissive]
+    A --> C[Weak Copyleft]
+    A --> D[Strong Copyleft]
+
+    B --> B1[MIT / BSD]:::permissive
+    B --> B2[Apache 2.0]:::permissive
+    
+    C --> C1[LGPL / MPL]:::copyleft
+    
+    D --> D1[GPL / AGPL]:::strong
+
+    style B1 fill:#e2f0d9,stroke:#385723
+    style B2 fill:#c6e0b4,stroke:#385723,stroke-width:3px
+```
+
+### 1.1. Permissive Licenses (MIT, BSD, Apache 2.0)
+These licenses allow anyone to use, modify, distribute, sublicense, and sell the software in proprietary, closed-source commercial applications. They offer maximum freedom with minimal restrictions.
+
+### 1.2. Copyleft/ShareAlike Licenses (GPL)
+Often referred to as "viral" licenses. If you modify or link a GPL library into your application and distribute it, **you are legally forced to open-source your entire proprietary codebase under the same GPL license**. For commercial software companies, this is an immediate **red flag** and a deal-breaker.
+
+### 1.3. Weak Copyleft Licenses (LGPL, MPL)
+These allow linking (dynamic or static) without forcing your proprietary code to become open-source, *as long as you do not modify the library itself*. However, their compliance rules are notoriously complex and highly scrutinized by corporate legal departments.
+
+---
+
+## 2. The Silent Trap: Permissive but "Patent-Blind" (MIT vs. Apache 2.0)
+
+A common misconception among developers is that the **MIT License** is the perfect corporate license because of its simplicity. While popular for small utilities, MIT has a massive, critical loophole for large enterprise software: **the lack of explicit patent grants**.
+
+### The MIT Patent Loophole
+The MIT license grants copyright permissions but is completely silent regarding patents. This creates two catastrophic risks for a business:
+
+1. **Submarine Patents**: A contributor might submit code to an MIT-licensed project that is covered by one of their active patents. If your company uses this project in a high-revenue commercial system, that contributor (or their parent company) can legally sue you for patent infringement, demanding massive royalties. The MIT copyright grant does not shield you from patent litigation.
+2. **Patent Trolling**: Competitors can weaponize patents against your system because the open-source library you built on did not require contributors to sign away patent litigation rights.
+
+### The Apache 2.0 Shield: Complete Patent Peace
+The **Apache 2.0 License** was engineered specifically to solve the patent loophole, making it the preferred license for robust enterprise software (chosen by Google for Kubernetes/Android, the Apache Foundation, and Microsoft for .NET core libraries).
+
+Apache 2.0 implements two vital protections:
+
+* **Explicit Patent Grant**: Every contributor to an Apache 2.0 project automatically grants users a worldwide, royalty-free, perpetual, and irrevocable patent license to use their contributions.
+* **Patent Retaliation Clause**: If a user initiates patent litigation against *any* entity claiming that the Apache 2.0 software infringes their patents, **their license to the software is terminated immediately**. This acts as an intellectual property peace treaty, preventing patent lawsuits entirely.
+
+---
+
+## 3. Brand Protection: Trademarks
+
+For a framework like Dext, building an ecosystem of high quality, stability, and trust is paramount. 
+* Under **MIT**, anyone can fork your code, keep your name, repackage it with buggy modifications, and distribute it, potentially damaging the brand reputation of the original framework.
+* **Apache 2.0 explicitly excludes trademark rights**. It states that users cannot use the trade names, trademarks, service marks, or product names of the licensor without express permission. This ensures that the name **Dext** remains synonymous with professional-grade, high-performance software, protecting both the framework and the companies that build on it.
+
+---
+
+## 4. Comparing Licenses for Corporate Compliance
+
+Below is a direct comparison of the key licenses that corporate legal teams evaluate during software audits:
+
+| Legal / Compliance Metric | MIT | Apache 2.0 | LGPL | GPL / AGPL |
+|:---|:---:|:---:|:---:|:---:|
+| **Commercial Use in Closed Source** | ✅ Yes | ✅ Yes | 🟡 Conditional | ❌ **Strictly Prohibited** |
+| **Patent Litigation Retaliation** | ❌ No | ✅ **Yes (Legal Shield)** | ❌ No | ❌ No |
+| **Trademark Protection** | ❌ No | ✅ **Yes** | ❌ No | ❌ No |
+| **IP Exposure Risk for Core App** | 🟢 None | 🟢 None | 🟡 Medium (Static Link Risk) | 🔴 **High (Systemic)** |
+| **Compliance Complexity / Audits** | 🟢 Extremely Low | 🟢 Low | 🔴 High | 🔴 Critical |
+
+---
+
+## 5. Why Dext is Enterprise-Grade from Day One
+
+By releasing the Dext Framework under the **Apache 2.0 License**, the creators of Dext made a highly conscious, strategic architectural decision to provide corporate clients with absolute legal security.
+
+1. **Production-Ready Compliance**: Dext easily clears automated dependency scans (Black Duck, Snyk, WhiteSource) used by corporate compliance teams at major global enterprises.
+2. **Safe from Patent Litigation**: Companies can build high-revenue proprietary applications on top of the Dext ORM and Web Server with the absolute certainty that they are protected by an irrevocable patent license grant from all contributors.
+3. **No Viral Contamination**: Dext is completely free of GPL/AGPL dependencies. Unlike minimal frameworks that rely on LGPL-3.0 libraries (such as `Delphi-Cross-Socket` for WebSocket handling), Dext enforces strict separation of concerns, ensuring that your commercial ERP or fiscal system remains 100% proprietary and closed-source.
+4. **Brand Integrity**: The Apache 2.0 trademark clause ensures that your technology choice is backed by a secure brand name, protecting your business from copycat projects and untrusted forks.
+
+## Conclusion
+
+Performance metrics, change tracking, and memory efficiency are vital, but **legal compliance is the ultimate gatekeeper of enterprise deployment**. 
+
+Dext's Apache 2.0 license is not just a detail; it is a **business-critical feature** that enables CTOs and Architects to confidently propose Dext as the modern, high-performance, and legally secure foundation for the next decade of enterprise Delphi systems.

--- a/Docs/Comparison/Open_Source_Licensing_Enterprise.pt-br.md
+++ b/Docs/Comparison/Open_Source_Licensing_Enterprise.pt-br.md
@@ -1,0 +1,128 @@
+# Licenciamento Open-Source no Ambiente Corporativo: Por que a Licença Apache 2.0 Torna o Dext Pronto para Produção em Grandes Empresas
+
+Quando arquitetos de software e CTOs de empresas de escala corporativa (como instituições financeiras multinacionais, grandes provedores de ERP ou players globais de tecnologia) selecionam uma stack tecnológica, os critérios de avaliação vão muito além da velocidade do compilador e de DSLs ergonômicas. 
+
+Um guardião silencioso, mas crítico, em toda grande empresa moderna é a **Conformidade Legal e a Proteção de PI (Propriedade Intelectual)**. 
+
+Em ambientes corporativos de alta criticidade, uma única dependência open-source sob licença copyleft ou juridicamente obscura pode desencadear auditorias legais obrigatórias, bloquear deploys em produção ou até mesmo forçar a empresa a abrir o código-fonte proprietário de seus sistemas core.
+
+---
+
+## 1. A Realidade do Pipeline de Commit: Um Estudo de Caso Real
+
+Considere um cenário típico em uma unidade de tecnologia global. A equipe de engenharia está trabalhando em ritmo acelerado, realizando commits e pushes de código várias vezes ao dia. Para garantir a segurança e a conformidade jurídica em escala, a empresa utiliza ferramentas automatizadas de análise de vulnerabilidade e licenciamento, como o **Snyk**, integradas diretamente ao pipeline de CI/CD pós-commit.
+
+Em uma tarde comum, um arquiteto sênior é repentinamente convocado para uma reunião de emergência com a equipe de compliance e o departamento jurídico corporativo.
+
+```
+[Push do Desenvolvedor] ──> [Pipeline de CI/CD] ──> [Snyk Scan] ──> ❌ BUILD FALHOU!
+                                                                      │
+                                                [Compliance Vetou a Publicação]
+                                                                      │
+                                                [Arquiteto Convocado para Ajuste]
+```
+
+### O Atrito
+O que disparou o alarme? Um desenvolvedor, buscando resolver um pequeno problema de utilidade de forma rápida, importou uma biblioteca auxiliar open-source leve. A biblioteca parecia perfeita, funcional e estava rotulada como "open-source". No entanto, ela carregava uma licença copyleft (como a GPL) ou era uma biblioteca permissiva construída sobre uma base copyleft (como um pacote web minimalista que dependia de um transporte de socket sob LGPL-3.0).
+
+As consequências desse único commit são graves:
+* **Pipeline Bloqueado**: A verificação do Snyk quebrou automaticamente o build, paralisando todo o pipeline de release.
+* **Auditoria de Risco de PI**: A equipe jurídica precisa auditar se alguma propriedade intelectual proprietária foi "contaminada" ou vinculada estaticamente ao código copyleft.
+* **Horas de Engenharia Desperdiçadas**: A equipe de arquitetura é forçada a interromper o desenvolvimento, explicar o erro a assessores jurídicos não técnicos e passar dias removendo a biblioteca e reescrevendo a funcionalidade do zero.
+
+Essa realidade destaca uma verdade fundamental: **A conveniência do desenvolvedor nunca deve comprometer a segurança jurídica corporativa.**
+
+---
+
+## 2. O Espectro das Licenças Open-Source
+
+As licenças open-source geralmente se enquadram em três categorias principais. Suas diferenças determinam se sua empresa pode legalmente empacotar e distribuir uma biblioteca dentro de um software proprietário de código fechado.
+
+```mermaid
+graph TD
+    classDef permissive fill:#d4edda,stroke:#28a745,color:#155724;
+    classDef copyleft fill:#fff3cd,stroke:#ffc107,color:#856404;
+    classDef strong fill:#f8d7da,stroke:#dc3545,color:#721c24;
+
+    A[Licenças Open Source] --> B[Permissivas]
+    A --> C[Copyleft Fraco]
+    A --> D[Copyleft Forte]
+
+    B --> B1[MIT / BSD]:::permissive
+    B --> B2[Apache 2.0]:::permissive
+    
+    C --> C1[LGPL / MPL]:::copyleft
+    
+    D --> D1[GPL / AGPL]:::strong
+
+    style B1 fill:#e2f0d9,stroke:#385723
+    style B2 fill:#c6e0b4,stroke:#385723,stroke-width:3px
+```
+
+### 1.1. Licenças Permissivas (MIT, BSD, Apache 2.0)
+Essas licenças permitem que qualquer pessoa use, modifique, distribua, sublicencie e venda o software em aplicações comerciais proprietárias de código fechado. Oferecem liberdade máxima com restrições mínimas.
+
+### 1.2. Licenças Copyleft/Compartilhamento pela Mesma Licença (GPL)
+Frequentemente chamadas de licenças "virais". Se você modificar ou vincular uma biblioteca GPL em sua aplicação e distribuí-la, **você será legalmente obrigado a abrir todo o código-fonte proprietário do seu sistema sob a mesma licença GPL**. Para empresas de software comercial, isso é um **sinal vermelho** imediato e impeditivo.
+
+### 1.3. Licenças Copyleft Fraco (LGPL, MPL)
+Permitem o vínculo (dinâmico ou estático) sem forçar o seu código proprietário a se tornar open-source, *desde que você não modifique a própria biblioteca*. No entanto, suas regras de conformidade são complexas e altamente escrutinadas pelos departamentos jurídicos corporativos.
+
+---
+
+## 3. A Armadilha Silenciosa: Permissiva, mas "Cega para Patentes" (MIT vs. Apache 2.0)
+
+Um equívoco comum entre os desenvolvedores é pensar que a **Licença MIT** é a licença corporativa ideal devido à sua extrema simplicidade. Embora excelente para pequenos utilitários, a MIT possui uma lacuna massiva e crítica para softwares corporativos de grande porte: **a ausência de concessões explícitas de patentes**.
+
+### A Brecha de Patentes da MIT
+A licença MIT concede permissões de direitos autorais (copyright), mas é completamente omissa em relação a patentes. Isso cria dois riscos catastróficos para um negócio:
+
+1. **Patentes Submarinas (Submarine Patents)**: Um colaborador pode enviar código para um projeto licenciado sob MIT que esteja coberto por uma de suas patentes ativas. Se sua empresa utilizar esse projeto em um sistema comercial de alta receita, esse colaborador (ou sua empresa-mãe) poderá processá-lo legalmente por violação de patente, exigindo royalties massivos. A concessão de direitos autorais da MIT não protege sua empresa contra litígios de patentes.
+2. **Ataques de Patentes (Patent Trolling)**: Concorrentes podem usar patentes como armas contra seu sistema porque a biblioteca open-source na qual você se baseou não exigia que os colaboradores abrissem mão de direitos de litígio de patentes.
+
+### O Escudo Apache 2.0: Paz Completa de Patentes
+A **Licença Apache 2.0** foi projetada especificamente para resolver essa lacuna de patentes, tornando-se a licença preferida para softwares corporativos robustos (escolhida pelo Google para o Kubernetes/Android, pela Apache Foundation e pela Microsoft para as bibliotecas core do .NET).
+
+A Apache 2.0 implementa duas proteções fundamentais:
+
+* **Concessão Explícita de Patentes**: Cada colaborador de um projeto Apache 2.0 concede automaticamente aos usuários uma licença de patente mundial, livre de royalties, perpétua e irrevogável para utilizar suas contribuições.
+* **Cláusula de Retaliação de Patentes**: Se um usuário iniciar um litígio de patentes contra *qualquer* entidade alegando que o software sob Apache 2.0 viola suas patentes, **sua licença para o software será rescindida imediatamente**. Isso funciona como um tratado de paz de propriedade intelectual, prevenindo processos de patentes.
+
+---
+
+## 4. Proteção de Marca: Marcas Registradas (Trademarks)
+
+Para um framework como o Dext, construir um ecossistema de alta qualidade, estabilidade e confiança é primordial.
+* Sob a licença **MIT**, qualquer pessoa pode criar um fork do seu código, manter o seu nome, empacotá-lo com modificações instáveis ou de baixa qualidade e distribuí-lo, potencialmente prejudicando a reputação da marca do framework original.
+* **A Apache 2.0 exclui explicitamente direitos de marca registrada**. Ela estabelece que os usuários não podem usar os nomes comerciais, marcas registradas, marcas de serviço ou nomes de produtos do licenciador sem permissão expressa. Isso garante que o nome **Dext** permaneça sinônimo de software de nível profissional e alto desempenho, protegendo tanto o framework quanto as empresas que o adotam.
+
+---
+
+## 5. Comparação de Licenças para Conformidade Corporativa
+
+Abaixo está uma comparação direta das principais licenças que os departamentos jurídicos corporativos avaliam durante as auditorias de software:
+
+| Métrica Legal / Compliance | MIT | Apache 2.0 | LGPL | GPL / AGPL |
+|:---|:---:|:---:|:---:|:---:|
+| **Uso Comercial em Código Fechado** | ✅ Sim | ✅ Sim | 🟡 Condicional | ❌ **Estritamente Proibido** |
+| **Proteção contra Litígio de Patentes** | ❌ Não | ✅ **Sim (Escudo Legal)** | ❌ Não | ❌ Não |
+| **Proteção de Marca Registrada** | ❌ Não | ✅ **Sim** | ❌ Não | ❌ Não |
+| **Risco de Exposição de PI para o App Core** | 🟢 Nenhum | 🟢 Nenhum | 🟡 Médio (Risco de Link Estático) | 🔴 **Alto (Sistêmico)** |
+| **Complexidade de Conformidade / Auditorias** | 🟢 Extremamente Baixa | 🟢 Baixa | 🔴 Alta | 🔴 Crítica |
+
+---
+
+## 6. Por que o Dext é Pronto para Empresas desde o Primeiro Dia
+
+Ao disponibilizar o Dext Framework sob a **Licença Apache 2.0**, os criadores do Dext tomaram uma decisão arquitetônica estratégica e consciente para fornecer aos clientes corporativos segurança jurídica absoluta.
+
+1. **Conformidade Pronta para Produção**: O Dext passa facilmente por varreduras automatizadas de dependências (como Black Duck, Snyk, WhiteSource) usadas por equipes de compliance em grandes corporações globais.
+2. **Seguro contra Litígios de Patentes**: As empresas podem criar aplicações proprietárias de alta receita sobre o Dext ORM e o Web Server com a certeza absoluta de que estão protegidas por uma concessão irrevogável de licença de patente de todos os colaboradores.
+3. **Livre de Contaminação Viral**: O Dext é totalmente isento de dependências GPL/AGPL. Diferente de frameworks minimalistas que dependem de bibliotecas LGPL-3.0 (como o `Delphi-Cross-Socket` para manipulação de WebSockets), o Dext reforça uma separação estrita de conceitos, garantindo que o seu ERP comercial ou sistema fiscal permaneça 100% proprietário e de código fechado.
+4. **Integridade da Marca**: A cláusula de marca registrada da Apache 2.0 garante que sua escolha tecnológica seja respaldada por um nome de marca seguro, protegendo seu negócio contra projetos imitadores e forks não confiáveis.
+
+## Conclusão
+
+Métricas de desempenho, rastreamento de mudanças e eficiência de memória são vitais, mas **a conformidade legal é o portão final para a implantação corporativa**.
+
+A licença Apache 2.0 do Dext não é apenas um detalhe burocrático; é um **recurso de missão crítica** que permite a CTOs e Arquitetos proporem o Dext com total confiança como a base moderna, de alto desempenho e juridicamente segura para a próxima década de sistemas empresariais em Delphi.

--- a/Docs/Comparison/README.md
+++ b/Docs/Comparison/README.md
@@ -1,0 +1,90 @@
+# Dext Framework — Marketing Documentation
+
+This folder contains the strategic positioning and technical comparison documents for the Dext Framework.
+
+---
+
+## Document Map
+
+### 1. [`Dext_vs_DotNet_Narrative.md`](./Dext_vs_DotNet_Narrative.md) — *The Story*
+
+> **"Why Dext was built — and what it means for Delphi in 2026."**
+
+A human, narrative-first document. Ideal for blog posts, forum threads, community presentations, and anyone getting their first impression of Dext. It tells the *why* and the *so what*, not just the *what*.
+
+**Best for:**
+- Blog posts and community articles
+- Introduction threads on Delphi/programming forums
+- A quick read for CTOs and engineering managers
+- Developers from .NET or other ecosystems evaluating Dext for the first time
+
+---
+
+### 2. [`Feature_Comparison_Dext_vs_DotNet.md`](./Feature_Comparison_Dext_vs_DotNet.md) — *The Reference Table*
+
+> **"What Dext does — feature by feature, side by side with .NET."**
+
+A structured, objective reference document. Organized into four blocks:
+- **Block A**: 60+ features at full parity with ASP.NET Core + EF Core
+- **Block B**: 17 features exclusive to Dext (not available in .NET)
+- **Block C**: Honest gaps and roadmap items
+- **Block D**: Platform differences that don't apply to Delphi by design
+
+**Best for:**
+- Tech leads doing a formal technical evaluation
+- Developers wanting a precise feature lookup
+- PR or README links as a technical evidence page
+- Open-source contributors evaluating where to focus efforts
+
+---
+
+### 3. [`Dext_ORM_Capabilities.md`](./Dext_ORM_Capabilities.md) — *The ORM Deep-Dive*
+
+> **"How the Dext ORM works — architecture, code, and exclusive capabilities."**
+
+A technical deep-dive focused exclusively on the ORM and data access layer. Contains side-by-side code examples (Delphi vs C#) for all core patterns, including advanced sections on Multi-Mapping, Stored Procedures, Smart Properties, EntityDataSet, JSON Column queries, and high-performance engineering internals.
+
+**Best for:**
+- Delphi developers learning or adopting Dext.ORM
+- Technical writers documenting the ORM
+- Developers migrating from FireDAC + legacy components to Dext
+- Anyone evaluating the ORM's depth independently from the rest of the framework
+
+---
+
+### 4. [`Open_Source_Licensing_Enterprise.md`](./Open_Source_Licensing_Enterprise.md) — *The Enterprise Safety Guide*
+
+> **"Why Apache 2.0 matters — compliance, patent protection, and CI/CD pipeline clearance."**
+
+A whitepaper-style document for enterprise and legal evaluation. Covers the strategic importance of Apache 2.0 over GPL/MIT/LGPL, how Dext clears automated compliance tools (like Snyk), and what it means for commercial product development.
+
+**Best for:**
+- Enterprise procurement and legal teams
+- CTOs and architects evaluating open-source risk
+- Organizations with strict IP and patent compliance requirements
+- Teams running automated license-scanning in their CI/CD pipelines
+
+---
+
+## Suggested Reading Order by Audience
+
+| You are… | Start with | Then read |
+|:---|:---|:---|
+| **Dev from .NET / Java / Go** curious about Dext | Narrative | Feature_Comparison (Block B) |
+| **Tech lead** doing a formal evaluation | Feature_Comparison | ORM_Capabilities |
+| **Delphi dev** adopting the ORM | ORM_Capabilities | — |
+| **CTO / Manager** needing a business case | Narrative (skip to "The Numbers") | Licensing |
+| **Enterprise procurement / legal** | Licensing | — |
+| **Open-source contributor** | Feature_Comparison (Block C roadmap) | Ecosystem Overview |
+
+---
+
+## External References
+
+- 📘 [Dext Ecosystem Overview](https://github.com/cesarliws/dext/blob/main/Docs/Dext_Ecosystem_Overview.md) — Architecture deep-dive: zero-allocation pipeline, SIMD collections, Binary Code Folding
+- 📗 [Features Implemented Index](https://github.com/cesarliws/dext/blob/main/Docs/Features_Implemented_Index.md) — Complete feature implementation index with spec links
+- 🗺️ [Roadmap](https://github.com/cesarliws/dext/blob/main/Docs/ROADMAP.md) — Planned features and Wave delivery schedule
+
+---
+
+*Dext Framework | May 2026*

--- a/Docs/Comparison/README.pt-br.md
+++ b/Docs/Comparison/README.pt-br.md
@@ -1,0 +1,90 @@
+# Dext Framework — Documentação de Posicionamento e Marketing
+
+Esta pasta contém os documentos de posicionamento estratégico e comparações técnicas para o Dext Framework.
+
+---
+
+## Mapa de Documentos
+
+### 1. [`Dext_vs_DotNet_Narrative.pt-br.md`](./Dext_vs_DotNet_Narrative.pt-br.md) — *A História*
+
+> **"Por que o Dext foi construído — e o que ele representa para o Delphi em 2026."**
+
+Um documento narrativo, focado na leitura humana. Ideal para postagens em blogs, fóruns de tecnologia, apresentações para a comunidade ou para qualquer pessoa que queira ter uma primeira impressão geral do Dext. Explica o *porquê* e os impactos práticos, em vez de focar apenas em listagens de recursos.
+
+**Ideal para:**
+- Posts em blogs e artigos para a comunidade
+- Tópicos de introdução em fóruns de programação e comunidades Delphi
+- Leitura rápida para CTOs e gerentes de engenharia
+- Desenvolvedores vindos de outros ecossistemas (como .NET, Java ou Go) avaliando o Dext pela primeira vez
+
+---
+
+### 2. [`Feature_Comparison_Dext_vs_DotNet.pt-br.md`](./Feature_Comparison_Dext_vs_DotNet.pt-br.md) — *A Tabela de Referência*
+
+> **"O que o Dext faz — recurso por recurso, lado a lado com o .NET."**
+
+Um documento técnico, objetivo e altamente estruturado. Está organizado em quatro blocos distintos:
+- **Bloco A**: Mais de 60 recursos em paridade funcional total com o ASP.NET Core + EF Core
+- **Bloco B**: 17 recursos exclusivos do Dext (indisponíveis de forma nativa no ecossistema .NET)
+- **Bloco C**: Lacunas honestas e roadmap de desenvolvimento do framework
+- **Bloco D**: Diferenças de plataforma e contexto que não se aplicam ao Delphi por design
+
+**Ideal para:**
+- Líderes técnicos que precisam fazer uma avaliação formal de tecnologia
+- Desenvolvedores que buscam um dicionário preciso ou consulta rápida de recursos
+- Links em relações públicas ou no README do projeto como comprovação técnica de recursos
+- Contribuidores de código open-source analisando onde focar esforços
+
+---
+
+### 3. [`Dext_ORM_Capabilities.pt-br.md`](./Dext_ORM_Capabilities.pt-br.md) — *O Deep-Dive no ORM*
+
+> **"Como o Dext ORM funciona — arquitetura, código e capacidades exclusivas."**
+
+Um mergulho técnico focado exclusivamente no ORM e na camada de acesso a dados. Contém exemplos de código reais lado a lado (Delphi vs C#) para todos os padrões essenciais de persistência, incluindo seções detalhadas sobre Mapeamento Aninhado (Multi-Mapping), Stored Procedures declarativas, Smart Properties, EntityDataSet, Consultas em Colunas JSON e as otimizações de arquitetura de alto desempenho em tempo de compilação.
+
+**Ideal para:**
+- Desenvolvedores Delphi adotando ou aprendendo o Dext.ORM
+- Escritores técnicos documentando as capacidades do ORM
+- Equipes migrando de soluções legadas como FireDAC ou outros frameworks de mercado para o Dext
+- Engenheiros avaliando a profundidade do ORM de forma independente do restante do framework
+
+---
+
+### 4. [`Open_Source_Licensing_Enterprise.pt-br.md`](./Open_Source_Licensing_Enterprise.pt-br.md) — *O Guia de Segurança Corporativa*
+
+> **"Por que a Apache 2.0 importa — conformidade legal, proteção de patentes e validação automática no pipeline de CI/CD."**
+
+Um whitepaper focado na avaliação jurídica e de compliance corporativo. Cobre a importância estratégica da licença Apache 2.0 sobre outras opções (GPL, MIT, LGPL), como o Dext é validado por ferramentas automatizadas de análise de licenças (como o Snyk) e o que isso significa para o desenvolvimento de produtos comerciais proprietários.
+
+**Ideal para:**
+- Departamentos jurídicos e setores de compras de grandes empresas
+- CTOs e arquitetos de software avaliando riscos de licenciamento de terceiros
+- Organizações com diretrizes estritas de PI (Propriedade Intelectual) e patentes
+- Equipes que operam verificação automatizada de conformidade no pipeline de CI/CD
+
+---
+
+## Ordem de Leitura Recomendada por Perfil
+
+| Seu perfil... | Comece por | Em seguida, leia |
+|:---|:---|:---|
+| **Desenvolvedor .NET / Java / Go** curioso sobre Dext | A História (Narrative) | Tabela de Referência (Bloco B) |
+| **Líder Técnico / Arquiteto** avaliando a stack | Tabela de Referência | Mergulho no ORM (ORM Capabilities) |
+| **Desenvolvedor Delphi** adotando o framework | Mergulho no ORM (ORM Capabilities) | — |
+| **CTO / Gestor** precisando de uma visão executiva | A História (pule para "Os Números") | Guia de Segurança Corporativa (Licensing) |
+| **Jurídico / Compliance Corporativo** | Guia de Segurança Corporativa (Licensing) | — |
+| **Contribuidor do Projeto** | Tabela de Referência (Bloco C - Roadmap) | Visão Geral do Ecossistema |
+
+---
+
+## Referências Externas
+
+- 📘 [Visão Geral do Ecossistema Dext](https://github.com/cesarliws/dext/blob/main/Docs/Dext_Ecosystem_Overview.pt-br.md) — Deep-dive arquitetônico: pipelines de alocação zero, coleções SIMD e Binary Code Folding.
+- 📗 [Índice de Recursos Implementados](https://github.com/cesarliws/dext/blob/main/Docs/Features_Implemented_Index.pt-br.md) — Lista completa de funcionalidades implementadas e especificações técnicas de design.
+- 🗺️ [Roadmap](https://github.com/cesarliws/dext/blob/main/Docs/ROADMAP.md) — Cronograma de entrega planejado por ondas (Waves).
+
+---
+
+*Dext Framework | Maio de 2026*

--- a/Docs/Dext_Ecosystem_Overview.md
+++ b/Docs/Dext_Ecosystem_Overview.md
@@ -1,66 +1,434 @@
-# Dext Framework Ecosystem Overview
+# Dext Framework — Ecosystem Overview
 
-## 🛡️ The Vision: Industrial-Grade Engineering for Delphi
-Dext is not just another library; it is a **cohesive engineering ecosystem** designed to bring the architectural maturity and productivity of modern platforms (like .NET Core, Go, and Spring) to the Delphi world. 
+> *"Not a collection of libraries. A cohesive integrated platform."*
 
-The framework was built on a "Total Integration" philosophy, where the ORM, the Web Pipeline, Dependency Injection, and the Collection Library are not separate pieces glued together, but a single engine engineered for extreme performance and developer ergonomics.
+This document presents the **Dext Framework** as a unified ecosystem, highlighting how each subsystem interconnects to form a complete enterprise development platform — something that **did not exist in Delphi** until now.
 
----
-
-## 🚀 Key Engineering Breakthroughs
-
-### 1. Zero-Allocation Web Pipeline
-Unlike traditional frameworks that allocate strings and objects for every HTTP request, Dext's pipeline is built on **Zero-Allocation** principles.
-- **TSpan<T> & TVector<T>**: Uses stack-allocated structures for routing and middleware.
-- **Direct Memory Inject**: During JSON parsing, values are injected directly into field offsets (`PByte(Obj) + Offset`), bypassing the overhead of RTTI setters.
-- **Performance**: Capable of matching 10,000 routes in **47ms** with **ZERO** heap allocations.
-
-### 2. Binary Code Folding (The Generic Bloom Cure)
-To prevent the "Generic Bloom" (binary bloat) common in Delphi, Dext uses **Binary Code Folding**. Typed generic lists are thin wrappers over a raw memory management core (`TRawList`). 
-- **Result**: Up to **60% reduction in compile times** and a significantly smaller binary footprint.
-
-### 3. Implicit CQRS & Streaming
-The `DataApi` engine segregates responsibilities without boilerplate:
-- **Read Path**: High-speed **Direct-to-JSON Streaming** from `IDbReader` to the socket. Memory consumption remains O(1) regardless of the dataset size.
-- **Write Path**: Domain-safe hydration with full business rule validation and Dependency Injection support.
-
-### 4. Smart Properties & Type-Safe Expressions
-Dext eliminates "magic strings" in queries. Using operator overloading, `Prop<T>` fields generate a reusable **Abstract Syntax Tree (AST)** at compile-time.
-- Same engine for ORM queries (`Db.Users.Where(U.Age > 18)`) and Web filtering (`?age_gt=18`).
-
-### 5. Native .http Support & Dext Dashboard
-Bridge the gap between development and testing. Dext includes a native parser for the standard `.http` files used by VS Code and IntelliJ.
-- **Source of Truth**: The same file documents the API, is tested in the **Dext Dashboard**, and is executed by the **Dext.Net.RestClient** in production.
+There are excellent projects in the Delphi ecosystem that solve isolated problems (ORM, DI, testing, REST). Dext's core differentiator is that **every single piece was designed to work together**, from the HTTP request down to database persistence, passing through DI, logging, validation, serialization, and telemetry — all within a unified and cohesive pipeline.
 
 ---
 
-## 💎 Ecosystem Components
+## 🧬 The Philosophy: Simplicity Requires Sophisticated Engineering
 
-### 🏗️ Dext.Core (The Foundation)
-- **High-Performance DI**: A specialized Dependency Injection container with zero-allocation resolution for Scoped and Singleton services.
-- **Dext.Collections**: A high-performance collection library with SIMD-accelerated lookups (AVX2/SSE2) and lock-free channels.
-- **Observability**: Built-in telemetry via `TDiagnosticSource` for SQL and HTTP lifecycle tracking.
+> *"Simplicity is Complicated."* — Rob Pike
 
-### 📦 Dext.ORM (The Data Engine)
-- **DbContext Pattern**: Manage entity state and transactions with a modern, unit-of-work approach.
-- **Cross-Database Integrity**: Validated against SQL Server, PostgreSQL, MySQL, Firebird, and SQLite.
+The developer writes `App.MapGet('/users', ...)` and gains routing, model binding, JSON serialization, DI, logging, and error handling. But under the hood, the framework resolves:
 
-### 🌐 Dext.Web (The Communication Layer)
-- **Controller-Based Routing**: Clean, attribute-based routing inspired by modern web standards.
-- **Middleware Pipeline**: A composable, non-blocking pipeline for Auth, Logging, Compression, and Caching.
+1. The **Reflection Engine** discovers parameter types via thread-safe RTTI cache.
+2. The **Activator** resolves dependencies with **greedy constructor selection**.
+3. The **DI Container** injects services with hybrid lifecycles (ARC for interfaces, manual for classes).
+4. The **Model Binder** deserializes the JSON body using the high-performance driver (zero-allocation UTF-8).
+5. The **Validation Engine** applies validation attributes automatically.
+6. The handler executes the business logic.
+7. The result is serialized via `TUtf8JsonWriter` directly to the socket — **without intermediate string allocation**.
 
-### 🧪 Dext.Testing (The Quality Shield)
-- **TAutoMocker<T>**: Automatically resolve and mock dependencies for unit testing.
-- **Snapshot Testing**: Validate complex JSON outputs with single-line assertions.
+All of this happens invisibly to the developer. That is the promise.
+
+> *"Make what is right easy and what is wrong difficult."* — Steve "Ardalis" Smith
+
+---
+
+## 🌐 Web Server Agnostic: Hosting Flexibility
+
+The Dext Web Framework is completely isolated from the underlying HTTP server implementation. You write your application and routing logic once and choose how to serve the traffic depending on the environment and licensing, supporting:
+
+1. **Indy (Built-in)**: The default choice. It comes natively with Delphi, with zero external dependencies. Perfect for internal APIs, standalone microservices, testing, and rapid development.
+2. **WebBroker (Delphi Professional/Enterprise)**: The choice for legacy infrastructure or consolidated web servers. It allows running the same Dext application as an **Apache Module**, **ISAPI** (IIS), or **FastCGI** (to be served via NGINX).
+3. **Delphi Cross Sockets - DCS (High Performance)**: The choice for extreme scalability and Real-Time applications. It uses asynchronous operating system APIs (**IOCP** on Windows, **EPOLL** on Linux, and **KQUEUE** on macOS) and offers native support for **WebSockets** for bidirectional communications.
+   * *Licensing Note:* DCS is a third-party dependency licensed under **LGPL**. If you choose to use it in production, it is necessary to evaluate compatibility with the distribution terms of your commercial project.
+
+---
+
+## 🔥 Zero-Allocation Web Pipeline: The Performance Engine
+
+Dext's HTTP pipeline was refactored from the ground up to **eliminate heap allocations** in request-processing hot-paths. This is not a local optimization — it is an architectural philosophy that spans the entire stack:
+
+### From Request to Response — Without Allocating
+
+```
+[Socket] → TByteSpan (raw bytes, stack-allocated)
+         → TUtf8JsonReader (zero-copy parsing directly from the buffer)
+         → TUtf8JsonSerializer (record fields via PTypeInfo cache — no TValue boxing)
+         → Prop<T> / Smart Types (query mode or runtime mode, no intermediates)
+         → Handler executes logic
+         → TUtf8JsonWriter (direct streaming to the socket — no intermediate string)
+         → [Socket]
+```
+
+**Components involved in the zero-allocation pipeline:**
+
+| Layer | Component | Impact |
+|---|---|---|
+| **Input Parsing** | `TByteSpan` + `TUtf8JsonReader` | Avoids UTF-8 → UTF-16 → UTF-8 conversion |
+| **Deserialization** | `TUtf8JsonSerializer` | `TJsonRecordInfo` cache per `PTypeInfo` — eliminates repeated RTTI scans |
+| **RTTI / Reflection** | `TReflection` | Lock-free fast path with singleton metadata cache |
+| **Value Conversion** | `TValueConverterRegistry` | 3-level lookup without intermediate TValue allocation |
+| **Comparisons** | `TDextSimd.EqualsBytes` | AVX2 (32 bytes/cycle) or SSE2 (16 bytes/cycle) |
+| **Output Serialization** | `TUtf8JsonWriter` | Direct streaming to output buffer — zero temporary strings |
+| **View Engine** | Flyweight Iterators | O(1) memory in template loops |
+
+**The result**: Request processing time dropped **drastically** compared to traditional pipelines that convert strings multiple times. Each request touches the heap **as little as possible**.
+
+---
+
+## 🧠 Smart Types: The DSL That Shouldn't Exist in Delphi
+
+The `Prop<T>` system is Dext's most significant innovation — a **LINQ-like fluent DSL with strong typing** implemented entirely via **operator overloading** and **expression trees**. This did not exist in Delphi.
+
+### What the Developer Writes
+
+```pascal
+TUser = class
+  property Age: IntType ...;      // Alias for Prop<Integer>
+  property Name: StringType ...;  // Alias for Prop<string>
+end;
+
+var U := Prototype.Entity<TUser>;
+// Static compilation query with IntelliSense
+var Users := DbContext.Users
+  .Where((U.Age > 18) and (U.Name.StartsWith('Ce')))
+  .OrderBy(U.Age.Desc)
+  .Take(50)
+  .ToList;
+```
+
+### What Happens Under the Hood
+
+1. `TPrototype` creates a "phantom" instance of `TUser` with `IPropInfo` injected into each `Prop<T>`.
+2. When `U.Age > 18` executes, the `Prop<Integer>` is in **Query Mode** — instead of comparing values, it generates a `TBinaryExpression(TPropertyExpression('Age'), TLiteralExpression(18), boGreaterThan)` node.
+3. The `and` operator combines expressions into `TLogicalExpression(left, right, loAnd)`.
+4. The final `BooleanExpression` carries the entire AST.
+5. The **SQL Dialect Compiler** traverses the tree and generates: `WHERE "Age" > 18 AND "Name" LIKE 'Ce%'`.
+
+**The magic**: The same `Prop<T>` works in two modes. In query context, it generates SQL. In runtime context, it operates as a standard value type. The developer **never changes the API** — it is the same entity in both scenarios.
+
+### Type System Depth
+
+```
+Prop<T>  ───────────►  BooleanExpression  ────►  IExpression (AST)
+  │                           │                    │
+  ├─ Implicit(T)              └─ and/or/not        ├─ TPropertyExpression
+  ├─ Implicit(Nullable<T>)                         ├─ TBinaryExpression
+  ├─ Implicit(Variant)                             ├─ TLogicalExpression
+  ├─ Like/StartsWith/Contains                      ├─ TFunctionExpression
+  ├─ In/NotIn/Between/IsNull                       ├─ TLiteralExpression
+  ├─ Asc/Desc → IOrderBy                           └─ TConstantExpression
+  └─ Arithmetic: +, -, *, /
+```
+
+---
+
+## 📦 Dext.ORM Innovations: Multi-Mapping and Command Pattern
+
+Dext.ORM does not limit itself to emulating Entity Framework; it solves historical data access pain points with high-performance solutions inspired by micro-mappers (like Dapper) and advanced architectural patterns.
+
+### 1. Multi-Mapping Without Boilerplate (Split-free)
+Unlike Dapper (.NET), which requires declaring magic splitting strings (`splitOn: 'Id'`) to map flat join results to complex object graphs, Dext performs **convention-driven path routing**:
+* **Column Scanning**: When encountering columns with separators like `_` or `.` (e.g. `Product_Name` or `Product.Price`), the hydrator recognizes the nesting intent.
+* **Recursive Auto-Instantiation**: If the nested object (`Product: TProduct`) is marked with `[Nested]` and is currently `nil`, the framework dynamically allocates it on-the-fly via the optimized, thread-safe `TActivator` cache.
+* **Infinite Depth**: Dext's hydrator traverses column paths of any depth (e.g. `Order_Customer_Address_City`) recursively and automatically.
+* **O(1) Performance**: Hydration bypasses slow property setters and injects values directly into physical memory offsets of backing fields (`FFields`), eliminating intermediate heap allocations.
+
+### 2. Stored Procedures as Command/CQRS Pattern
+Executing stored procedures with multiple input/output parameters or multiple datasets in traditional ORMs is a constant source of connection leaks and low-level code. Dext transforms procedures into **strongly-typed Command classes**:
+* **Contract Class**: The developer declares a class representing the procedure (e.g. `TGetTopProducts`), annotating input and output parameters with `[DbParam]`.
+* **Auto-Hydration of Projections**: Returned datasets are automatically hydrated into collections (e.g. `Results: IList<TProduct>`) exposed on the class itself.
+* **Database Isolation**: All complexity regarding creating ADO.NET/FireDAC parameter objects, binding physical datatypes, and opening/closing cursors is abstracted by Dext. The developer simply instantiates the command, sets the input properties, and executes `Db.Execute(Command)`.
+
+---
+
+## 🖼️ TEntityDataSet: The Magic Bridge Between ORM and Design-Time UI
+
+> *"What if a company with a massive legacy ERP wants to adopt Dext? How would they handle hundreds of forms packed with DB-aware components (DBGrids, DevExpress cxGrid) and dozens of FastReport reports visually designed in the IDE?"*
+
+It was exactly this question that guided the creation of this feature. Building modern APIs with POCOs and Clean Architecture is excellent, but Delphi remains unmatched in rapid visual UI construction. `TEntityDataSet` was engineered to be the perfect bridge between the new domain architecture and the rich ecosystem of legacy visual components, **without compromising performance or developer experience (DX)**.
+
+1. **Absurd Performance via Zero-Allocation**: Unlike traditional dataset adapters that use RTTI scans on every read operation, `TEntityDataSet` connects natively to a `TList<T>` (or `TObjectList<T>`). It extracts memory *offsets* during initialization via `TEntityMap`. During data binding with the grid, reading a value is virtually accessing a memory pointer directly, with zero reflection overhead.
+2. **Automatic Setup (Entity Parsing)**: Forget manual column configurations. At design-time, Dext parses your units, locates entities marked with attributes, and **creates all `TFields` automatically** in the DataSet.
+3. **Real Design-Time Data Preview**: Designing reports (FastReport) "in the dark" is frustrating. Dext solves this brilliantly: if you provide a `TFDConnection` and a `DataProvider`, the framework **generates dynamic SQL at design-time** and populates `TEntityDataSet` with real database records. You see the actual data live inside the IDE!
+   * *Note:* At runtime, this design-time SQL is never executed. The component directly consumes your real in-memory object list, fully respecting your application logic.
+
+---
+
+## 🏎️ Collections & Concurrency: Performance Oasis
+
+Dext rebuilds Delphi's data foundations to solve the two biggest bottlenecks of modern backends: **Generic Code Bloat** (binary size inflation/slow build times) and **Thread Contention** (locks under multi-core load).
+
+### 1. Binary Code Folding: Curing Generic Bloat
+The Delphi compiler duplicates binary machine code for every specialization of a generic class. Dext implements the **Code Folding** pattern, where hundreds of typed `IList<T>` instances share a single core engine `TRawList` operating over raw memory.
+* **Real Impact**: Up to **60% reduction in compile times** in large projects (e.g., a 9-minute build reduced to 3.5 minutes).
+
+### 2. Sniper Architecture (Zero-Alloc & SIMD)
+* **Dictionaries with Open Addressing**: Unlike the standard RTL (which uses linked lists and causes cache misses), `TRawDictionary` uses *Linear Probing* in contiguous memory. **Result: 6.6x faster than RTL.**
+* **SIMD Acceleration**: Memory scans using hardware-level vector instructions (AVX2/SSE2) process up to 32 bytes per clock cycle. **Result: Sorts are 6.8x faster.**
+* **Vector + Span**: Manipulating massive buffers and files without intermediate memory allocations.
+
+### 3. Modern Concurrency (Inspired by Go and .NET 8)
+* **IChannel\<T\>**: Lock-Free transmission channels with native support for **Backpressure** (Bounded Channels) — essential to prevent fast producers from crashing the server.
+* **Frozen Collections**: Immutable collections ("Write once, freeze") allowing infinite simultaneous read operations without using any locks (`TCriticalSection`), eliminating scalability bottlenecks in multi-threaded backends.
+
+---
+
+## 🧪 The Complete Quality Lifecycle
+
+Dext doesn't just let you build applications — it guarantees they are **testable from end to end**:
+
+```
+[Code] → [Unit Tests + Mocking]
+       → [Auto-Mocking Container (TAutoMocker)]
+       → [Snapshot Testing (JSON baselines)]
+       → [Code Coverage (dext test --coverage)]
+       → [Quality Gates (CI/CD thresholds)]
+       → [Reports: JUnit XML, TRX, SonarQube, HTML]
+       → [Live Dashboard (dext ui)]
+```
+
+**Fully Integrated with DI**: `TTestServiceProvider` replaces production services with mocks without changing application code.
+
+### The Quality Arsenal
+
+1. **Auto-Mocking Container (`TAutoMocker`)**: No more instantiating dozens of mocks manually. `TAutoMocker` resolves the dependency graph and automatically injects mock objects into all interfaces required by the system under test.
+2. **Snapshot Testing (`MatchSnapshot`)**: For validating complex JSON payloads or massive DTO outputs. Dext serializes the result, compares it with an approved baseline snapshot, and reports any regression.
+3. **Integrated Code Coverage**: Run `dext test --coverage` via the CLI, and the framework uses its own instrumentation to generate detailed coverage reports (lines/branches) ready for SonarQube.
+4. **Native CI/CD Integration**: Out-of-the-box support for generating standard industry reports: JUnit XML, TRX (Azure DevOps), and HTML. Quality Gates fail the pipeline automatically if coverage falls below your thresholds.
+5. **Live Test Dashboard**: Execute `dext ui` and gain a local, modern dark-themed dashboard running in your browser to visualize the execution of your entire test suite in real-time.
+
+---
+
+## 🗄️ Database as API: One Line of Code, the Entire Ecosystem Working
+
+**Database as API** is the ultimate demonstration of how Dext's integrated ecosystem eliminates architectural friction. It is entirely possible to build similar APIs by stitching together isolated libraries, but the engineering cost is brutal: mountains of boilerplate code, performance bottlenecks, exhausting DTO mappings, excessive heap allocations, and a fragile, high-maintenance codebase. 
+
+Dext resolves this at the root: with **a single line of code**, the developer gains a complete REST API with security, filters, pagination, documentation, and telemetry — all operating in harmony over a zero-allocation pipeline with enterprise quality.
+
+### What the Developer Writes
+
+```pascal
+[Table, DataApi]  // ← This is all.
+TProduct = class
+  [PK, AutoInc] property Id: Integer;
+  property Name: string;
+  property Price: Double;
+end;
+
+// In startup:
+App.Builder.MapDataApis;  // Scans RTTI, registers all [DataApi] classes automatically
+```
+
+### What the Framework Delivers
+
+```
+One line → 5 REST endpoints (GET list, GET by id, POST, PUT, DELETE)
+          → 11 URL QueryString filter operators (_gt, _lt, _cont, _in, ...)
+          → Automatic pagination (_limit, _offset)
+          → Dynamic sorting (_orderby=price desc)
+          → Operation-level security (RequireAuth, RequireRole, ReadRole vs WriteRole)
+          → Automatic Swagger/OpenAPI documentation
+          → Telemetry (TDiagnosticSource)
+          → Structured Logging
+          → Multi-tenancy (RequireTenant)
+          → Full support for UUID, GUID, and Composite Keys
+```
+
+### How Many Subsystems Are Activated with One Line?
+
+| Subsystem | What It Does in DataApi |
+|---|---|
+| **RTTI / Reflection** | `TDataApi.MapAll` scans `[DataApi]` attributes via `TReflection`. `ResolvePropertyName` converts snake_case→PascalCase via `GetHandlerBySnakeCase` |
+| **DI Container** | `GetDbContext` resolves the scoped `TDbContext` instance for the current HTTP request |
+| **ORM (TDbContext)** | `DataSet(ClassInfo)` returns dynamic `IDbSet`. Handles `Add`, `Update`, `Remove`, `FindObject`, `ListObjects` |
+| **Specifications (AST)** | QueryString filters generate `IExpression` via `TStringExpressionParser.Parse` — the **same AST** used by `Prop<T>` |
+| **JSON Engine** | `TDextJson.Deserialize` (input) + `TDextSerializer` (output) with configurable `NamingStrategy` and `EnumStyle` |
+| **Model Binding** | `TEntityIdResolver` delegates to `IModelBinder` to convert `{id}` from the URL to Integer/TUUID/TGUID automatically |
+| **Security** | `CheckAuthorization` validates JWT token via `IClaimsPrincipal` with clean read/write role separation |
+| **Swagger / OpenAPI** | Endpoints are automatically exposed in the OpenAPI spec with proper tags and descriptions |
+| **Telemetry** | `TDiagnosticSource.Write` publishes tracing events at start/complete phases of model binding and execution |
+| **Naming Conventions** | `TDataApiNaming` removes `T` prefix, pluralizes path names, and generates `/api/products` |
+
+This is what integration means: None of these subsystems were built *exclusively* for the DataApi. Each was built as an independent, decoupled piece of the ecosystem. The DataApi simply **orchestrates** them — resulting in a single line of code activating 10 subsystems working in perfect harmony.
+
+---
+
+## 🏗️ The Integrated Ecosystem: How Everything Connects
+
+What separates Dext from isolated third-party libraries is **end-to-end integration**. Every subsystem was engineered with deep awareness of the others:
+
+### The Integration Graph
+
+```
+                        ┌──────────────────┐
+                        │     Dext CLI     │
+                        │  (dext new/add)  │
+                        └────────┬─────────┘
+                                 │ generates projects using
+                                 ▼
+┌────────────────┐      ┌──────────────────┐      ┌────────────────┐
+│ Template Engine│◄─────│   Web Pipeline   │─────►│  View Engine   │
+│ (AST-based)    │      │  (Zero-Alloc)    │      │ (SSR/Stencils) │
+└────────────────┘      └────────┬─────────┘      └────────────────┘
+                                 │
+                    ┌────────────┼──────────────┐
+                    ▼            ▼              ▼
+        ┌──────────────┐  ┌────────────────┐  ┌──────────────┐
+        │ DI Container │  │  JSON Engine   │  │  Validation  │
+        │ (Hybrid ARC) │  │ (UTF-8 0-alloc)│  │ (Attribute)  │
+        └──────┬───────┘  └──────┬─────────┘  └──────────────┘
+               │                 │
+               ▼                 ▼
+        ┌──────────────┐ ┌────────────┐  ┌──────────────────┐
+        │  Reflection  │ │Smart Types │  │   Collections    │
+        │  (Cache)     │ │ (Prop<T>)  │  │ (SIMD/Channels)  │
+        └──────┬───────┘ └──────┬─────┘  └────────┬─────────┘
+               │                │                 │
+               ▼                ▼                 ▼
+        ┌──────────────────────────────────────────────────┐
+        │        Memory & Performance Foundation           │
+        │   (TSpan<T>, TByteSpan, SIMD, Code Folding)      │
+        └───────────────┬────────────────┬─────────────────┘
+                        │                │
+                        ▼                ▼
+                ┌──────────────┐   ┌──────────────┐
+                │     ORM      │◄──│Specifications│
+                │  (Multi-DB)  │   │ (IExpression)│
+                └──────┬───────┘   └──────────────┘
+                       │
+              ┌────────┼──────────┐
+              ▼        ▼          ▼
+          ┌────────┐  ┌────────┐  ┌────────┐
+          │ PgSQL  │  │ MSSQL  │  │ MySQL  │ ... + Firebird, SQLite, Oracle
+          └────────┘  └────────┘  └────────┘
+```
+
+---
+
+## 📊 What Dext Brought to Delphi
+
+| Capability | How Dext Resolves It |
+|---|---|
+| **Type-safe LINQ-like DSL** | `Prop<T>` + Expression Trees + operator overloading |
+| **Separated Companion Metadata** | `TEntityType<T>` separates domain data (POCO) from query metadata |
+| **Zero-allocation HTTP pipeline** | `TByteSpan` → `TUtf8JsonReader` → handler → `TUtf8JsonWriter` → socket |
+| **Generic Code Folding** | `TRawList` shares binary core — **up to 60% faster compilation** |
+| **Frozen Collections** | `TFrozenDictionary<K,V>`, `TFrozenSet<T>` — lock-free concurrent reads |
+| **Go-style Channels** | `IChannel<T>` with bounded/unbounded options and native back-pressure |
+| **SIMD-accelerated collections** | kontiguous memory + AVX2/SSE2 — **6.6x faster lookups, 6.8x faster sorts** |
+| **Lock Striping** | `TConcurrentDictionary<K,V>` with a striped array of `TSpinLock` |
+| **Minimal API routing** | `App.MapGet`, `App.MapPost` with fast, zero-allocation model binding |
+| **Auto-Mocking Container** | `TAutoMocker` automatically resolves and injects mock interfaces |
+| **Snapshot Testing** | `MatchSnapshot` against JSON baseline files |
+| **Database as API (1 line)** | `[DataApi]` maps complete CRUD REST routes, activating 10 subsystems in 1 line |
+| **Dual-mode Expression Evaluator** | Same `IExpression` AST generates SQL in the DB and filters lists in-memory |
+| **Declarative Soft Delete** | `[SoftDelete]` turns DELETE to UPDATE, with `Restore` and `OnlyDeleted` features |
+| **JSON/JSONB Queries** | `.Json('path')` translates to PG `#>>`, MySQL `JSON_EXTRACT`, etc. |
+| **Flutter-style Desktop Navigator** | Push/Pop/PopUntil + 3 UI Adapters + Middleware Pipeline + Auth Guards |
+| **Magic Binding (Desktop MVVM)** | Two-way attribute binding: `[BindEdit]`, `[BindText]`, `[OnClickMsg]` |
+| **Zero-alloc EntityDataSet** | Direct binding to `TList<T>` via memory offsets, plus design-time data sync |
+| **Flyweight SSR Iterators** | Streams queries directly to templates with O(1) memory — no `ToList` |
+| **HTMX Auto-Detection** | Automatically suppresses layout wrappers for `HX-Request` headers |
+| **REST Client with Connection Pool** | Lightweight record facade with async chaining, custom auth, and cancellation |
+| **Fluent TAsyncTask** | Chained async operations: `Run<T>.ThenBy<U>.OnComplete.OnException.Start` |
+| **Typed IOptions<T>** | Binds JSON/YAML/ENV sections directly to typed configuration classes |
+| **Native AI Skills** | Integrated Claude/Antigravity skills for direct generation of Dext-idiomatic code |
+| **Multi-Tenancy (3 Strategies)** | Column, Schema, and Database isolation fully integrated in the ORM |
+| **SignalR-compatible Hubs** | Real-time bi-directional messaging with groups and broadcasting |
+| **AST Template Engine** | Tokenizer → AST → execution pipeline with WebStencils integration (Delphi 12.2+) |
+| **Hybrid DI Lifecycle** | Automatic ARC for interfaces, manual lifecycle management for concrete classes |
+| **precise Stack Trace Extraction** | Detailed stack frame extraction in `Dext.Core.Debug` to locate exact errors |
+
+---
+
+## 📐 Engineering Decisions: Why It Works
+
+### 1. Record Types as Foundation
+Modern Delphi (10.3+) supports **operator overloading in records**, **implicit/explicit operators**, and **class operators**. Dext exploits this to the limit: `Prop<T>`, `Nullable<T>`, `TUUID`, `TByteSpan`, `TSpan<T>`, `BooleanExpression` are all records with value semantics, completely eliminating heap allocation overhead.
+
+### 2. Hybrid Memory Model
+Instead of forcing a single strategy (ARC or manual), the DI Container automatically adapts: interfaces use native Delphi ARC (reference counting), while classes use framework-managed lifecycles (Singleton is destroyed at host shutdown, Scoped at request completion, and Transient is managed by the caller).
+
+### 3. Driver Pattern for Extensibility
+JSON serialization, the HTTP Server, and Database connections share the same decoupled driver design. You can swap `JsonDataObjects` for `System.JSON`, or `Indy` for `DCS`/`WebBroker`, without touching a single line of application code.
+
+### 4. Reflection Cache as Backbone
+The thread-safe RTTI cache with lock-free fast paths is the backbone of the entire framework. JSON, ORM, Validation, Model Binding, and Smart Types all query the same singleton metadata cache. A single RTTI scan at startup serves the entire process lifecycle.
+
+### 5. Binary Code Folding
+To prevent Delphi's classic generic binary bloat, Dext's typed generic lists are thin, compiler-friendly wrappers over core `TRaw` implementations managing raw memory block structures. This preserves absolute type safety for the developer while saving megabytes in the final executable and minutes in build time.
+
+### 6. Direct Memory Inject (JSON Parsing)
+Instead of invoking slow property setters and heavy reflection during JSON deserialization, Dext maps physical field offsets in memory beforehand (`PByte(Obj) + Offset`). During parsing, values are injected directly into their physical memory addresses, achieving speeds close to C++ struct parsing.
+
+### 7. Implicit CQRS (Read vs. Write Pipeline)
+The Dext DataApi enforces an implicit read/write segregation strategy:
+* **Read (GET)**: An ultra-fast *Direct-to-JSON Streaming* pipeline that sends records from the database driver straight to the network socket, keeping memory consumption at O(1).
+* **Write (POST/PUT)**: A domain-centric pipeline focusing on data integrity, hydrating the full entity, and executing all validations and business rules before saving.
+
+### 8. Apache 2.0 Licensing (Enterprise Compliance & Snyk-Approved)
+Legal security and governance are absolute prerequisites for corporate adoption. Dext's licensing model is a core pillar of its enterprise compliance:
+* **CI/CD Pipeline Compliant**: Dext is completely free of copyleft (GPL/AGPL) dependencies. It effortlessly passes automated license scanners (like **Snyk** or **Black Duck**) integrated into post-commit pipelines.
+* **Irrevocable Patent Grant (Patent Peace)**: The Apache 2.0 license guarantees that every contributor explicitly grants users a worldwide, perpetual, royalty-free patent license, shielding your proprietary apps from patent claims.
+* **Patent Litigation Retaliation**: A legal shield. If a user sues anyone over patent infringement regarding Dext, their license is terminated immediately, preventing patent trolling.
+* **LGPL Isolation**: The *Delphi Cross Sockets (DCS)* dependency — which uses **LGPL** — is completely optional and isolated. Dext runs natively over Indy or WebBroker, ensuring your commercial executables remain strictly proprietary and immune to licensing contamination.
+
+---
+
+## 5. Infrastructure Flywheel — Exponential Feature Composition
+
+The maturity of the core infrastructure creates a **flywheel effect**: every new feature composes existing engines, drastically accelerating framework evolution.
+
+**A Case Study — The Specification Pattern (inspired by Steve "Ardalis" Smith)**:
+The Specification engine was originally designed for type-safe ORM queries (`Prop<T>` → `IExpression` → SQL). When the need for dynamic URL filtering arose in the DataApi, the Specification engine **already knew how to resolve it** — `TStringExpressionParser` translates URL filters to the exact same `IExpression` nodes. The complex filtering feature was practically "free."
+
+```
+Original Core Engine             →  Emergent Composition
+─────────────────────────────────────────────────────────────────────────────
+Specification (ORM queries)      →  DataApi (URL filtering — free)
+                                 →  In-Memory Evaluator (zero extra code)
+Reflection Cache (JSON)          →  ORM + Validation + Model Binding + EntityDataSet
+TByteSpan (zero-allocation)      →  JSON Reader + EntityDataSet + [Roadmap] Redis RESP3
+TConnectionPool (REST Client)    →  [Roadmap] Redis Client (same pattern)
+TAsyncTask (async/await)         →  REST Client + [Roadmap] Redis + Background Services
+```
+
+**Practical Result**: During the feasibility study of the high-performance Redis Client, ~80% of the required infrastructure was already fully implemented: `TByteSpan`, `TAsyncTask`, `TConnectionPool`, and `ICancellationToken`. The only new code required was the raw RESP3 protocol driver itself.
+
+### 6. The Integration Trade-off
+Decoupled integration brings a **multiplication of responsibility**: a change in `IExpression` must be validated against **every consumer**. This makes automated testing not a luxury, but a necessity for existence. 
+
+The ecosystem is sustained by hundreds of test suites and thousands of assertions, ranging from atomic unit tests to integration tests verified across a 5-database CI matrix. The framework's architectural maturity is proven by real-world deployments in **AWS and Azure** and mission-critical production pilots handling **over 800,000 requests per day**. In total, the framework and its tests encompass **over 200,000 lines of pure Pascal code**, proving its industrial-grade rigor.
+
+---
+
+## 🛤️ Roadmap: Where the Ecosystem Is Going
+
+### Current Wave (In Progress)
+* **S14 — SOA via Interfaces**: Transparent Code-First RPC/gRPC — define standard Delphi interfaces and the framework generates all network transport layers automatically.
+* **S02 — gRPC & Protobuf**: High-performance, native IOCP/EPOLL engine for binary communication.
+* **S06 — OAuth2 & OIDC**: Native OAuth2 login with Google, Microsoft, and custom JWT providers.
+* **S13 — Redis Client**: High-performance asynchronous client supporting RESP3 and RedisJSON.
+
+### Future
+* Native HTTP Server (pure IOCP/EPOLL/Kqueue — removing DCS dependency).
+* OData and GraphQL native support.
+* Microservices Service Mesh (Service discovery, load balancing, health checking).
+* Native UI rendering using Skia.
 
 ---
 
 ## 📊 Industrial Authority
-- **Codebase**: 200,000+ lines of pure, high-performance Pascal code.
-- **Field Tested**: Powering systems in AWS/Azure processing **800,000 requests per day**.
-- **Compatibility**: Engineered for Delphi 10.3 (Rio) through 12.x (Athens).
+* **Codebase**: 200,000+ lines of pure, high-performance Pascal code.
+* **Field Tested**: Powering production systems in AWS/Azure processing **~800,000 requests per day** in fiscal management.
+* **Test Coverage**: Hundreds of test suites across a 5-database CI matrix (PostgreSQL, SQL Server, MySQL, SQLite, Firebird).
+* **Stress Tested**: High concurrency, race conditions, and memory leak scenarios fully validated under heavy load.
+* **Compatibility**: Engineered for Delphi 10.3 (Rio) through 12.x (Athens). Limited support for 10.1–10.2 via inline variable refactoring. Web Stencils requires 12.2+.
 
 ---
 
 ## 🎯 Conclusion
-Dext is the answer to the fragmentation of the Delphi ecosystem. It provides the **Industrial Foundation** required to build mission-critical, high-scale applications with the productivity of 2026.
+
+Dext is the definitive answer to the fragmentation of the Delphi ecosystem. It provides the **Industrial Foundation** required to build mission-critical, high-scale applications with the rapid productivity of 2026.
+
+For a detailed feature comparison with .NET/EF Core, see: [`Docs/Marketing/Feature_Comparison_Dext_vs_DotNet.md`](https://github.com/cesarliws/dext/blob/main/Docs/Marketing/Feature_Comparison_Dext_vs_DotNet.md)
+
+---
+
+*Dext Framework — Native performance, modern productivity, complete ecosystem.*

--- a/Docs/Dext_Ecosystem_Overview.pt-br.md
+++ b/Docs/Dext_Ecosystem_Overview.pt-br.md
@@ -79,10 +79,11 @@ O sistema `Prop<T>` é a inovação mais significativa do Dext — uma **DSL flu
 
 ```pascal
 TUser = class
-  FAge: IntType;      // Alias para Prop<Integer>
-  FName: StringType;  // Alias para Prop<string>
+  property Age: IntType ...;      // Alias para Prop<Integer>
+  property Name: StringType ...;  // Alias para Prop<string>
 end;
 
+var U := Prototype.Entity<TUser>;
 // Query com compilação estática e IntelliSense
 var Users := DbContext.Users
   .Where((U.Age > 18) and (U.Name.StartsWith('Ce')))
@@ -202,6 +203,24 @@ O que diferencia o Dext de soluções isoladas é a **integração de ponta a po
 | **HTMX → View Engine → ORM** | Flyweight Iterators streamam queries do ORM direto para templates; HTMX auto-detection suprime layouts | Full-stack SSR com O(1) memória e zero JavaScript |
 
 ---
+## 📦 Inovações no Dext.ORM: Multi-Mapping e Command Pattern
+
+O Dext.ORM não se limita a emular o Entity Framework; ele resolve dores históricas de acesso a dados com soluções de alta performance inspiradas em micro-mappers (como o Dapper) e padrões arquiteturais avançados.
+
+### 1. Multi-Mapping Sem Boilerplate (Split-free)
+Diferente do Dapper (.NET), que exige a declaração de strings mágicas de divisão (`splitOn: 'Id'`) para mapear joins planos para grafos de objetos, o Dext realiza **roteamento de caminhos baseado em convenção**:
+* **Varredura de Colunas**: Ao encontrar colunas com separadores `_` ou `.` (ex: `Product_Name` ou `Product.Price`), o hidratador reconhece a intenção de aninhamento.
+* **Auto-Instanciação Recursiva**: Se o objeto aninhado (`Product: TProduct`) estiver marcado com `[Nested]` e for `nil`, o framework o aloca dinamicamente em tempo de execução via `TActivator` de forma preguiçosa.
+* **Profundidade Infinita**: O hidratador do Dext percorre caminhos de qualquer profundidade (ex: `Order_Customer_Address_City`) de forma recursiva automática.
+* **Performance O(1)**: O mapeamento ignora *setters* lentos e injeta os valores diretamente nos offsets de memória física dos campos de suporte (`FFields`), eliminando alocações de heap intermediárias.
+
+### 2. Stored Procedures como Command/CQRS Pattern
+Executar stored procedures com múltiplos parâmetros de entrada/saída ou múltiplos datasets em ORMs tradicionais é uma fonte constante de vazamentos de conexão e código de baixo nível. O Dext transforma procedures em classes de **Command fortemente tipadas**:
+* **Classe de Contrato**: O desenvolvedor declara uma classe representando a procedure (ex: `TGetTopProducts`), anotando parâmetros de entrada e saída com `[DbParam]`.
+* **Auto-Hidratação de Projeções**: Conjuntos de dados retornados são hidratados automaticamente em coleções (ex: `Results: IList<TProduct>`) expostas na própria classe.
+* **Isolamento de Banco**: Toda a complexidade de criar objetos de parâmetros do ADO.NET/FireDAC, associar tipos de dados físicos e abrir/fechar cursores é abstraída pelo Dext. O desenvolvedor apenas instancia o comando, define as propriedades de entrada e executa `Db.Execute(Command)`.
+
+---
 
 ## 🖼️ TEntityDataSet: A Ponte Mágica entre ORM e Design-Time UI
 
@@ -249,8 +268,7 @@ O **Database as API** é a demonstração definitiva de como o ecossistema integ
 ### O Que o Desenvolvedor Escreve
 
 ```pascal
-[DataApi]  // ← Isso é tudo.
-[Table]
+[Table, DataApi]  // ← Isso é tudo.
 TProduct = class
   [PK, AutoInc] property Id: Integer;
   property Name: string;
@@ -280,7 +298,7 @@ Uma linha → 5 endpoints REST (GET list, GET by id, POST, PUT, DELETE)
 
 | Subsistema | O Que Faz no DataApi |
 |---|---|
-| **RTTI / Reflection ** | `TDataApi.MapAll` escaneia atributos `[DataApi]` via `TReflection.Context.GetTypes`. `ResolvePropertyName` converte snake_case→PascalCase via `GetHandlerBySnakeCase` |
+| **RTTI / Reflection** | `TDataApi.MapAll` escaneia atributos `[DataApi]` via `TReflection.Context.GetTypes`. `ResolvePropertyName` converte snake_case→PascalCase via `GetHandlerBySnakeCase` |
 | **DI Container** | `GetDbContext` resolve `TDbContext` do scope da request — cada request HTTP tem sua própria instância |
 | **ORM (TDbContext)** | `DataSet(ClassInfo)` retorna `IDbSet` dinâmico. `Add`, `Update`, `Remove`, `FindObject`, `ListObjects` |
 | **Specifications (AST)** | Filtros da QueryString geram `IExpression` via `TStringExpressionParser.Parse` — a **mesma AST** usada por `Prop<T>` |
@@ -397,6 +415,13 @@ O Dext DataApi adota uma estratégia de segregação de responsabilidade implíc
 - **Read (GET)**: Pipeline ultra-rápido de *Direct-to-JSON Streaming*, enviando dados do `IDbReader` direto para o socket com consumo de memória O(1).
 - **Write (POST/PUT)**: Pipeline focado em segurança de domínio, com hidratação completa da entidade, rodando regras de negócio e validações antes da persistência.
 
+### 8. Licenciamento Apache 2.0 (Segurança e Conformidade Snyk)
+A governabilidade e segurança jurídica são requisitos fundamentais em projetos de nível corporativo. A escolha de licença do Dext é um elemento central de sua arquitetura de conformidade:
+* **Conformidade em Pipelines CI/CD**: O Dext é 100% livre de dependências virais GPL ou AGPL. Ele passa sem restrições em ferramentas de auditoria e segurança como o **Snyk** ou **Black Duck** integradas em pipelines pós-commit.
+* **Garantia de Patentes (Patent Peace)**: A licença Apache 2.0 concede explicitamente aos usuários direitos mundiais e irrevogáveis sobre qualquer patente detida pelos colaboradores que possa cobrir o código do Dext.
+* **Retaliação de Patentes**: Blindagem jurídica contra trolls de patentes. Caso qualquer usuário processe judicialmente outro alegando violação de patente sobre o Dext, a sua licença de uso do framework é terminada imediatamente.
+* **Isolamento de Outras Licenças**: A dependência do *Delphi Cross Sockets (DCS)* — que possui licença **LGPL** — é opcional e totalmente isolada do core. O Dext roda de forma 100% permissiva sobre o Indy ou WebBroker nativos, garantindo que o seu executável comercial permaneça estritamente proprietário e imune a contaminações de licenças Share-Alike.
+
 ### 5. Infrastructure Flywheel — Velocidade Exponencial de Features
 A maturidade da infraestrutura cria um **efeito flywheel**: cada nova feature compõe de engines existentes, acelerando dramaticamente o desenvolvimento.
 
@@ -409,9 +434,9 @@ Engine Original                  →  Reuso Emergente
 Specification (ORM queries)      →  DataApi (URL filtering — grátis)
                                  →  In-Memory Evaluator (zero código extra)
 Reflection Cache (JSON)          →  ORM + Validation + Model Binding + EntityDataSet
-TByteSpan (zero-allocation)      →  JSON Reader + EntityDataSet + Redis RESP3 (~80% pronto)
-TConnectionPool (REST Client)    →  Redis Client (mesmo padrão)
-TAsyncTask (async/await)         →  REST Client + Redis + Background Services
+TByteSpan (zero-allocation)      →  JSON Reader + EntityDataSet + [Roadmap] Redis RESP3
+TConnectionPool (REST Client)    →  [Roadmap] Redis Client (mesmo padrão)
+TAsyncTask (async/await)         →  REST Client + [Roadmap] Redis + Background Services
 ```
 
 **Resultado prático**: Na análise de viabilidade do Redis Client, ~80% da infraestrutura já existia — `TByteSpan`, `TAsyncTask`, `TConnectionPool`, `ICancellationToken`. O único código genuinamente novo é o protocolo RESP3.

--- a/Docs/Features_Implemented_Index.md
+++ b/Docs/Features_Implemented_Index.md
@@ -218,8 +218,8 @@ Dext was designed to leverage modern Object Pascal features while maintaining a 
 
 ### 3.7 Real-time & Caching
 - **SSE (Server-Sent Events)** — Unidirectional event streaming.
-- **Hubs (SignalR-compatible)** — Groups, user targeting, and JSON-based broadcast.
-- **Caching** — In-Memory and Redis. Detailed **Health Checks**.
+- **SSE-based Messaging (SignalR roadmap)** — Basic SSE event broadcast. High-performance SignalR-equivalent bi-directional WebSockets/Hubs are planned.
+- **Caching** — In-Memory. (A full high-performance native Redis client is planned and under active development, currently ~80% complete). Detailed **Health Checks** (expandable roadmap under development).
 
 ### 3.8 API Documentation & Scaffolding
 - **OpenAPI / Swagger** — Automatic specification generation.
@@ -310,7 +310,7 @@ One of Dext's most powerful features: **automatic generation of full REST APIs f
 - Automated Code-First evolution with chronological database model snapshots.
 
 ### 4.6 Dialect Support (Polyglot)
-- PostgreSQL, SQL Server, MySQL, SQLite, Oracle, Firebird.
+- PostgreSQL, SQL Server, MySQL, SQLite, Oracle, Firebird, InterBase.
 - **Legacy Paging** — Automatic wrapping for `ROWNUM` in older Oracle/SQL Server versions.
 
 ### 4.7 Soft Delete (`[SoftDelete]`)
@@ -347,6 +347,7 @@ One of Dext's most powerful features: **automatic generation of full REST APIs f
 - Automatic converters for GUID, Enums, JSONB, and UUID v7.
 - **Stored Procedures** — Declarative execution via `[StoredProcedure]` and `[DbParam]`.
 - **Multi-Tenancy** — Shared Database (TenantId), Schema Isolation (`search_path`), Tenant per Database.
+- **Bulk / Batch Operations** — High-performance batch APIs: `AddRange`, `UpdateRange`, and `RemoveRange` supporting raw generic collections (`TArray<T>`, `IEnumerable<T>`) for bulk database operations in a single context transaction.
 
 ---
 

--- a/Docs/Features_Implemented_Index.pt-br.md
+++ b/Docs/Features_Implemented_Index.pt-br.md
@@ -218,8 +218,8 @@ O Dext foi desenhado para alavancar recursos modernos da linguagem Object Pascal
 
 ### 3.7 Real-time & Caching
 - **SSE (Server-Sent Events)** — Streaming unidirecional de eventos.
-- **Hubs (SignalR-compatible)** — Grupos, targeting por usuário, broadcast via JSON.
-- **Caching** — In-Memory e Redis. **Health Checks** detalhados.
+- **SSE-based Messaging (SignalR roadmap)** — Broadcast básico de eventos via SSE. Suporte bidirecional robusto equivalente a SignalR (WebSockets/Hubs) planejado.
+- **Caching** — In-Memory. (Cliente Redis nativo de alta performance planejado e em desenvolvimento ativo, atualmente ~80% completo). **Health Checks** detalhados (com plano de expansão no roadmap).
 
 ### 3.8 API Documentation & Scaffolding
 - **OpenAPI / Swagger** — Geração automática de especificação.
@@ -310,7 +310,7 @@ Uma das features mais poderosas do Dext: **geração automática de APIs REST co
 - Evolução Code-First automatizada com snapshots cronológicos do modelo de dados.
 
 ### 4.6 Dialect Support (Poliglota)
-- PostgreSQL, SQL Server, MySQL, SQLite, Oracle, Firebird.
+- PostgreSQL, SQL Server, MySQL, SQLite, Oracle, Firebird, InterBase.
 - **Legacy Paging** — Envelopamento automático para `ROWNUM` em Oracle/SQL Server antigos.
 
 ### 4.7 Soft Delete (`[SoftDelete]`)
@@ -347,6 +347,7 @@ Uma das features mais poderosas do Dext: **geração automática de APIs REST co
 - Conversores automáticos para GUID, Enums, JSONB e UUID v7.
 - **Stored Procedures** — Execução declarativa via `[StoredProcedure]` e `[DbParam]`.
 - **Multi-Tenancy** — Banco Compartilhado (TenantId), Isolamento por Schema (`search_path`), Tenant per Database.
+- **Operações em Lote / Bulk** — APIs em lote de alta performance: `AddRange`, `UpdateRange`, e `RemoveRange` com suporte a coleções genéricas brutas (`TArray<T>`, `IEnumerable<T>`) para persistência em massa em uma única transação de contexto.
 
 ---
 

--- a/Docs/ROADMAP.md
+++ b/Docs/ROADMAP.md
@@ -45,6 +45,7 @@ Status | Task | Spec | Description
 - [ ] **OData Support**: Full OData query support.
 - [ ] **GraphQL**: Native layer for data graphs.
 - [ ] **Microservices Mesh**: Service discovery and native Load Balancing.
+- [ ] **DbContext Auto-Hydration**: [S30](Specs/S30-DbContext-AutoHydration.md) RTTI automatic repository hydration and fluent DbOptions builder records.
 
 ---
 
@@ -86,6 +87,7 @@ Status | Tarefa | Spec | Descrição
 - [ ] **Suporte a OData**: Suporte completo a queries OData.
 - [ ] **GraphQL**: Camada nativa para exposição de grafos de dados.
 - [ ] **Microservices Mesh**: Service discovery e Load Balancing nativo.
+- [ ] **Auto-Hidratação de DbContext**: [S30](Specs/S30-DbContext-AutoHydration.md) Hidratação RTTI automática de repositórios e records fluent builders de DbOptions.
 
 - HTTP Server nativo IOCP, EPOLL, Kqueue
 - UI Nativo com Skia

--- a/Docs/Specs/S28-Conditional-Query-Parameters.md
+++ b/Docs/Specs/S28-Conditional-Query-Parameters.md
@@ -129,7 +129,7 @@ Should(FullUrl).Contain('sort=name');
 This guarantees absolute stability for automated CI/CD runners.
 
 ### 5.2. Test Coverage
-A comprehensive unit test was added in `TWebFeaturesTests.TestConditionalQueryParams` inside [Dext.Web.Features.Tests.pas](file:///C:/dev/Dext/DextRepository/Tests/Web/Dext.Web.Features.Tests.pas), covering all edge cases:
+A comprehensive unit test was added in `TWebFeaturesTests.TestConditionalQueryParams` inside [Dext.Web.Features.Tests.pas](../../Tests/Web/Dext.Web.Features.Tests.pas), covering all edge cases:
 - Spaces/Blank characters (`'   '`) skipped.
 - Empty strings (`''`) skipped.
 - Default fallbacks selected correctly.

--- a/Docs/Specs/S30-DbContext-AutoHydration.md
+++ b/Docs/Specs/S30-DbContext-AutoHydration.md
@@ -1,0 +1,164 @@
+# S30 — Automatic DbContext Hydration & TDbOptions Builder Evolution
+
+This architectural specification details the design for introducing **Automatic DbContext Hydration** (Wave 2/3 productivity) to eliminate boilerplate code inside custom `TDbContext` classes, and defines the builder record syntax evolution for fluent configuration initialization.
+
+---
+
+## 1. Context & Motivation
+
+Currently in Dext, developers map entity tables to `IDbSet<T>` repositories inside a custom `TDbContext` subclass. A typical best-practice context requires explicit property declarations paired with manual getters returning the generic `Entity<T>` call:
+
+```pascal
+type
+  TAppDbContext = class(TDbContext)
+  private
+    function GetProducts: IDbSet<TProduct>;
+    function GetOrders: IDbSet<TOrder>;
+  public
+    property Products: IDbSet<TProduct> read GetProducts;
+    property Orders: IDbSet<TOrder> read GetOrders;
+  end;
+
+function TAppDbContext.GetProducts: IDbSet<TProduct>;
+begin
+  Result := Entity<TProduct>;
+end;
+```
+
+While extremely clean compared to legacy Delphi, this still introduces redundant getter methods for large databases with dozens of tables. 
+
+Our goal is to build an **Automatic Hydration Factory** into `TDbContext` using RTTI scanning at instantiation. During class construction, Dext should automatically inspect all generic fields/properties of type `IDbSet<T>`, resolve their mapping, and populate them automatically, eliminating getters entirely.
+
+Additionally, we address the initialization syntax of configuration builders. The previous mock syntax:
+```pascal
+var Db := TAppDbContext.Create(
+  DbOptions.UsePostgreSQL(ConnectionString)
+);
+```
+needs to be fully resolved. In Pascal, `DbOptions` is either a class that requires a `.Create` call (introducing boilerplate), or it can be engineered as a **fluent Builder Record** utilizing a global inline constructor function and **Implicit Operator Overloading** to yield the concrete configuration instance.
+
+---
+
+## 2. Part A: DbContext Auto-Hydration Patterns
+
+We analyze three candidate patterns to support automatic instantiation of repositories during DbContext construction.
+
+### Pattern 1: Public/Published Fields (Direct Auto-Binding)
+```pascal
+type
+  TAppDbContext = class(TDbContext)
+  public
+    Products: IDbSet<TProduct>;
+    Orders: IDbSet<TOrder>;
+  end;
+```
+* **Pros**: 
+  - Absolute minimum code footprint. 
+  - No getters, no private fields, no properties. Very clean, close to C# `DbSet<T>` fields.
+* **Cons**: 
+  - **Critical Architectural Risk**: Fields are read-write. An accidental assignment in user code (e.g., `Db.Products := nil;` or overriding it with another instance) breaks context consistency and change-tracking tracking, causing runtime AVs that are hard to debug.
+
+### Pattern 2: Private Fields + Public Read-Only Properties (Highly Safe & Recommended)
+```pascal
+type
+  TAppDbContext = class(TDbContext)
+  private
+    FProducts: IDbSet<TProduct>;
+    FOrders: IDbSet<TOrder>;
+  public
+    property Products: IDbSet<TProduct> read FProducts;
+    property Orders: IDbSet<TOrder> read FOrders;
+  end;
+```
+* **Pros**:
+  - **Complete Architectural Safety**: The property is strictly read-only. User code cannot accidentally assign, overwrite, or clear the repository instance.
+  - Highly idiomatic Delphi.
+* **Cons**:
+  - Slightly more verbose than Pattern 1 (requires writing the private field and property wrapper).
+
+---
+
+## 3. The Implementation Specification (Pattern 2)
+
+Dext implements **Pattern 2** natively inside `TDbContext`.
+
+### RTTI Hydration Factory Implementation
+When `TDbContext` is constructed, it will scan its own class structure using `Dext.Core.Reflection` (specifically the optimized type cache from [S07](S07-High-Perf-Reflection.md)):
+
+1. Scan all private fields of the instance (`TRttiField`).
+2. Identify fields where the type is a generic interface matching `IDbSet<T>`.
+3. Extract the generic parameter type `T` from `PTypeInfo`.
+4. Call `Entity<T>` internally to obtain or instantiate the corresponding repository.
+5. Inject the instantiated `IDbSet<T>` directly into the private field using low-level field write offsets (`TRttiField.SetValue`).
+
+This process happens once per class layout, cached in the global RTTI cache, ensuring that instantiation overhead is sub-microsecond and completely negligible.
+
+---
+
+## 4. Part B: TDbOptions Builder Evolution
+
+To support the highly ergonomic initialization syntax:
+```pascal
+var Db := TAppDbContext.Create(
+  DbOptions.UsePostgreSQL(ConnectionString)
+);
+```
+We define the structure of `DbOptions`. 
+
+### The Under-the-Hood Architecture
+1. **`DbOptions` (Global Constructor Function)**: A global inline function returning a `TDbOptionsBuilder` record.
+2. **`TDbOptionsBuilder` (Fluent Record)**: A record that contains chainable configuration methods: `.UsePostgreSQL(ConnectionString)`, `.UseSQLite(ConnectionString)`, etc.
+3. **Implicit Operator Overloading**: The record implements an implicit operator to convert `TDbOptionsBuilder` to the concrete, allocated class `TDbOptions` required by the `TDbContext` constructor.
+
+```pascal
+type
+  TDbOptions = class
+  private
+    FDriverId: string;
+    FConnectionString: string;
+  public
+    property DriverId: string read FDriverId write FDriverId;
+    property ConnectionString: string read FConnectionString write FConnectionString;
+  end;
+
+  TDbOptionsBuilder = record
+  private
+    FDriverId: string;
+    FConnectionString: string;
+  public
+    function UsePostgreSQL(const AConnStr: string): TDbOptionsBuilder;
+    function UseSQLite(const AConnStr: string): TDbOptionsBuilder;
+    
+    class operator Implicit(const ABuilder: TDbOptionsBuilder): TDbOptions;
+  end;
+
+// Global Constructor Function
+function DbOptions: TDbOptionsBuilder; inline;
+
+implementation
+
+function DbOptions: TDbOptionsBuilder;
+begin
+  Result := Default(TDbOptionsBuilder);
+end;
+
+function TDbOptionsBuilder.UsePostgreSQL(const AConnStr: string): TDbOptionsBuilder;
+begin
+  Result := Self;
+  Result.FDriverId := 'PG';
+  Result.FConnectionString := AConnStr;
+end;
+
+class operator TDbOptionsBuilder.Implicit(const ABuilder: TDbOptionsBuilder): TDbOptions;
+begin
+  Result := TDbOptions.Create;
+  Result.DriverId := ABuilder.FDriverId;
+  Result.ConnectionString := ABuilder.FConnectionString;
+end;
+```
+
+This ensures that the final user syntax is extremely elegant and 100% compile-safe, completely hiding manual instantiation and resource cleanup of options from the end-user.
+
+---
+
+*Dext Specifications — S30 Automatic Context Hydration | May 2026*

--- a/Docs/Tasks/TaskProgressLog-S23-HTMX-Streaming.md
+++ b/Docs/Tasks/TaskProgressLog-S23-HTMX-Streaming.md
@@ -42,7 +42,7 @@ Concluí a estabilização do framework e a implementação da infraestrutura ba
 *   **Fase 2 (HTMX):** Iniciar a criação dos helpers para HTMX no `IHttpResponse` e validar a renderização de fragmentos HTML (parciais) no View Engine.
 *   **Teste no Sidecar:** Validar a recepção de telemetria no Dashboard atual usando a nova rota `/mcp/sse` (ou similar) como prova de conceito.
 
-O documento de tarefas [Task-S23-HTMX-Streaming.md](file:///C:/dev/Dext/DextRepository/Docs/Tasks/Task-S23-HTMX-Streaming.md) foi atualizado com o status atual.
+O documento de tarefas [Task-S23-HTMX-Streaming.md](Task-S23-HTMX-Streaming.md) foi atualizado com o status atual.
 
 Searched for "IdHTTP|IdContext|IdGlobal|IdTCP"
 Viewed Dext.MCP.Tools.pas:1-385

--- a/README.md
+++ b/README.md
@@ -10,11 +10,23 @@
 ---
 
 > [!IMPORTANT]
-> Dext Framework is currently in **Version 1 Release Candidate (RC1)**.
+> Dext Framework is currently in **Version 1 Release Candidate (RC2)**.
 
 **Dext Framework** is a native and integrated ecosystem for Delphi development.
 
 It brings together Dependency Injection, ORM, Web Pipeline, and Testing into a single, high-performance architecture. Designed to eliminate the need for connecting isolated libraries and to drastically reduce boilerplate code, Dext handles the infrastructure complexity so your team can focus strictly on business logic.
+
+## Delphi Modernization & .NET Parity
+
+Dext was built to bridge the perception and architectural gap between Delphi and modern platforms like .NET Core. If your team is considering migrating a legacy VCL/FMX system to another modern stack due to the lack of modern enterprise patterns, Dext offers a complete native alternative without the cost, risk, and time of rewriting your entire codebase.
+
+We provide full functional parity with modern ASP.NET Core & Entity Framework Core patterns, while leveraging native compilation (no JIT, zero cold starts, and minimal memory footprint).
+
+Explore our detailed comparison and capability references:
+*   [**Dext vs .NET Architectural Narrative**](Docs/Comparison/Dext_vs_DotNet_Narrative.md) — How Dext bridges the backend gap with native compilation.
+*   [**Feature-by-Feature Parity Matrix**](Docs/Comparison/Feature_Comparison_Dext_vs_DotNet.md) — Over 60+ features compared directly between ASP.NET/EF Core and Dext.
+*   [**Complete ORM Capabilities Reference**](Docs/Comparison/Dext_ORM_Capabilities.md) — DbContext, Change Tracking, JSON columns, and Lazy/Eager strategies.
+*   [**Enterprise Licensing Guide**](Docs/Comparison/Open_Source_Licensing_Enterprise.md) — Why Dext is completely free, secure, and ready for commercial use under Apache 2.0.
 
 ## Where to Use?
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -10,11 +10,23 @@
 ---
 
 > [!IMPORTANT]
-> O Dext Framework está atualmente em **Versão 1 Release Candidate (RC1)**.
+> O Dext Framework está atualmente em **Versão 1 Release Candidate (RC2)**.
 
 O **Dext Framework** é um ecossistema nativo e integrado para o desenvolvimento em Delphi.
 
 Ele une Injeção de Dependência, ORM, Web Pipeline e Testes em uma arquitetura única de altíssima performance. Desenvolvido para eliminar a necessidade de conectar bibliotecas isoladas e reduzir drasticamente o código *boilerplate*, o Dext resolve a complexidade da infraestrutura base para que a sua equipe escreva estritamente a regra de negócio.
+
+## Modernização do Delphi & Paridade com o .NET
+
+O Dext foi construído para fechar o abismo de percepção e arquitetura entre o Delphi e plataformas modernas como o .NET Core. Se a sua equipe está considerando migrar um sistema legado VCL/FMX para outra stack moderna devido à falta de padrões corporativos modernos, o Dext oferece uma alternativa nativa completa sem o custo, risco e tempo de reescrever todo o seu código do zero.
+
+Oferecemos paridade funcional completa com os padrões do ASP.NET Core e Entity Framework Core, aproveitando as vantagens da compilação nativa (sem JIT, sem cold starts e com baixíssimo consumo de memória).
+
+Explore nossos guias detalhados de comparação e capacidades:
+*   [**Dext vs .NET: Uma Comparação de Arquitetura**](Docs/Comparison/Dext_vs_DotNet_Narrative.pt-br.md) — Como o Dext une padrões modernos com compilação nativa.
+*   [**Matriz de Paridade Recurso por Recurso**](Docs/Comparison/Feature_Comparison_Dext_vs_DotNet.pt-br.md) — Mais de 60 recursos comparados diretamente entre o ASP.NET/EF Core e o Dext.
+*   [**Referência Completa de Recursos do ORM**](Docs/Comparison/Dext_ORM_Capabilities.pt-br.md) — DbContext, Change Tracking, colunas JSON e estratégias Lazy/Eager.
+*   [**Guia de Licenciamento Corporativo**](Docs/Comparison/Open_Source_Licensing_Enterprise.pt-br.md) — Por que o Dext é 100% gratuito e seguro para uso comercial sob a Licença Apache 2.0.
 
 ## Onde Usar?
 


### PR DESCRIPTION
- Bump version reference to V1 Release Candidate 2 (RC2) in main README files
- Relocate and translate marketing documents into a unified Comparison directory
- Embed high-impact architectural parity and modernization sections in root READMEs
- Add comprehensive ORM documentation covering nested mapping strategies
- Update ecosystem overview, implemented features indexes, and roadmap metrics
- Add technical specifications for conditional query parameters and DbContext auto-hydration
- Add tasks progress log for stream handling features