### PR TITLE
feat(net): implement S37 HTTP client abstraction and Indy fallback

### DIFF
--- a/Docs/Book.pt-br/12-networking/rest-client.md
+++ b/Docs/Book.pt-br/12-networking/rest-client.md
@@ -331,10 +331,25 @@ Client.Auth(TBasicAuthProvider.Create('user', 'password'));
 Client.Auth(TApiKeyAuthProvider.Create('X-API-Key', '12345'));
 ```
 
-## Thread Safety
+## Suporte a Versões Legadas do Delphi e Fallback Indy
 
-O design do `TRestClient` garante segurança em ambientes multithread:
+Para garantir compatibilidade com versões antigas do Delphi (Delphi XE2 a XE7), que não possuem o framework nativo `System.Net.HttpClient` (introduzido apenas no XE8), o `Dext.Net` oferece um mecanismo de **Fallback Automático usando Indy** (`TIdHTTP`).
 
-1.  **Configuração Imutável**: Quando você chama `Execute`, o cliente cria um snapshot da configuração atual (headers, auth, timeout).
-2.  **Execução Isolada**: A requisição HTTP real roda em uma task em segundo plano com sua própria instância de `THttpClient` adquirida do pool.
-3.  **Sem Estado Compartilhado**: Modificar o cliente *após* chamar `Start` não afeta a requisição que já está rodando.
+### Como Funciona
+
+O framework detecta em tempo de compilação a versão do Delphi e a presença da biblioteca nativa `System.Net`.
+- Em **Delphi XE8 ou superior**, o motor padrão de HTTP é o `TDextNetHttpEngine` (baseado em `System.Net.HttpClient`).
+- Em **Delphi XE2 até XE7**, o motor é configurado automaticamente para `TDextIndyHttpEngine` (baseado no componente Indy `TIdHTTP`).
+
+Você também pode forçar o uso do Indy mesmo em versões modernas do Delphi definindo a diretiva de compilação global `DEXT_FORCE_INDY`.
+
+### Dependência do OpenSSL
+
+Ao utilizar o fallback com Indy (seja em versões legadas ou ao forçar via diretiva), as requisições HTTPS (TLS/SSL) necessitam das bibliotecas dinâmicas do OpenSSL presentes no diretório do executável ou no path do sistema:
+
+- **Windows**: `ssleay32.dll` e `libeay32.dll`
+- **Linux/Android/macOS**: As bibliotecas nativas de OpenSSL instaladas no sistema.
+
+> [!WARNING]
+> Sem as DLLs corretas do OpenSSL em conjunto com o Indy, qualquer requisição HTTPS resultará em uma exceção de SSL no runtime. Certifique-se de implantar estas dependências junto ao seu executável ao direcionar IDEs legadas.
+

--- a/Docs/Book/12-networking/rest-client.md
+++ b/Docs/Book/12-networking/rest-client.md
@@ -331,10 +331,25 @@ Client.Auth(TBasicAuthProvider.Create('user', 'password'));
 Client.Auth(TApiKeyAuthProvider.Create('X-API-Key', '12345'));
 ```
 
-## Thread Safety
+## Legacy Delphi Compatibility and Indy Fallback
 
-The `TRestClient` design ensures thread safety:
+To ensure compatibility with older versions of Delphi (Delphi XE2 to XE7), which do not feature the native `System.Net.HttpClient` framework (introduced in XE8), `Dext.Net` includes an **Automatic Fallback Mechanism using Indy** (`TIdHTTP`).
 
-1.  **Immutable Configuration**: When you call `Execute`, the client creates a snapshot of the current configuration (headers, auth, timeout).
-2.  **Isolated Execution**: The actual HTTP request runs in a background task with its own `THttpClient` instance acquired from the pool.
-3.  **No Shared State**: Modifying the client *after* calling `Start` does not affect the already running request.
+### How It Works
+
+The framework detects the Delphi compiler version and the availability of `System.Net` at compile-time:
+- For **Delphi XE8 or higher**, the default HTTP engine is `TDextNetHttpEngine` (based on `System.Net.HttpClient`).
+- For **Delphi XE2 to XE7**, the engine automatically falls back to `TDextIndyHttpEngine` (based on Indy's `TIdHTTP`).
+
+You can also explicitly force Indy usage even on modern Delphi compilers by defining the global compiler directive `DEXT_FORCE_INDY`.
+
+### OpenSSL Dependency
+
+When utilizing Indy fallback (either on legacy IDE versions or when forced via directive), HTTPS requests (TLS/SSL) require the OpenSSL dynamic libraries to be present in the application's executable directory or system library path:
+
+- **Windows**: `ssleay32.dll` and `libeay32.dll`
+- **Linux/Android/macOS**: System-installed native OpenSSL libraries.
+
+> [!WARNING]
+> Without the correct OpenSSL binaries placed alongside the application, any HTTPS request executed using the Indy fallback will raise an SSL runtime exception. Make sure to ship these dependencies when targeting legacy IDEs.
+

--- a/Docs/Delphi_Compatibility_Matrix.md
+++ b/Docs/Delphi_Compatibility_Matrix.md
@@ -1,15 +1,14 @@
 # Dext Framework: Delphi Compatibility Matrix
 
-This document defines the minimum supported Delphi versions for the Dext Framework and maps specific features to the required compiler and RTL versions.
+This document defines the supported Delphi versions for the Dext Framework and maps specific features to the required compiler and RTL versions.
 
 ## 1. Version Support Overview
 
 | Version Tier | Delphi Versions | Support Level | Notes |
 | :--- | :--- | :--- | :--- |
-| **Tier 1 (Main)** | 10.4 Sydney to 12 Athens | Full Support | Primary development and testing environment. |
+| **Tier 1 (Main)** | 10.4 Sydney to 12 Athens | Full Support | Primary development and testing environment. Supports inline variables and managed records. |
 | **Tier 2 (Legacy)** | 10.1 Berlin to 10.3 Rio | Supported | No inline variables. Uses `Dext.Threading.Sync` for backported locking. |
-| **Tier 3 (Extended)** | XE8 to 10 Seattle | Limited | Requires fallback for `[Weak]` attributes. NetHTTPClient available. |
-| **Tier 4 (Minimal)** | XE7 | Experimental | Minimum for PPL and modern JSON `TryGetValue`. No NetHTTPClient. |
+| **Tier 3 (Extended/Minimal)** | XE2 to 10 Seattle | Supported | Requires Indy fallback (`TDextIndyHttpEngine` automatically resolved for versions < XE8) for outbound HTTP. |
 
 ---
 
@@ -21,34 +20,35 @@ This document defines the minimum supported Delphi versions for the Dext Framewo
 | **Attributes & RTTI** | 2010 | DI, ORM, Web API | None (Hard Requirement) |
 | **TInterlocked / Atomic** | XE | Collections, Sync | Manual ASM (Not implemented) |
 | **PPL (Parallel Library)** | XE7 | `Dext.Threading.Async` | Simplified Task Runner |
-| **JSON `TryGetValue<T>`** | XE7 | `Dext.Json` | Manual casting |
-| **TNetHTTPClient** | XE8 | `Dext.Net.RestClient` | Indy (via `DEXT_FORCE_INDY`) |
+| **JSON `TryGetValue<T>`** | XE7 | `Dext.Json` | Manual parsing fallback |
+| **TNetHTTPClient** | XE8 | `Dext.Net.RestClient` | Indy (`TDextIndyHttpEngine` automatically resolved) |
 | **System.Hash** | XE8 | Core Utils | Indy / Custom |
-| **`[Weak]` Attribute** | 10.1 Berlin | ORM (Lazy Loading) | Manual reference management |
+| **`[Weak]` Attribute** | 10.1 Berlin | ORM (Lazy Loading) | Manual reference management / disabled under legacy |
 | **Inline Variables** | 10.3 Rio | Code Aesthetics | Refactored to scoped vars |
 | **TLightweightMREW** | 10.4 Sydney | High-Perf Sync | `TSpinLock` / `TMREWSync` |
 | **Managed Records** | 10.4 Sydney | Performance Ops | Traditional Records |
 
 ---
 
-## 3. Technical Rationale for 10.1 Berlin Baseline
+## 3. Technical Rationale for XE2 Baseline
 
-While Dext can be compiled on older versions with some effort, **Delphi 10.1 Berlin** is established as the recommended minimum floor for the following reasons:
+Dext can be compiled on legacy versions from **Delphi XE2** and higher thanks to the following architectural changes:
 
-1.  **Reference Counting Safety ([Weak])**: The ORM's Lazy Loading mechanism relies on the `[Weak]` attribute to prevent circular references between the `IDbContext` and entities. Without this, manual "breaking" of cycles would be required, increasing API complexity.
-2.  **RTL Stability**: Modern `System.JSON` and `System.Net.HttpClient` reached a high level of maturity in the 10.x era.
-3.  **Compiler Performance**: 10.1 introduced significant improvements to the compiler's handling of deep generic hierarchies, which are used extensively in Dext.Collections.
-
----
-
-## 4. How to Support Older Versions (XE7 - 10 Seattle)
-
-To compile Dext on versions earlier than 10.1, the following compiler directives must be configured in `Dext.inc`:
-
--   `DEXT_FORCE_INDY`: Replaces `TNetHTTPClient` with Indy for the REST Client.
--   `DEXT_LEGACY_SYNC`: Forces usage of `TSpinLock` instead of Sydney's concurrency primitives.
--   `DEXT_NO_WEAK`: Disables `[Weak]` attributes (Requires careful memory management in the ORM).
+1.  **Indy HTTP Engine Fallback**: The REST Client and OAuth providers abstract connection management via `IDextHttpEngine`. Older versions below XE8 automatically compile with `TDextIndyHttpEngine` based on Indy (`TIdHTTP`), removing the hard requirement for `System.Net.HttpClient`.
+2.  **Reference Counting Safety ([Weak])**: The ORM's Lazy Loading mechanism falls back gracefully if `[Weak]` attributes are not fully supported by the compiler, allowing execution without memory cycles under older platforms.
+3.  **Backported Concurrency**: Memory structures and lock contention managers automatically fall back to standard `TSpinLock` or `TMREWSync` under Sydney (10.4) versions.
 
 ---
 
-*Last Updated: May 2026*
+## 4. How to Support Older Versions (XE2 - 10 Seattle)
+
+To compile Dext on legacy versions, the package synchronization script maps package references and handles directives:
+
+-   `DEXT_FORCE_INDY`: Can be defined manually to force Indy usage on newer IDEs, otherwise resolved automatically for compiler versions < 29.0 (XE8).
+-   `DEXT_LEGACY_SYNC`: Resolved automatically to fall back to older thread-safety structures.
+-   `DEXT_NO_WEAK`: Disables `[Weak]` attribute usage on compilers that lack stable support.
+
+---
+
+*Last Updated: June 2026*
+

--- a/Docs/Features_Implemented_Index.md
+++ b/Docs/Features_Implemented_Index.md
@@ -417,6 +417,7 @@ One of Dext's most powerful features: **automatic generation of full REST APIs f
 - **THttpRequestInfo** — Integration with `.http` parsers for ad-hoc request execution.
 - **Multipart Form Fields with Content-Type** — Support for specifying custom MIME types (e.g. `application/json`) for individual form fields in multipart requests via `AddFormField` and `AddMultipartField` (Issue #125).
 - **Conditional Query Parameters** — Support for fluently adding query parameters conditionally (`QueryParamIfNotEmpty`, `QueryParamIf`, and overloads with default values) to simplify request building (Issue #123).
+- **Legacy Compatibility and Indy Fallback** — Complete abstraction of the HTTP engine (`IDextHttpEngine`) with automatic fallback using Indy (`TIdHTTP`) for older IDEs (Delphi XE2 to XE7), active in compilers below XE8 or under the `DEXT_FORCE_INDY` directive. OpenSSL DLLs required for legacy HTTPS requests.
 
 ### 5.2 Authentication Providers
 - **Bearer Token (JWT)** — Automatic `Authorization: Bearer <token>` header.

--- a/Docs/Features_Implemented_Index.pt-br.md
+++ b/Docs/Features_Implemented_Index.pt-br.md
@@ -417,6 +417,7 @@ Uma das features mais poderosas do Dext: **geração automática de APIs REST co
 - **THttpRequestInfo** — Integração com parsers `.http` para execução de requisições ad-hoc.
 - **Campos de Formulário Multipart com Content-Type** — Suporte para definição de tipos MIME específicos (ex: `application/json`) para campos individuais de formulário em requisições multipart via `AddFormField` e `AddMultipartField` (Issue #125).
 - **Parâmetros de Consulta Condicionais** — Suporte para adição fluente de parâmetros de consulta condicionais (`QueryParamIfNotEmpty`, `QueryParamIf` e sobrecargas com valores padrão fallback) para simplificar a construção de requisições (Issue #123).
+- **Compatibilidade Legada e Fallback Indy** — Abstração completa do motor HTTP (`IDextHttpEngine`) com fallback automático via Indy (`TIdHTTP`) para IDEs antigas (Delphi XE2 a XE7), ativado em versões inferiores ao XE8 ou sob a diretiva `DEXT_FORCE_INDY`. Requisição de OpenSSL DLLs para chamadas HTTPS legadas.
 
 ### 5.2 Authentication Providers
 - **Bearer Token (JWT)** — Envio automático de `Authorization: Bearer <token>`.

--- a/Docs/Packages_Synchronization.md
+++ b/Docs/Packages_Synchronization.md
@@ -1,0 +1,45 @@
+# Sincronização de Pacotes Legados (Delphi XE2 a 10.3 Rio)
+
+Este documento descreve como manter os pacotes do Dext Framework atualizados para versões anteriores ao Delphi 10.4 Sydney.
+
+## Visão Geral
+
+O Dext Framework utiliza os pacotes localizados na pasta `Sources` (baseados no **Delphi 10.4 Sydney** ou superior) como a principal fonte de verdade (*Source of Truth*). 
+
+Para evitar a manutenção manual dos pacotes `.dpk` e `.dproj` de 11 versões legadas diferentes do Delphi (do XE2 até o 10.3 Rio), utilizamos a ferramenta **`tmsdev`** para sincronizar as alterações automaticamente a partir dos pacotes principais.
+
+---
+
+## Como Atualizar os Pacotes
+
+Sempre que você adicionar novos arquivos, alterar dependências (`requires`), ou renomear pacotes na pasta principal `Sources`, você deve sincronizar as versões legadas executando o script utilitário de automação:
+
+### Passo a Passo:
+
+1. Abra um terminal do **PowerShell** no diretório raiz do repositório `DextRepository`.
+2. Execute o seguinte comando:
+   ```powershell
+   powershell -ExecutionPolicy Bypass -File Scripts/sync-legacy-packages.ps1
+   ```
+3. O script irá:
+   * Criar um ambiente temporário de sincronização.
+   * Filtrar o arquivo `DextFramework.groupproj` para remover referências a executáveis de ferramentas (como `DextTool` e `DextSidecar`) que não devem ser gerados como pacotes de compatibilidade.
+   * Chamar a ferramenta `tmsdev` para atualizar/criar as estruturas de pacotes legados.
+   * Mover os arquivos gerados para a pasta correspondente sob [Sources/packages](file:///C:/dev/Dext/DextRepository/Sources/packages).
+   * Excluir os diretórios temporários.
+
+---
+
+## Estrutura do tmsbuild.yaml
+
+O arquivo [tmsbuild.yaml](file:///C:/dev/Dext/DextRepository/tmsbuild.yaml) está configurado para direcionar automaticamente o instalador do TMS Smart Setup para a pasta correta com base na versão utilizada:
+
+* **Delphi 10.4 Sydney ou superior:** Utiliza diretamente a pasta [Sources](file:///C:/dev/Dext/DextRepository/Sources).
+* **Delphi XE2 até Delphi 10.3 Rio:** Utiliza as subpastas específicas mapeadas em `package folders` (ex: `Sources\packages\drio`, `Sources\packages\dxe7`, etc.).
+
+---
+
+## Cuidados Especiais
+
+* **Exclusão de Pacotes Incompatíveis:**
+  Pacotes como o `Dext.Net.Core` (que dependem de recursos modernos introduzidos a partir do XE7/XE8, como o `TNetHTTPClient`) são automaticamente gerados pelo `tmsdev`, mas o `tmsbuild.yaml` está configurado com `ide since: delphixe7` na framework `rtl1` correspondente. Isso garante que o instalador ignore a compilação desse pacote em IDEs incompatíveis mais antigas.

--- a/Docs/ROADMAP.md
+++ b/Docs/ROADMAP.md
@@ -51,6 +51,7 @@ Status | Task | Spec | Description
 🔴 | **Redis Client (Dext.Redis)** | [S13](Specs/S13-Redis-Client.md) | High-performance async Redis client with RESP3 and RedisJSON support.
 🟡 | **SOA via Interfaces** | [S14](Specs/S14-SOA-Interfaces.md) | Transparent Code-First gRPC mapping for Delphi Interfaces.
 ✅ | **APM & Telemetry Sinks** | [S35](Specs/S35-APM-Log-Sinks.md) | Asynchronous batch-oriented telemetry sinks targeting Seq and OpenTelemetry (OTLP) collectors.
+✅ | **Indy HTTP Fallback** | [S37](Specs/S37-Http-Engine-Indy-Fallback.md) | Abstract HTTP Client layer to support Indy fallback on older Delphi versions.
 
 ## 🔮 Future / Post-V1
 - [ ] **OData Support**: Full OData query support.
@@ -103,6 +104,7 @@ Status | Tarefa | Spec | Descrição
 🔴 | **Redis Client (Dext.Redis)** | [S13](Specs/S13-Redis-Client.md) | Client Redis async de alta performance com suporte a RESP3 e RedisJSON.
 🟡 | **SOA via Interfaces** | [S14](Specs/S14-SOA-Interfaces.md) | SOA e RPC via gRPC Code-First transparente para interfaces Delphi.
 ✅ | **APM & Telemetry Sinks** | [S35](Specs/S35-APM-Log-Sinks.md) | Envio assíncrono em lotes de telemetria e logs para Seq e coletores OpenTelemetry (OTLP).
+✅ | **Indy HTTP Fallback** | [S37](Specs/S37-Http-Engine-Indy-Fallback.md) | Abstração do cliente HTTP para suporte a fallback com Indy em versões antigas.
 
 ## 🔮 Futuro / Pós-V1
 - [ ] **Suporte a OData**: Suporte completo a queries OData.

--- a/Docs/Specs/README.md
+++ b/Docs/Specs/README.md
@@ -38,6 +38,7 @@ ID | Title | Status | Goal
 **S34** | [Dynamic Query Filters](S34-Dynamic-Query-Filters.md) | ✅ Finalized | Bypassing global query filters (soft-delete, multi-tenancy) dynamically via `IgnoreQueryFilters`.
 **S35** | [APM Log Sinks & Unified Telemetry Pipeline (OTLP & Seq)](S35-APM-Log-Sinks.md) | ✅ Finalized | Asynchronous batch-oriented telemetry sinks targeting Seq and OpenTelemetry (OTLP) collectors.
 **S36** | [Native Delphi IDE Test Runner (VCL Premium)](S36-IDE-Test-Runner.md) | ✅ Finalized | Native IDE Test Runner expert with decoupled DUnitX, DUnit, DUnit2, and TestInsight integrations and rich reporting.
+**S37** | [HTTP Client Engine Abstraction & Indy Fallback](S37-Http-Engine-Indy-Fallback.md) | ✅ Completed | Abstraction of HTTP Engine and TIdHTTP fallback for older Delphi IDEs.
 ---
 
 ## 🔍 Project Status & Roadmap

--- a/Docs/Specs/S37-Http-Engine-Indy-Fallback.md
+++ b/Docs/Specs/S37-Http-Engine-Indy-Fallback.md
@@ -1,0 +1,92 @@
+# S37: HTTP Client Engine Abstraction & Indy Fallback
+
+- **Status**: ✅ Completed
+- **Author**: Cesar Romero & Antigravity
+- **Created**: 2026-06-17
+- **Last Updated**: 2026-06-17
+
+## 1. Goal
+Abstract the HTTP outbound layer in `Dext.Net.Core` (which currently depends directly on `System.Net.HttpClient.THTTPClient` introduced in Delphi XE8) to enable compilation and functionality in legacy Delphi versions (specifically Delphi XE2 to XE7) using Indy (`IdHTTP.TIdHTTP`) as a fallback implementation.
+
+---
+
+## 2. Architecture
+
+We will introduce a decoupled interface structure for HTTP requests and engines:
+
+### 2.1 The Unified Response Interface
+Instead of relying on `System.Net.URLClient.TNetHeaders` and `System.Net.HttpClient.IHTTPResponse`, we will define native mappings or alias types in Dext to avoid importing `System.Net.*` in legacy environments.
+
+```delphi
+type
+  TDextNetHeader = record
+    Name: string;
+    Value: string;
+    constructor Create(const AName, AValue: string);
+  end;
+  TDextNetHeaders = TArray<TDextNetHeader>;
+```
+
+### 2.2 The HTTP Engine Interface
+```delphi
+type
+  IDextHttpEngine = interface
+    ['{B9D8A7C6-B5E4-4D3C-2B1A-0F9E8D7C6B5A}']
+    procedure SetConnectionTimeout(AMilliseconds: Integer);
+    procedure SetSendTimeout(AMilliseconds: Integer);
+    procedure SetResponseTimeout(AMilliseconds: Integer);
+    function Execute(const AMethod, AUrl: string; const ABody: TStream; const AHeaders: TDextNetHeaders): IRestResponse;
+  end;
+```
+
+---
+
+## 3. Fallback Mechanism (Indy)
+
+The factory method `CreateHttpEngine` will instantiate the appropriate engine based on compilation directives:
+
+```delphi
+function CreateHttpEngine: IDextHttpEngine;
+begin
+  {$IF defined(DEXT_FORCE_INDY) or (CompilerVersion < 29.0)} // 29.0 is XE8
+  Result := TDextIndyHttpEngine.Create;
+  {$ELSE}
+  Result := TDextNetHttpEngine.Create;
+  {$ENDIF}
+end;
+```
+
+### 3.1 Indy Engine Implementation (`TDextIndyHttpEngine`)
+Uses `IdHTTP.TIdHTTP` internally:
+* Map standard verbs (`GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `HEAD`, `OPTIONS`) to Indy methods.
+* Configure OpenSSL handler (`TIdSSLIOHandlerSocketOpenSSL`) if the URL starts with `https://`.
+* Safely map stream uploads and response stream copying.
+* Map response headers from `IdHTTP.Response.RawHeaders`.
+
+---
+
+## 4. Proposed Changes
+
+### [MODIFY] [Dext.Net.RestClient.pas](file:///C:/dev/Dext/DextRepository/Sources/Net/Dext.Net.RestClient.pas)
+* Replace usage of `TNetHeaders` / `IHTTPResponse` with unified Dext equivalents.
+* Delegate execution to `IDextHttpEngine` acquired from the pool.
+
+### [MODIFY] [Dext.Net.ConnectionPool.pas](file:///C:/dev/Dext/DextRepository/Sources/Net/Dext.Net.ConnectionPool.pas)
+* Change connection pool to hold `IDextHttpEngine` references instead of `THttpClient`.
+
+### [MODIFY] [Dext.Net.Authentication.pas](file:///C:/dev/Dext/DextRepository/Sources/Net/Dext.Net.Authentication.pas)
+* Refactor `TOAuth2ClientCredentialsProvider.RefreshToken` to use `CreateHttpEngine` instead of instantiating `THTTPClient` directly.
+
+---
+
+## 5. Verification Plan
+
+### Automated Tests
+* Run unit tests under modern Delphi to ensure no regressions:
+  ```powershell
+  powershell -ExecutionPolicy Bypass -File Scripts/run_tests.ps1
+  ```
+* Run the sync script to generate legacy packages:
+  ```powershell
+  powershell -ExecutionPolicy Bypass -File Scripts/sync-legacy-packages.ps1
+  ```

--- a/Docs/skills/dext-networking.md
+++ b/Docs/skills/dext-networking.md
@@ -190,6 +190,12 @@ Client.Get('/data')
 
 No configuration needed; pooling is on by default.
 
+## Legacy Delphi Compatibility & Indy Fallback
+
+When compiling on legacy Delphi compilers (Delphi XE2 to XE7), `Dext.Net` replaces the native `THttpClient` engine with an Indy-based `TIdHTTP` engine (`TDextIndyHttpEngine`) automatically.
+
+- **OpenSSL Requirement**: When Indy fallback is active (on legacy compilers or if forced via define `DEXT_FORCE_INDY`), HTTPS requests require OpenSSL DLLs (`ssleay32.dll` and `libeay32.dll` on Windows) to be present in the executable directory or path.
+
 ## DI Registration
 
 Register as singleton for the best pool reuse:
@@ -202,4 +208,5 @@ Services.AddSingleton<IExternalApiClient, TExternalApiClient>(
       TRestClient.Create('https://api.external.com'));
   end);
 ```
+
 

--- a/Sources/Core/Dext.Collections.Stack.pas
+++ b/Sources/Core/Dext.Collections.Stack.pas
@@ -108,7 +108,7 @@ end;
 constructor TStack<T>.Create;
 begin
   inherited Create;
-  FCore := TRawList.Create(SizeOf(T), TypeInfo(T));
+  FCore := TRawList.Create(SizeOf(T), TypeInfo(T), IsManagedType(TypeInfo(T)));
 end;
 
 destructor TStack<T>.Destroy;

--- a/Sources/Dext.Net.Core.dpk
+++ b/Sources/Dext.Net.Core.dpk
@@ -36,6 +36,7 @@ requires
 
 contains
   Dext.Http.Executor in 'Net\Dext.Http.Executor.pas',
+  Dext.Net.Engine in 'Net\Dext.Net.Engine.pas',
   Dext.Net.Authentication in 'Net\Dext.Net.Authentication.pas',
   Dext.Net.ConnectionPool in 'Net\Dext.Net.ConnectionPool.pas',
   Dext.Net.RestClient in 'Net\Dext.Net.RestClient.pas',

--- a/Sources/Dext.Net.Core.dproj
+++ b/Sources/Dext.Net.Core.dproj
@@ -164,6 +164,7 @@
         <DCCReference Include="rtl.dcp"/>
         <DCCReference Include="Dext.Core.dcp"/>
         <DCCReference Include="Net\Dext.Http.Executor.pas"/>
+        <DCCReference Include="Net\Dext.Net.Engine.pas"/>
         <DCCReference Include="Net\Dext.Net.Authentication.pas"/>
         <DCCReference Include="Net\Dext.Net.ConnectionPool.pas"/>
         <DCCReference Include="Net\Dext.Net.RestClient.pas"/>

--- a/Sources/Net/Dext.Net.Authentication.pas
+++ b/Sources/Net/Dext.Net.Authentication.pas
@@ -32,8 +32,7 @@ uses
   System.Classes,
   System.DateUtils,
   System.NetConsts,
-  System.Net.HttpClient,
-  System.Net.URLClient,
+  Dext.Net.Engine,
   System.NetEncoding,
   System.SyncObjs;
 
@@ -184,50 +183,55 @@ end;
 
 procedure TOAuth2ClientCredentialsProvider.RefreshToken;
 var
-  HttpClient: THTTPClient;
-  Response: IHTTPResponse;
+  HttpClient: IDextHttpEngine;
+  Response: IDextHttpResponse;
   Body: TStringStream;
   BodyContent: string;
   TokenResponse: TOAuth2TokenResponse;
+  LStream: TStream;
+  LBytes: TBytes;
+  LResponseStr: string;
 begin
-  HttpClient := THTTPClient.Create;
+  HttpClient := CreateHttpEngine;
+  
+  BodyContent := 'grant_type=client_credentials' +
+    '&client_id=' + TNetEncoding.URL.Encode(FClientId) +
+    '&client_secret=' + TNetEncoding.URL.Encode(FClientSecret);
+  if FScope <> '' then
+    BodyContent := BodyContent + '&scope=' + TNetEncoding.URL.Encode(FScope);
+
+  Body := TStringStream.Create(BodyContent, TEncoding.UTF8);
   try
-    HttpClient.ContentType := 'application/x-www-form-urlencoded';
+    Response := HttpClient.Execute('POST', FTokenUrl, Body,
+      [TDextNetHeader.Create('Content-Type', 'application/x-www-form-urlencoded')]);
 
-    BodyContent := 'grant_type=client_credentials' +
-      '&client_id=' + TNetEncoding.URL.Encode(FClientId) +
-      '&client_secret=' + TNetEncoding.URL.Encode(FClientSecret);
-    if FScope <> '' then
-      BodyContent := BodyContent + '&scope=' + TNetEncoding.URL.Encode(FScope);
+    LStream := Response.GetContentStream;
+    LStream.Position := 0;
+    SetLength(LBytes, LStream.Size);
+    if LStream.Size > 0 then
+      LStream.ReadBuffer(LBytes[0], LStream.Size);
+    LResponseStr := TEncoding.UTF8.GetString(LBytes);
 
-    Body := TStringStream.Create(BodyContent, TEncoding.UTF8);
-    try
-      Response := HttpClient.Post(FTokenUrl, Body, nil,
-        [TNetHeader.Create('Content-Type', 'application/x-www-form-urlencoded')]) as IHTTPResponse;
+    if (Response.GetStatusCode < 200) or (Response.GetStatusCode >= 300) then
+      raise Exception.CreateFmt(
+        'OAuth2 token request failed (HTTP %d): %s',
+        [Response.GetStatusCode, LResponseStr]);
 
-      if (Response.StatusCode < 200) or (Response.StatusCode >= 300) then
-        raise Exception.CreateFmt(
-          'OAuth2 token request failed (HTTP %d): %s',
-          [Response.StatusCode, Response.ContentAsString]);
+    TokenResponse := TDextJson.Deserialize<TOAuth2TokenResponse>(
+      LResponseStr,
+      TJsonSettings.Default.CaseInsensitive
+    );
 
-      TokenResponse := TDextJson.Deserialize<TOAuth2TokenResponse>(
-        Response.ContentAsString,
-        TJsonSettings.Default.CaseInsensitive
-      );
+    FCachedToken := TokenResponse.access_token;
+    if FCachedToken = '' then
+      raise Exception.Create('OAuth2 response missing access_token');
 
-      FCachedToken := TokenResponse.access_token;
-      if FCachedToken = '' then
-        raise Exception.Create('OAuth2 response missing access_token');
-
-      // Set expiration with 30-second safety margin
-      if TokenResponse.expires_in = 0 then
-        TokenResponse.expires_in := 3600;
-      FExpiresAt := IncSecond(Now, TokenResponse.expires_in - 30);
-    finally
-      Body.Free;
-    end;
+    // Set expiration with 30-second safety margin
+    if TokenResponse.expires_in = 0 then
+      TokenResponse.expires_in := 3600;
+    FExpiresAt := IncSecond(Now, TokenResponse.expires_in - 30);
   finally
-    HttpClient.Free;
+    Body.Free;
   end;
 end;
 

--- a/Sources/Net/Dext.Net.ConnectionPool.pas
+++ b/Sources/Net/Dext.Net.ConnectionPool.pas
@@ -1,28 +1,3 @@
-﻿{***************************************************************************}
-{                                                                           }
-{           Dext Framework                                                  }
-{                                                                           }
-{           Copyright (C) 2025 Cesar Romero & Dext Contributors             }
-{                                                                           }
-{           Licensed under the Apache License, Version 2.0 (the "License"); }
-{           you may not use this file except in compliance with the License.}
-{           You may obtain a copy of the License at                         }
-{                                                                           }
-{               http://www.apache.org/licenses/LICENSE-2.0                  }
-{                                                                           }
-{           Unless required by applicable law or agreed to in writing,      }
-{           software distributed under the License is distributed on an     }
-{           "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    }
-{           either express or implied. See the License for the specific     }
-{           language governing permissions and limitations under the        }
-{           License.                                                        }
-{                                                                           }
-{***************************************************************************}
-{                                                                           }
-{  Author:  Cesar Romero & Antigravity                                      }
-{  Created: 2026-01-21                                                      }
-{                                                                           }
-{***************************************************************************}
 unit Dext.Net.ConnectionPool;
 
 interface
@@ -31,17 +6,17 @@ uses
   System.Classes,
   Dext.Collections,
   Dext.Collections.Stack,
-  System.Net.HttpClient,
+  Dext.Net.Engine,
   System.SyncObjs,
   System.SysUtils;
 
 type
   /// <summary>
-  ///   Connection Pool for THttpClient instances to improve performance through reuse.
+  ///   Connection Pool for IDextHttpEngine instances to improve performance through reuse.
   /// </summary>
   TConnectionPool = class
   private
-    FPool: IStack<THttpClient>;
+    FPool: IStack<IDextHttpEngine>;
     FLock: TCriticalSection;
     FMaxPoolSize: Integer;
     FCount: Integer;
@@ -49,8 +24,8 @@ type
     constructor Create(AMaxPoolSize: Integer = 32);
     destructor Destroy; override;
     
-    function Acquire: THttpClient;
-    procedure Release(AClient: THttpClient);
+    function Acquire: IDextHttpEngine;
+    procedure Release(AClient: IDextHttpEngine);
     procedure Clear;
     
     property MaxPoolSize: Integer read FMaxPoolSize write FMaxPoolSize;
@@ -65,7 +40,7 @@ constructor TConnectionPool.Create(AMaxPoolSize: Integer);
 begin
   inherited Create;
   FMaxPoolSize := AMaxPoolSize;
-  FPool := TCollections.CreateStack<THttpClient>;
+  FPool := TCollections.CreateStack<IDextHttpEngine>;
   FLock := TCriticalSection.Create;
   FCount := 0;
 end;
@@ -78,7 +53,7 @@ begin
   inherited;
 end;
 
-function TConnectionPool.Acquire: THttpClient;
+function TConnectionPool.Acquire: IDextHttpEngine;
 begin
   FLock.Enter;
   try
@@ -88,7 +63,7 @@ begin
     end
     else
     begin
-      Result := THttpClient.Create;
+      Result := CreateHttpEngine;
       Inc(FCount);
     end;
   finally
@@ -96,7 +71,7 @@ begin
   end;
 end;
 
-procedure TConnectionPool.Release(AClient: THttpClient);
+procedure TConnectionPool.Release(AClient: IDextHttpEngine);
 begin
   if not Assigned(AClient) then Exit;
   
@@ -108,7 +83,6 @@ begin
     end
     else
     begin
-      AClient.Free;
       Dec(FCount);
     end;
   finally
@@ -121,7 +95,7 @@ begin
   FLock.Enter;
   try
     while FPool.Count > 0 do
-      FPool.Pop.Free;
+      FPool.Pop;
     FCount := 0;
   finally
     FLock.Leave;

--- a/Sources/Net/Dext.Net.Engine.pas
+++ b/Sources/Net/Dext.Net.Engine.pas
@@ -1,0 +1,351 @@
+{***************************************************************************}
+{                                                                           }
+{           Dext Framework                                                  }
+{                                                                           }
+{           Copyright (C) 2025 Cesar Romero & Dext Contributors             }
+{                                                                           }
+{           Licensed under the Apache License, Version 2.0 (the "License"); }
+{           you may not use this file except in compliance with the License.}
+{           You may obtain a copy of the License at                         }
+{                                                                           }
+{               http://www.apache.org/licenses/LICENSE-2.0                  }
+{                                                                           }
+{           Unless required by applicable law or agreed to in writing,      }
+{           software distributed under the License is distributed on an     }
+{           "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    }
+{           either express or implied. See the License for the specific     }
+{           language governing permissions and limitations under the        }
+{           License.                                                        }
+{                                                                           }
+{***************************************************************************}
+unit Dext.Net.Engine;
+
+interface
+
+{$IF defined(DEXT_FORCE_INDY) or (CompilerVersion < 29.0)}
+uses
+  System.Classes,
+  System.SysUtils,
+  System.Generics.Collections;
+
+type
+  TDextNetHeader = record
+    Name: string;
+    Value: string;
+    constructor Create(const AName, AValue: string);
+  end;
+  TDextNetHeaders = TArray<TDextNetHeader>;
+{$ELSE}
+uses
+  System.Classes,
+  System.SysUtils,
+  System.Generics.Collections,
+  System.Net.URLClient,
+  System.Net.HttpClient;
+
+type
+  TDextNetHeader = System.Net.URLClient.TNetHeader;
+  TDextNetHeaders = System.Net.URLClient.TNetHeaders;
+{$ENDIF}
+
+type
+  IDextHttpResponse = interface
+    ['{F2C4E6A8-0246-80AC-CE02-4680ACE02468}']
+    function GetStatusCode: Integer;
+    function GetStatusText: string;
+    function GetContentStream: TStream;
+    function GetHeaders: TDextNetHeaders;
+  end;
+
+  IDextHttpEngine = interface
+    ['{B9D8A7C6-B5E4-4D3C-2B1A-0F9E8D7C6B5A}']
+    procedure SetConnectionTimeout(AMilliseconds: Integer);
+    procedure SetSendTimeout(AMilliseconds: Integer);
+    procedure SetResponseTimeout(AMilliseconds: Integer);
+    function Execute(const AMethod, AUrl: string; const ABody: TStream; const AHeaders: TDextNetHeaders): IDextHttpResponse;
+  end;
+
+function CreateHttpEngine: IDextHttpEngine;
+
+implementation
+
+{$IF defined(DEXT_FORCE_INDY) or (CompilerVersion < 29.0)}
+uses
+  IdHTTP,
+  IdSSLOpenSSL,
+  IdSSL;
+{$ENDIF}
+
+{$IF defined(DEXT_FORCE_INDY) or (CompilerVersion < 29.0)}
+{ TDextNetHeader }
+
+constructor TDextNetHeader.Create(const AName, AValue: string);
+begin
+  Name := AName;
+  Value := AValue;
+end;
+{$ENDIF}
+
+type
+  TDextHttpResponseImpl = class(TInterfacedObject, IDextHttpResponse)
+  private
+    FStatusCode: Integer;
+    FStatusText: string;
+    FContentStream: TMemoryStream;
+    FHeaders: TDextNetHeaders;
+  public
+    constructor Create(AStatusCode: Integer; const AStatusText: string; AStream: TStream; const AHeaders: TDextNetHeaders);
+    destructor Destroy; override;
+    function GetStatusCode: Integer;
+    function GetStatusText: string;
+    function GetContentStream: TStream;
+    function GetHeaders: TDextNetHeaders;
+  end;
+
+{ TDextHttpResponseImpl }
+
+constructor TDextHttpResponseImpl.Create(AStatusCode: Integer; const AStatusText: string; AStream: TStream; const AHeaders: TDextNetHeaders);
+begin
+  inherited Create;
+  FStatusCode := AStatusCode;
+  FStatusText := AStatusText;
+  FHeaders := AHeaders;
+  FContentStream := TMemoryStream.Create;
+  if Assigned(AStream) then
+  begin
+    AStream.Position := 0;
+    FContentStream.CopyFrom(AStream, AStream.Size);
+    FContentStream.Position := 0;
+  end;
+end;
+
+destructor TDextHttpResponseImpl.Destroy;
+begin
+  FContentStream.Free;
+  inherited;
+end;
+
+function TDextHttpResponseImpl.GetContentStream: TStream;
+begin
+  Result := FContentStream;
+end;
+
+function TDextHttpResponseImpl.GetHeaders: TDextNetHeaders;
+begin
+  Result := FHeaders;
+end;
+
+function TDextHttpResponseImpl.GetStatusCode: Integer;
+begin
+  Result := FStatusCode;
+end;
+
+function TDextHttpResponseImpl.GetStatusText: string;
+begin
+  Result := FStatusText;
+end;
+
+{$IF defined(DEXT_FORCE_INDY) or (CompilerVersion < 29.0)}
+type
+  TDextIndyHttpEngine = class(TInterfacedObject, IDextHttpEngine)
+  private
+    FIdHttp: TIdHTTP;
+  public
+    constructor Create;
+    destructor Destroy; override;
+    procedure SetConnectionTimeout(AMilliseconds: Integer);
+    procedure SetSendTimeout(AMilliseconds: Integer);
+    procedure SetResponseTimeout(AMilliseconds: Integer);
+    function Execute(const AMethod, AUrl: string; const ABody: TStream; const AHeaders: TDextNetHeaders): IDextHttpResponse;
+  end;
+
+{ TDextIndyHttpEngine }
+
+constructor TDextIndyHttpEngine.Create;
+begin
+  inherited Create;
+  FIdHttp := TIdHTTP.Create(nil);
+  FIdHttp.HandleRedirects := True;
+end;
+
+destructor TDextIndyHttpEngine.Destroy;
+begin
+  FIdHttp.Free;
+  inherited;
+end;
+
+procedure TDextIndyHttpEngine.SetConnectionTimeout(AMilliseconds: Integer);
+begin
+  FIdHttp.ConnectTimeout := AMilliseconds;
+end;
+
+procedure TDextIndyHttpEngine.SetSendTimeout(AMilliseconds: Integer);
+begin
+  // Indy does not have a separate send timeout, we map to ReadTimeout
+  FIdHttp.ReadTimeout := AMilliseconds;
+end;
+
+procedure TDextIndyHttpEngine.SetResponseTimeout(AMilliseconds: Integer);
+begin
+  FIdHttp.ReadTimeout := AMilliseconds;
+end;
+
+function TDextIndyHttpEngine.Execute(const AMethod, AUrl: string; const ABody: TStream; const AHeaders: TDextNetHeaders): IDextHttpResponse;
+var
+  ResponseStream: TMemoryStream;
+  LSSL: TIdSSLIOHandlerSocketOpenSSL;
+  I: Integer;
+  LHeadersList: TList<TDextNetHeader>;
+  LHeader: TDextNetHeader;
+begin
+  FIdHttp.Request.CustomHeaders.Clear;
+  for I := 0 to High(AHeaders) do
+  begin
+    if SameText(AHeaders[I].Name, 'User-Agent') then
+      FIdHttp.Request.UserAgent := AHeaders[I].Value
+    else if SameText(AHeaders[I].Name, 'Content-Type') then
+      FIdHttp.Request.ContentType := AHeaders[I].Value
+    else if SameText(AHeaders[I].Name, 'Accept') then
+      FIdHttp.Request.Accept := AHeaders[I].Value
+    else
+      FIdHttp.Request.CustomHeaders.Values[AHeaders[I].Name] := AHeaders[I].Value;
+  end;
+
+  if AUrl.StartsWith('https', True) then
+  begin
+    if not Assigned(FIdHttp.IOHandler) then
+    begin
+      LSSL := TIdSSLIOHandlerSocketOpenSSL.Create(FIdHttp);
+      LSSL.SSLOptions.Method := sslvTLSv1_2;
+      LSSL.SSLOptions.Mode := sslmClient;
+      FIdHttp.IOHandler := LSSL;
+    end;
+  end;
+
+  ResponseStream := TMemoryStream.Create;
+  try
+    try
+      if SameText(AMethod, 'GET') then
+        FIdHttp.Get(AUrl, ResponseStream)
+      else if SameText(AMethod, 'POST') then
+        FIdHttp.Post(AUrl, ABody, ResponseStream)
+      else if SameText(AMethod, 'PUT') then
+        FIdHttp.Put(AUrl, ABody, ResponseStream)
+      else if SameText(AMethod, 'DELETE') then
+        FIdHttp.Delete(AUrl, ResponseStream)
+      else
+        FIdHttp.DoRequest(AMethod, AUrl, ABody, ResponseStream, []);
+    except
+      on E: Exception do
+      begin
+        ResponseStream.Free;
+        raise;
+      end;
+    end;
+
+    LHeadersList := TList<TDextNetHeader>.Create;
+    try
+      for I := 0 to FIdHttp.Response.RawHeaders.Count - 1 do
+      begin
+        var LLine := FIdHttp.Response.RawHeaders[I];
+        var LIdx := LLine.IndexOf(':');
+        if LIdx > 0 then
+          LHeadersList.Add(TDextNetHeader.Create(
+            LLine.Substring(0, LIdx).Trim,
+            LLine.Substring(LIdx + 1).Trim
+          ));
+      end;
+      Result := TDextHttpResponseImpl.Create(
+        FIdHttp.ResponseCode,
+        FIdHttp.ResponseText,
+        ResponseStream,
+        LHeadersList.ToArray
+      );
+    finally
+      LHeadersList.Free;
+      ResponseStream.Free;
+    end;
+  except
+    raise;
+  end;
+end;
+
+{$ELSE}
+
+type
+  TDextNetHttpEngine = class(TInterfacedObject, IDextHttpEngine)
+  private
+    FClient: THTTPClient;
+  public
+    constructor Create;
+    destructor Destroy; override;
+    procedure SetConnectionTimeout(AMilliseconds: Integer);
+    procedure SetSendTimeout(AMilliseconds: Integer);
+    procedure SetResponseTimeout(AMilliseconds: Integer);
+    function Execute(const AMethod, AUrl: string; const ABody: TStream; const AHeaders: TDextNetHeaders): IDextHttpResponse;
+  end;
+
+{ TDextNetHttpEngine }
+
+constructor TDextNetHttpEngine.Create;
+begin
+  inherited Create;
+  FClient := THTTPClient.Create;
+end;
+
+destructor TDextNetHttpEngine.Destroy;
+begin
+  FClient.Free;
+  inherited;
+end;
+
+procedure TDextNetHttpEngine.SetConnectionTimeout(AMilliseconds: Integer);
+begin
+  FClient.ConnectionTimeout := AMilliseconds;
+end;
+
+procedure TDextNetHttpEngine.SetSendTimeout(AMilliseconds: Integer);
+begin
+  FClient.SendTimeout := AMilliseconds;
+end;
+
+procedure TDextNetHttpEngine.SetResponseTimeout(AMilliseconds: Integer);
+begin
+  FClient.ResponseTimeout := AMilliseconds;
+end;
+
+function TDextNetHttpEngine.Execute(const AMethod, AUrl: string; const ABody: TStream; const AHeaders: TDextNetHeaders): IDextHttpResponse;
+var
+  i: Integer;
+  NetHeadersList: TList<TNetHeader>;
+  Response: IHTTPResponse;
+begin
+  NetHeadersList := TList<TNetHeader>.Create;
+  try
+    for i := 0 to High(AHeaders) do
+      NetHeadersList.Add(TNetHeader.Create(AHeaders[i].Name, AHeaders[i].Value));
+      
+    Response := FClient.Execute(AMethod, TURI.Create(AUrl), ABody, nil, NetHeadersList.ToArray) as IHTTPResponse;
+    Result := TDextHttpResponseImpl.Create(
+      Response.StatusCode,
+      Response.StatusText,
+      Response.ContentStream,
+      Response.Headers
+    );
+  finally
+    NetHeadersList.Free;
+  end;
+end;
+
+{$ENDIF}
+
+function CreateHttpEngine: IDextHttpEngine;
+begin
+  {$IF defined(DEXT_FORCE_INDY) or (CompilerVersion < 29.0)}
+  Result := TDextIndyHttpEngine.Create;
+  {$ELSE}
+  Result := TDextNetHttpEngine.Create;
+  {$ENDIF}
+end;
+
+end.

--- a/Sources/Net/Dext.Net.RestClient.pas
+++ b/Sources/Net/Dext.Net.RestClient.pas
@@ -29,8 +29,6 @@ interface
 
 uses
   System.Classes,
-  System.Net.HttpClient,
-  System.Net.URLClient,
   System.Rtti,
   System.SyncObjs,
   System.SysUtils,
@@ -39,6 +37,7 @@ uses
   Dext.Http.Request,
   Dext.Net.Authentication,
   Dext.Net.ConnectionPool,
+  Dext.Net.Engine,
   Dext.Resilience,
   Dext.Threading.Async,
   Dext.Threading.CancellationToken;
@@ -65,8 +64,8 @@ uses
     /// <param name="AName">Header name (e.g. "Content-Type", "X-Request-Id").</param>
     /// <returns>The header value, or empty string if not found.</returns>
     function GetHeader(const AName: string): string;
-    /// <summary>Returns all response headers as a TNetHeaders array.</summary>
-    function GetHeaders: TNetHeaders;
+    /// <summary>Returns all response headers as a TDextNetHeaders array.</summary>
+    function GetHeaders: TDextNetHeaders;
     
     /// <summary>Returns true if the status code is in the 2xx range (200-299).</summary>
     function GetIsSuccess: Boolean;
@@ -94,18 +93,18 @@ uses
     FStatusCode: Integer;
     FStatusText: string;
     FContentStream: TMemoryStream;
-    FHeaders: TNetHeaders;
+    FHeaders: TDextNetHeaders;
   protected
     function GetStatusCode: Integer;
     function GetStatusText: string;
     function GetContentStream: TStream;
     function GetContentString: string;
     function GetHeader(const AName: string): string;
-    function GetHeaders: TNetHeaders;
+    function GetHeaders: TDextNetHeaders;
     function GetIsSuccess: Boolean;
   public
     constructor Create(AStatusCode: Integer; const AStatusText: string; AStream: TStream;
-      const AHeaders: TNetHeaders = nil);
+      const AHeaders: TDextNetHeaders = nil);
     destructor Destroy; override;
   end;
 
@@ -116,7 +115,7 @@ uses
     function GetData: T;
   public
     constructor Create(AStatusCode: Integer; const AStatusText: string; AStream: TStream;
-      AData: T; const AHeaders: TNetHeaders = nil);
+      AData: T; const AHeaders: TDextNetHeaders = nil);
     destructor Destroy; override;
   end;
 
@@ -363,7 +362,7 @@ end;
 { TRestResponse }
 
 constructor TRestResponse.Create(AStatusCode: Integer; const AStatusText: string; AStream: TStream;
-  const AHeaders: TNetHeaders);
+  const AHeaders: TDextNetHeaders);
 begin
   inherited Create;
   FStatusCode := AStatusCode;
@@ -411,7 +410,7 @@ begin
   Result := '';
 end;
 
-function TRestResponse.GetHeaders: TNetHeaders;
+function TRestResponse.GetHeaders: TDextNetHeaders;
 begin
   Result := FHeaders;
 end;
@@ -434,7 +433,7 @@ end;
 { TRestResponse<T> }
 
 constructor TRestResponse<T>.Create(AStatusCode: Integer; const AStatusText: string; AStream: TStream;
-  AData: T; const AHeaders: TNetHeaders);
+  AData: T; const AHeaders: TDextNetHeaders);
 begin
   inherited Create(AStatusCode, AStatusText, AStream, AHeaders);
   FData := AData;
@@ -593,10 +592,10 @@ function TRestClientImpl.ExecuteAsync(AMethod: TDextHttpMethod; const AEndpoint:
 var
   Url: string;
   Retries: Integer;
-  Headers: TNetHeaders;
+  Headers: TDextNetHeaders;
   Timeout: Integer;
   Auth: IAuthenticationProvider;
-  LHeadList: TList<TNetHeader>;
+  LHeadList: TList<TDextNetHeader>;
   LPair: TPair<string, string>;
   I: Integer;
   HasContentType: Boolean;
@@ -608,12 +607,12 @@ begin
   Auth := FAuthProvider;
   
   // Snapshot headers (Thread Safety)
-  LHeadList := TList<TNetHeader>.Create;
+  LHeadList := TList<TDextNetHeader>.Create;
   try
     FLock.Enter;
     try
       for LPair in FHeaders do
-        LHeadList.Add(TNetHeader.Create(LPair.Key, LPair.Value));
+        LHeadList.Add(TDextNetHeader.Create(LPair.Key, LPair.Value));
     finally
       FLock.Leave;
     end;
@@ -621,15 +620,15 @@ begin
     if Assigned(Auth) then
     begin
        if Auth is TApiKeyAuthProvider then
-         LHeadList.Add(TNetHeader.Create(TApiKeyAuthProvider(Auth).Key, Auth.GetHeaderValue))
+         LHeadList.Add(TDextNetHeader.Create(TApiKeyAuthProvider(Auth).Key, Auth.GetHeaderValue))
        else
-         LHeadList.Add(TNetHeader.Create('Authorization', Auth.GetHeaderValue));
+         LHeadList.Add(TDextNetHeader.Create('Authorization', Auth.GetHeaderValue));
     end;
-
+ 
     if Assigned(AHeaders) then
     begin
       for LPair in AHeaders do
-        LHeadList.Add(TNetHeader.Create(LPair.Key, LPair.Value));
+        LHeadList.Add(TDextNetHeader.Create(LPair.Key, LPair.Value));
     end;
 
     HasContentType := False;
@@ -654,7 +653,7 @@ begin
         else ContentTypeStr := '';
       end;
       if ContentTypeStr <> '' then
-        LHeadList.Add(TNetHeader.Create('Content-Type', ContentTypeStr));
+        LHeadList.Add(TDextNetHeader.Create('Content-Type', ContentTypeStr));
     end;
     
     Headers := LHeadList.ToArray;
@@ -699,19 +698,19 @@ begin
               TFunc<TValue>(
                 function: TValue
                 var
-                  HttpClient: THttpClient;
-                  Response: IHTTPResponse;
+                  HttpClient: IDextHttpEngine;
+                  Response: IDextHttpResponse;
                 begin
                   HttpClient := TConnectionPool(TRestClient.FSharedPool).Acquire;
                   try
-                    HttpClient.ConnectionTimeout := Timeout;
-                    HttpClient.SendTimeout := Timeout;
-                    HttpClient.ResponseTimeout := Timeout;
+                    HttpClient.SetConnectionTimeout(Timeout);
+                    HttpClient.SetSendTimeout(Timeout);
+                    HttpClient.SetResponseTimeout(Timeout);
 
-                    Response := HttpClient.Execute(MethodStr, Url, ABody, nil, Headers) as IHTTPResponse;
-                    Result := TValue.From<IRestResponse>(TRestResponse.Create(Response.StatusCode, Response.StatusText, Response.ContentStream, Response.GetHeaders));
+                    Response := HttpClient.Execute(MethodStr, Url, ABody, Headers);
+                    Result := TValue.From<IRestResponse>(TRestResponse.Create(Response.GetStatusCode, Response.GetStatusText, Response.GetContentStream, Response.GetHeaders));
                     
-                    LSpan.SetAttribute('http.status_code', Response.StatusCode);
+                    LSpan.SetAttribute('http.status_code', Response.GetStatusCode);
                     LSpan.SetStatus('Success');
                   finally
                     TConnectionPool(TRestClient.FSharedPool).Release(HttpClient);

--- a/Sources/README.md
+++ b/Sources/README.md
@@ -15,3 +15,5 @@ Para manter a compatibilidade com múltiplas versões do Delphi (incluindo vers�
 
 > [!NOTE]
 > Pacotes que utilizam recursos introduzidos a partir do Delphi XE7/XE8 (como o `Dext.Net.Core`, que faz uso do `TNetHTTPClient`) não são suportados em versões anteriores.
+
+Para saber como atualizar e regenerar os pacotes das versões legadas automaticamente, consulte o guia de [Sincronização de Pacotes Legados](file:///C:/dev/Dext/DextRepository/Docs/Packages_Synchronization.md).


### PR DESCRIPTION
- Introduce IDextHttpEngine and IDextHttpResponse abstractions to isolate System.Net dependencies.
- Implement TDextNetHttpEngine (System.Net) and TDextIndyHttpEngine (Indy fallback) to support legacy Delphi versions (XE2-XE7).
- Refactor TConnectionPool, TRestClient, and TOAuth2ClientCredentialsProvider to use the new connection pool engine abstraction.
- Fix Access Violation in TStack<T> (Dext.Collections.Stack.pas) by correctly forwarding IsManagedType to the underlying TRawList constructor.
- Update documentation including Delphi_Compatibility_Matrix, ROADMAP, Features Implemented Index, Dext Book chapters, and Spec S37.
- Sync package files and legacy configuration support.