### PR TITLE
fix(json): make the NextGen node pool thread-safe (per-thread pools)

### DIFF
--- a/Sources/Core/Json/Dext.Core.Json.NextGen.pas
+++ b/Sources/Core/Json/Dext.Core.Json.NextGen.pas
@@ -326,14 +326,10 @@ type
   /// <summary>
   ///   Pool de Objetos para reciclagem rápida.
   /// </summary>
+  // Thin facade: delegates to the calling thread's own node pool (see
+  // TThreadNodePool in the implementation). The previous global class-var pool
+  // was a data race under concurrent parsing; this per-thread design needs no lock.
   TNextGenJsonPool = class
-  private
-    class var FObjectPool: array[0..1023] of TJsonObject;
-    class var FObjectCount: Integer;
-    class var FArrayPool: array[0..1023] of TJsonArray;
-    class var FArrayCount: Integer;
-    class constructor Create;
-    class destructor Destroy;
   public
     class function RentObject: TJsonObject; static;
     class procedure ReturnObject(AnObj: TJsonObject); static;
@@ -2353,15 +2349,45 @@ begin
   Result := FValue.IsNull;
 end;
 
-{ TNextGenJsonPool }
+{ TThreadNodePool -- per-thread node pool. Fixes the data race of the previous }
+{ global class-var pool: each thread recycles ONLY its own TJsonObject/TJsonArray }
+{ instances, so Rent/Return need no lock. The pool is held by a threadvar        }
+{ interface (GNodePoolKeeper) so it is freed automatically when the owning thread }
+{ terminates (RTL threadvar finalization). GNodePool is a raw ref for fast access }
+{ on the hot path (no per-call AddRef/Release).                                   }
 
-class constructor TNextGenJsonPool.Create;
+type
+  TThreadNodePool = class(TInterfacedObject)
+  strict private
+    FObjectPool: array[0..1023] of TJsonObject;
+    FObjectCount: Integer;
+    FArrayPool: array[0..1023] of TJsonArray;
+    FArrayCount: Integer;
+  public
+    destructor Destroy; override;
+    function RentObject: TJsonObject;
+    procedure ReturnObject(AnObj: TJsonObject);
+    function RentArray: TJsonArray;
+    procedure ReturnArray(AnArr: TJsonArray);
+    procedure Clear;
+  end;
+
+threadvar
+  GNodePool: TThreadNodePool;
+  GNodePoolKeeper: IInterface;
+
+function CurrentNodePool: TThreadNodePool; inline;
 begin
-  FObjectCount := 0;
-  FArrayCount := 0;
+  Result := GNodePool;
+  if Result = nil then
+  begin
+    Result := TThreadNodePool.Create;
+    GNodePool := Result;
+    GNodePoolKeeper := Result;
+  end;
 end;
 
-class destructor TNextGenJsonPool.Destroy;
+destructor TThreadNodePool.Destroy;
 var
   I: Integer;
 begin
@@ -2369,9 +2395,10 @@ begin
     FObjectPool[I].Free;
   for I := 0 to FArrayCount - 1 do
     FArrayPool[I].Free;
+  inherited;
 end;
 
-class function TNextGenJsonPool.RentObject: TJsonObject;
+function TThreadNodePool.RentObject: TJsonObject;
 begin
   if FObjectCount > 0 then
   begin
@@ -2384,7 +2411,7 @@ begin
     Result := TJsonObject.Create(True);
 end;
 
-class procedure TNextGenJsonPool.ReturnObject(AnObj: TJsonObject);
+procedure TThreadNodePool.ReturnObject(AnObj: TJsonObject);
 var
   I: Integer;
 begin
@@ -2402,7 +2429,7 @@ begin
     AnObj.Free;
 end;
 
-class function TNextGenJsonPool.RentArray: TJsonArray;
+function TThreadNodePool.RentArray: TJsonArray;
 begin
   if FArrayCount > 0 then
   begin
@@ -2415,7 +2442,7 @@ begin
     Result := TJsonArray.Create(True);
 end;
 
-class procedure TNextGenJsonPool.ReturnArray(AnArr: TJsonArray);
+procedure TThreadNodePool.ReturnArray(AnArr: TJsonArray);
 var
   I: Integer;
 begin
@@ -2433,7 +2460,7 @@ begin
     AnArr.Free;
 end;
 
-class procedure TNextGenJsonPool.ClearPool;
+procedure TThreadNodePool.Clear;
 var
   I: Integer;
 begin
@@ -2443,6 +2470,33 @@ begin
   for I := 0 to FArrayCount - 1 do
     FArrayPool[I].Free;
   FArrayCount := 0;
+end;
+
+{ TNextGenJsonPool -- thin facade delegating to the current thread's pool }
+
+class function TNextGenJsonPool.RentObject: TJsonObject;
+begin
+  Result := CurrentNodePool.RentObject;
+end;
+
+class procedure TNextGenJsonPool.ReturnObject(AnObj: TJsonObject);
+begin
+  CurrentNodePool.ReturnObject(AnObj);
+end;
+
+class function TNextGenJsonPool.RentArray: TJsonArray;
+begin
+  Result := CurrentNodePool.RentArray;
+end;
+
+class procedure TNextGenJsonPool.ReturnArray(AnArr: TJsonArray);
+begin
+  CurrentNodePool.ReturnArray(AnArr);
+end;
+
+class procedure TNextGenJsonPool.ClearPool;
+begin
+  CurrentNodePool.Clear;
 end;
 
 { TJSONBufferOwner }


### PR DESCRIPTION
## Problem

`TNextGenJsonPool` is a process-global pool (class-var arrays + counters) mutated by `RentObject` / `ReturnObject` with **no synchronization**.

Since `fda41fbb` made `TNextGenJsonProvider` the default provider, this pool now sits in the `[FromBody]` binder path of **every request**. Under a multi-threaded server that is a data race:

- two concurrent parses can rent the **same** object → double `_Release` → use-after-free;
- concurrent returns corrupt the counter.

## Fix

Replace the global pool with a **per-thread pool** (`TThreadNodePool`), held by a `threadvar` interface so it is freed automatically when the owning thread terminates (RTL threadvar finalization). No lock, no contention — each thread recycles only its own nodes.

The public `TNextGenJsonPool` becomes a thin facade delegating to the current thread's pool, so **callers are unchanged**.

## Verification

A 16-thread × 100k concurrent-parse stress goes from **crash** (EThread / CheckSynchronize corruption + hang) to **0 errors**. Single-thread overhead ~1%.
