### PR TITLE
perf(json): skip literal compares for numbers in NextGen ParseValue

### DIFF
--- a/Sources/Core/Json/Dext.Core.Json.NextGen.pas
+++ b/Sources/Core/Json/Dext.Core.Json.NextGen.pas
@@ -1051,11 +1051,17 @@ begin
     raise EJsonException.Create('Expected value');
 
   ValSpan := TByteSpan.Create(StartPos, FPtr - StartPos);
-  if ValSpan.EqualsString('true') then
+  // Dispatch sul PRIMO byte: solo 't'/'f'/'n' possono essere true/false/null.
+  // Per i numeri (primo byte cifra o '-') si saltano del tutto i confronti coi
+  // letterali -- EqualsString ri-scandisce ogni letterale per l'ASCII-check ed
+  // era chiamato fino a 3 volte per OGNI valore. Semantica invariata: un bareword
+  // non-numerico che non sia esattamente true/false/null cade comunque nel ramo
+  // numero (dove fallisce la validazione), esattamente come prima.
+  if (StartPos^ = Ord('t')) and ValSpan.EqualsString('true') then
     Val.Init(TDextJsonNodeType.jntBoolean, ValSpan)
-  else if ValSpan.EqualsString('false') then
+  else if (StartPos^ = Ord('f')) and ValSpan.EqualsString('false') then
     Val.Init(TDextJsonNodeType.jntBoolean, ValSpan)
-  else if ValSpan.EqualsString('null') then
+  else if (StartPos^ = Ord('n')) and ValSpan.EqualsString('null') then
     Val.Init(TDextJsonNodeType.jntNull, ValSpan)
   else
   begin


### PR DESCRIPTION
Small, safe win on the NextGen number/scalar parse path. Related to the NextGen performance work in #157.

## Problem

`ParseValue` classified every scalar value by calling `ValSpan.EqualsString` three times — `'true'`, `'false'`, `'null'` — before falling through to the number branch. `TByteSpan.EqualsString` re-scans the literal for an ASCII check on every call, so number-heavy JSON paid ~3 redundant literal walks (plus call overhead) per value, none of which can ever match a number.

## Change (`+9 / −3`, one file)

Dispatch on the **first byte**: only `t` / `f` / `n` can begin `true` / `false` / `null`, so numbers (first byte a digit or `-`) skip the literal compares entirely and go straight to number validation.

```pascal
if (StartPos^ = Ord('t')) and ValSpan.EqualsString('true') then ...
else if (StartPos^ = Ord('f')) and ValSpan.EqualsString('false') then ...
else if (StartPos^ = Ord('n')) and ValSpan.EqualsString('null') then ...
else
  <number validation, unchanged>
```

**Semantics are identical by construction.** Anything the old code matched as `true`/`false`/`null` necessarily begins with `t`/`f`/`n`, so the guarded `EqualsString` still runs and returns the same result. Anything else — including a `t`/`f`/`n` bareword that isn't the exact literal — falls through to the number branch exactly as before. The number-validation block is untouched.

## Benchmark

Intel i5-3450 (Ivy Bridge), Windows 10 x64, Delphi 12 / dcc64 Release. ns per parse, minimum of 10 rounds of 30k iterations; before/after taken back-to-back.

| Payload | before | after | speed-up |
|---|--:|--:|--:|
| **number-array** (200 numbers) | 38 431 | **31 448** | **1.22×** |
| tiny-dto (2 numbers + 1 bool) | 928 | 864 | 1.07× |
| medium-mixed (numbers/bool/null) | 2 553 | 2 419 | 1.06× |
| short-key-obj / long-strings (strings only) | — | — | flat |

Pure-string payloads are unchanged (they never reach this branch), confirming the change is localized. Allocations are unchanged (0/parse at steady state).

## Correctness

`Dext.Core` unit suite identical to clean `origin/main` — NextGen parser tests 7/7 pass, including `TestParsePrimitives` (int/double/bool/null) and `TestValidationExceptions` (malformed JSON).

## Honest note (not part of this PR)

This closes only part of the gap to `DextJsonDataObjects` on number arrays (after: 31 448 vs the fork's ~11 100 ns/op). The remaining cost isn't the character scan (~14 char-iterations, ~14 ns of a ~157 ns/number budget) — it's structural per-value overhead: the `TNextGenJsonValue` record (managed `string` + interface fields) is copied twice per value, plus lazy materialization. That's core to the value representation, so I've left it untouched here; flagging it in case it's useful for the S56 direction.
