### PR TITLE
perf(json): SIMD (SSE2) string-body scan in NextGen ScanString

### DIFF
--- a/Sources/Core/Json/Dext.Core.Json.NextGen.pas
+++ b/Sources/Core/Json/Dext.Core.Json.NextGen.pas
@@ -141,6 +141,16 @@ type
     function ParseObject: IDextJsonObject;
     function ParseArray: IDextJsonArray;
   public
+    // Scansione SIMD (SSE2) del CORPO di una stringa JSON: ritorna l'offset
+    // (0-based) del primo byte che e' '"' (0x22), '\' (0x5C) o un carattere di
+    // controllo (< 0x20); ritorna Len se nessuno di questi appare nei primi Len
+    // byte. E' il set di stop CORRETTO per ScanString (i caratteri strutturali
+    // { } [ ] , : sono legali dentro una stringa e NON devono fermarla).
+    class function ScanStringBody_SSE2(
+      Ptr: PByte;
+      Len: Integer
+    ): Integer; static;
+
     class function ScanStructural_SSE42(
       Ptr: PByte;
       Length: Integer
@@ -613,12 +623,19 @@ var
   B: Byte;
   HexIdx: Integer;
   HexByte: Byte;
+  Rem: NativeInt;
 begin
   while APtr < FEnd do
   begin
-    while (APtr < FEnd) and (APtr^ >= 32) and
-          (APtr^ <> Ord('"')) and (APtr^ <> Ord('\')) do
-      Inc(APtr);
+    // Scansione del corpo stringa: sui tratti lunghi (>= 16 byte) usa la SIMD
+    // (SSE2), altrimenti il loop scalare per i residui corti (tipici DTO).
+    Rem := FEnd - APtr;
+    if Rem >= 16 then
+      Inc(APtr, ScanStringBody_SSE2(APtr, Integer(Rem)))
+    else
+      while (APtr < FEnd) and (APtr^ >= 32) and
+            (APtr^ <> Ord('"')) and (APtr^ <> Ord('\')) do
+        Inc(APtr);
 
     if APtr >= FEnd then
       Break;
@@ -770,6 +787,96 @@ begin
   end;
   Result := Val * Sign;
 end;
+
+class function TNextGenJsonParser.ScanStringBody_SSE2(
+  Ptr: PByte;
+  Len: Integer
+): Integer;
+{$IF defined(CPUX64) and defined(MSWINDOWS)}
+asm
+  // Win64: RCX = Ptr, EDX = Len. Ritorno in EAX = offset del primo byte di
+  // stop ('"' / '\' / <0x20), oppure Len se nessuno appare. Puro SSE2
+  // (baseline su x64): niente pcmpistri (la terminazione implicita su NUL
+  // rende insidiosa la gestione dei control char). Nessun over-read: i blocchi
+  // da 16 byte partono solo quando restano >= 16 byte, il resto e' scalare.
+  mov     r8, rcx              // r8 = base ptr
+  movsxd  r9, edx              // r9 = Len
+  xor     r10, r10             // r10 = i = 0
+
+  // Costanti broadcast su tutti i 16 lane: 0x22 ('"'), 0x5C ('\'), 0x1F.
+  mov     eax, $22222222
+  movd    xmm1, eax
+  pshufd  xmm1, xmm1, 0
+  mov     eax, $5C5C5C5C
+  movd    xmm2, eax
+  pshufd  xmm2, xmm2, 0
+  mov     eax, $1F1F1F1F
+  movd    xmm3, eax
+  pshufd  xmm3, xmm3, 0
+
+@Loop16:
+  mov     rax, r9
+  sub     rax, r10
+  cmp     rax, 16
+  jl      @Tail
+  movdqu  xmm0, [r8 + r10]     // 16 byte
+  movdqa  xmm4, xmm0
+  pcmpeqb xmm4, xmm1           // == '"'
+  movdqa  xmm5, xmm0
+  pcmpeqb xmm5, xmm2           // == '\'
+  por     xmm4, xmm5
+  movdqa  xmm5, xmm0
+  pminub  xmm5, xmm3           // min(v, 0x1F)
+  pcmpeqb xmm5, xmm0           // == v  -> byte <= 0x1F (control)
+  por     xmm4, xmm5
+  pmovmskb eax, xmm4
+  test    eax, eax
+  jnz     @FoundVec
+  add     r10, 16
+  jmp     @Loop16
+
+@FoundVec:
+  bsf     eax, eax             // indice del primo bit -> 0..15
+  add     r10, rax
+  mov     rax, r10
+  ret
+
+@Tail:
+  cmp     r10, r9
+  jge     @NotFound
+  movzx   eax, byte ptr [r8 + r10]
+  cmp     al, $22
+  je      @FoundScalar
+  cmp     al, $5C
+  je      @FoundScalar
+  cmp     al, $20
+  jb      @FoundScalar         // < 0x20 (unsigned)
+  inc     r10
+  jmp     @Tail
+
+@FoundScalar:
+  mov     rax, r10
+  ret
+
+@NotFound:
+  mov     rax, r9              // = Len (nessuno stop nei primi Len byte)
+end;
+{$ELSE}
+var
+  I: Integer;
+  B: Byte;
+begin
+  I := 0;
+  while I < Len do
+  begin
+    B := Ptr[I];
+    if (B = Ord('"')) or (B = Ord('\')) or (B < 32) then
+      Exit(I);
+    Inc(I);
+  end;
+  Result := Len;
+end;
+{$ENDIF}
 
 class function TNextGenJsonParser.ScanStructural_SSE42(
   Ptr: PByte;


### PR DESCRIPTION
Addresses the "NextGen SIMD scanner not wired in" reminder in #157.

The hot inner loop of `TNextGenJsonParser.ScanString` advanced byte-by-byte until the string terminator / escape / control char. On string-heavy payloads this dominates parse time.

## The change (`+110 / −3`, one file)

A new `ScanStringBody_SSE2` returns the offset of the first byte that is `"` (0x22), `\` (0x5C) or a control char (`< 0x20`) — the correct stop set for a JSON string body (the structural chars `{ } [ ] , :` are legal **inside** a string and must not stop it).

- Pure **SSE2** (baseline on x64): `movdqu` + `pcmpeqb` + `pminub` + `pmovmskb`. It deliberately avoids `pcmpistr*`, whose implicit-NUL termination makes control-char handling subtle.
- Wired into `ScanString` gated at **≥ 16 bytes remaining** in the buffer, so short trailing fields keep the scalar tail. No over-read: 16-byte blocks start only when 16 bytes remain.

### Why not the existing `ScanStructural_SSE42`

The pre-existing (dead) SSE4.2 helper searches the 8-char structural set `{ } [ ] , : " \`. That set is not a correct drop-in for any real loop: in `ScanString` it would stop on `{ } , :` that are legal inside strings and miss control chars; in the number/bareword loop it misses whitespace (so `123 ` wouldn't stop). It is left untouched; this PR adds the correct primitive instead.

## Benchmark

Intel i5-3450 (Ivy Bridge, SSE4.2), Windows 10 x64, Delphi 12 / dcc64 Release. ns per parse, minimum of 15 rounds of 40k iterations. `System.JSON` (RTL) and the `DextJsonDataObjects` fork are shown as reference points (best-of-5). The two NextGen runs were taken back-to-back; the reference parsers landed within 0.5 % across both.

| Payload | bytes | System.JSON | fork JDO | NextGen before | NextGen after | speed-up |
|---|--:|--:|--:|--:|--:|--:|
| **long-strings** (~115 B values) | 5 991 | 60 767 | 12 578 | 21 691 | **6 996** | **3.10×** |
| medium-mixed | 165 | 5 890 | 1 621 | 2 647 | 2 348 | ≈ noise |
| short-key-obj | 341 | 13 448 | 4 577 | 5 127 | 4 547 | ≈ noise |
| tiny-dto | 56 | 2 812 | 692 | 994 | 899 | ≈ noise |
| number-array | 1 538 | 56 245 | 11 072 | 38 150 | 37 398 | ≈ noise |

On `long-strings` throughput goes **263 → 817 MB/s**, and NextGen flips from **1.7× behind** the fork to **1.8× ahead** of it (and 8.7× ahead of `System.JSON`).

**Honest reading:** the win is concentrated where string values are long (many 16-byte blocks per string). On short-field payloads the scan finds the closing quote almost immediately, so SIMD is at best break-even — every measured delta is favourable, none is a regression, but those rows are within run-to-run spread (baseline sd up to ~7 % there) and shouldn't be read as a real speed-up. `number-array`, which never touches `ScanString`, is flat — confirming no collateral effect.

### Allocations (heap blocks per parse, pool warm)

This change is scan-only, so allocations are unchanged — but for context, the node-pool architecture keeps NextGen at **0 heap allocations per parse** at steady state, where the fork and the RTL rebuild an owned tree every time:

| Payload | NextGen | fork JDO | System.JSON |
|---|--:|--:|--:|
| number-array | **0** | 16 | 419 |
| short-key-obj | **0** | 81 | 164 |
| long-strings | **0** | 60 | 118 |
| medium-mixed | **0** | 29 | 57 |
| tiny-dto | **0** | 12 | 29 |

`GetMem`/`AllocMem`/`ReallocMem` calls per parse. NextGen is **0 before and after** this PR — that is where it earns its keep under concurrency, independent of single-parse ns/op.

## Correctness

- **341,860** differential checks of `ScanStringBody_SSE2` vs a scalar reference (every length 0–64, every stop position and type incl. NUL, 4 start offsets) — **0 failures**.
- **300,000** randomized fuzz comparisons — 0 mismatches.
- Parse round-trips: escapes, structural-chars-in-string, `\u`, exact 16-byte boundary.
- `Dext.Core` unit suite identical to clean `origin/main` (NextGen parser tests 7/7 pass).

The benchmark + correctness harness is available if useful for reproduction.
