### PR TITLE
Feature/unidac support

### DIFF
--- a/Examples/03-Data/Orm.UniDACDemo/Orm.UniDACDemo.dpr
+++ b/Examples/03-Data/Orm.UniDACDemo/Orm.UniDACDemo.dpr
@@ -18,7 +18,7 @@ program Orm.UniDACDemo;
 
 uses
   System.SysUtils,
-  Dext.MM,
+  //Dext.MM,
   Dext.Utils,
   Dext,
   UniDACDemo.DbConfig in 'UniDACDemo.DbConfig.pas',

--- a/Examples/03-Data/Orm.UniDACDemo/Orm.UniDACDemo.dpr
+++ b/Examples/03-Data/Orm.UniDACDemo/Orm.UniDACDemo.dpr
@@ -18,13 +18,12 @@ program Orm.UniDACDemo;
 
 uses
   System.SysUtils,
-  //Dext.MM,
   Dext.Utils,
   Dext,
-  UniDACDemo.DbConfig in 'UniDACDemo.DbConfig.pas',
   UniDACDemo.Entities in 'UniDACDemo.Entities.pas',
   UniDACDemo.Tests.Base in 'UniDACDemo.Tests.Base.pas',
-  UniDACDemo.Tests.CRUD in 'UniDACDemo.Tests.CRUD.pas';
+  UniDACDemo.Tests.CRUD in 'UniDACDemo.Tests.CRUD.pas',
+  UniDACDemo.DbConfig in 'UniDACDemo.DbConfig.pas';
 
 begin
   try

--- a/Examples/03-Data/Orm.UniDACDemo/Orm.UniDACDemo.dpr
+++ b/Examples/03-Data/Orm.UniDACDemo/Orm.UniDACDemo.dpr
@@ -1,0 +1,53 @@
+program Orm.UniDACDemo;
+
+// ---------------------------------------------------------------------------
+// UniDAC Demo for Dext Framework
+// ---------------------------------------------------------------------------
+// Demonstrates basic ORM operations using UniDAC as the database driver.
+//
+// IMPORTANT: This project requires DEXT_USE_UNIDAC to be defined in the
+// project options (or in Dext.inc). Without it, the default FireDAC driver
+// will be used instead.
+//
+// To enable UniDAC, add to Project Options > Delphi Compiler > Conditional
+// defines:  DEXT_USE_UNIDAC
+// ---------------------------------------------------------------------------
+
+{$APPTYPE CONSOLE}
+{$DEFINE DEXT_USE_UNIDAC}
+
+uses
+  System.SysUtils,
+  Dext.MM,
+  Dext.Utils,
+  Dext,
+  UniDACDemo.DbConfig in 'UniDACDemo.DbConfig.pas',
+  UniDACDemo.Entities in 'UniDACDemo.Entities.pas',
+  UniDACDemo.Tests.Base in 'UniDACDemo.Tests.Base.pas',
+  UniDACDemo.Tests.CRUD in 'UniDACDemo.Tests.CRUD.pas';
+
+begin
+  try
+    WriteLn('Dext Framework - UniDAC Driver Demo');
+    WriteLn('======================================');
+    WriteLn;
+    WriteLn('Driver: UniDAC (SQLite in-memory)');
+    WriteLn;
+
+    UniDACDemo.Tests.CRUD.RunCRUDTests;
+
+  except
+    on E: Exception do
+    begin
+      WriteLn;
+      WriteLn('ERROR: ' + E.Message);
+      WriteLn;
+      WriteLn('Make sure UniDAC is installed and DEXT_USE_UNIDAC is defined.');
+      ExitCode := 1;
+    end;
+  end;
+
+  WriteLn;
+  Write('Press Enter to exit...');
+  ReadLn;
+end.

--- a/Examples/03-Data/Orm.UniDACDemo/Orm.UniDACDemo.dproj
+++ b/Examples/03-Data/Orm.UniDACDemo/Orm.UniDACDemo.dproj
@@ -24,18 +24,8 @@
         <CfgParent>Base</CfgParent>
         <Base>true</Base>
     </PropertyGroup>
-    <PropertyGroup Condition="('$(Platform)'=='iOSDevice32' and '$(Base)'=='true') or '$(Base_iOSDevice32)'!=''">
-        <Base_iOSDevice32>true</Base_iOSDevice32>
-        <CfgParent>Base</CfgParent>
-        <Base>true</Base>
-    </PropertyGroup>
     <PropertyGroup Condition="('$(Platform)'=='iOSDevice64' and '$(Base)'=='true') or '$(Base_iOSDevice64)'!=''">
         <Base_iOSDevice64>true</Base_iOSDevice64>
-        <CfgParent>Base</CfgParent>
-        <Base>true</Base>
-    </PropertyGroup>
-    <PropertyGroup Condition="('$(Platform)'=='iOSSimulator' and '$(Base)'=='true') or '$(Base_iOSSimulator)'!=''">
-        <Base_iOSSimulator>true</Base_iOSSimulator>
         <CfgParent>Base</CfgParent>
         <Base>true</Base>
     </PropertyGroup>
@@ -85,7 +75,7 @@
         <DCC_N>false</DCC_N>
         <DCC_S>false</DCC_S>
         <DCC_ImageBase>00400000</DCC_ImageBase>
-        <DCC_UnitSearchPath>..\..\..\Sources\Common;..\..\..\Apps\CLI\Commands;..\..\..\Output\$(ProductVersion)\$(Platform)\$(Config);$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <DCC_UnitSearchPath>..\..\..\Sources;..\..\..\Sources\Common;..\..\..\Apps\CLI\Commands;..\..\..\Output\$(ProductVersion)\$(Platform)\$(Config);$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
         <SanitizedProjectName>Orm_UniDACDemo</SanitizedProjectName>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=;CFBundleName=</VerInfo_Keys>
@@ -127,26 +117,8 @@
         <Android_LauncherIcon192>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_192x192.png</Android_LauncherIcon192>
         <EnabledSysJars>activity-1.7.2.dex.jar;annotation-experimental-1.3.0.dex.jar;annotation-experimental-1.4.1.dex.jar;annotation-jvm-1.6.0.dex.jar;annotation-jvm-1.8.1.dex.jar;annotations-13.0.dex.jar;appcompat-1.2.0.dex.jar;appcompat-resources-1.2.0.dex.jar;billing-6.0.1.dex.jar;billing-7.1.1.dex.jar;biometric-1.1.0.dex.jar;browser-1.4.0.dex.jar;cloud-messaging.dex.jar;collection-1.1.0.dex.jar;collection-jvm-1.4.2.dex.jar;concurrent-futures-1.1.0.dex.jar;core-1.10.1.dex.jar;core-1.15.0.dex.jar;core-common-2.2.0.dex.jar;core-ktx-1.10.1.dex.jar;core-ktx-1.15.0.dex.jar;core-runtime-2.2.0.dex.jar;cursoradapter-1.0.0.dex.jar;customview-1.0.0.dex.jar;documentfile-1.0.0.dex.jar;drawerlayout-1.0.0.dex.jar;error_prone_annotations-2.9.0.dex.jar;exifinterface-1.3.6.dex.jar;firebase-annotations-16.2.0.dex.jar;firebase-common-20.3.1.dex.jar;firebase-components-17.1.0.dex.jar;firebase-datatransport-18.1.7.dex.jar;firebase-encoders-17.0.0.dex.jar;firebase-encoders-json-18.0.0.dex.jar;firebase-encoders-proto-16.0.0.dex.jar;firebase-iid-interop-17.1.0.dex.jar;firebase-installations-17.1.3.dex.jar;firebase-installations-interop-17.1.0.dex.jar;firebase-measurement-connector-19.0.0.dex.jar;firebase-messaging-23.1.2.dex.jar;fmx.dex.jar;fragment-1.2.5.dex.jar;google-play-licensing.dex.jar;interpolator-1.0.0.dex.jar;javax.inject-1.dex.jar;kotlin-stdlib-1.8.22.dex.jar;kotlin-stdlib-common-1.8.22.dex.jar;kotlin-stdlib-jdk7-1.8.22.dex.jar;kotlin-stdlib-jdk8-1.8.22.dex.jar;kotlinx-coroutines-android-1.6.4.dex.jar;kotlinx-coroutines-core-jvm-1.6.4.dex.jar;legacy-support-core-utils-1.0.0.dex.jar;lifecycle-common-2.6.1.dex.jar;lifecycle-common-2.6.2.dex.jar;lifecycle-livedata-2.6.1.dex.jar;lifecycle-livedata-2.6.2.dex.jar;lifecycle-livedata-core-2.6.1.dex.jar;lifecycle-livedata-core-2.6.2.dex.jar;lifecycle-runtime-2.6.1.dex.jar;lifecycle-runtime-2.6.2.dex.jar;lifecycle-service-2.6.1.dex.jar;lifecycle-service-2.6.2.dex.jar;lifecycle-viewmodel-2.6.1.dex.jar;lifecycle-viewmodel-2.6.2.dex.jar;lifecycle-viewmodel-savedstate-2.6.1.dex.jar;lifecycle-viewmodel-savedstate-2.6.2.dex.jar;listenablefuture-1.0.dex.jar;loader-1.0.0.dex.jar;localbroadcastmanager-1.0.0.dex.jar;okio-jvm-3.4.0.dex.jar;play-services-ads-22.2.0.dex.jar;play-services-ads-base-22.2.0.dex.jar;play-services-ads-identifier-18.0.0.dex.jar;play-services-ads-lite-22.2.0.dex.jar;play-services-appset-16.0.1.dex.jar;play-services-base-18.1.0.dex.jar;play-services-base-18.5.0.dex.jar;play-services-basement-18.1.0.dex.jar;play-services-basement-18.4.0.dex.jar;play-services-cloud-messaging-17.0.1.dex.jar;play-services-location-21.0.1.dex.jar;play-services-maps-18.1.0.dex.jar;play-services-measurement-base-20.1.2.dex.jar;play-services-measurement-sdk-api-20.1.2.dex.jar;play-services-stats-17.0.2.dex.jar;play-services-tasks-18.0.2.dex.jar;play-services-tasks-18.2.0.dex.jar;print-1.0.0.dex.jar;profileinstaller-1.3.0.dex.jar;room-common-2.2.5.dex.jar;room-runtime-2.2.5.dex.jar;savedstate-1.2.1.dex.jar;sqlite-2.1.0.dex.jar;sqlite-framework-2.1.0.dex.jar;startup-runtime-1.1.1.dex.jar;tracing-1.0.0.dex.jar;tracing-1.2.0.dex.jar;transport-api-3.0.0.dex.jar;transport-backend-cct-3.1.8.dex.jar;transport-runtime-3.1.8.dex.jar;user-messaging-platform-2.0.0.dex.jar;vectordrawable-1.1.0.dex.jar;vectordrawable-animated-1.1.0.dex.jar;versionedparcelable-1.1.1.dex.jar;viewpager-1.0.0.dex.jar;work-runtime-2.7.0.dex.jar</EnabledSysJars>
     </PropertyGroup>
-    <PropertyGroup Condition="'$(Base_iOSDevice32)'!=''">
-        <iPhone_AppIcon120>$(BDS)\bin\Artwork\iOS\iPhone\FM_ApplicationIcon_120x120.png</iPhone_AppIcon120>
-        <iPhone_Spotlight80>$(BDS)\bin\Artwork\iOS\iPhone\FM_SpotlightSearchIcon_80x80.png</iPhone_Spotlight80>
-        <iPhone_Notification40>$(BDS)\bin\Artwork\iOS\iPhone\FM_NotificationIcon_40x40.png</iPhone_Notification40>
-        <iPhone_Notification60>$(BDS)\bin\Artwork\iOS\iPhone\FM_NotificationIcon_60x60.png</iPhone_Notification60>
-        <iPad_SpotLight80>$(BDS)\bin\Artwork\iOS\iPad\FM_SpotlightSearchIcon_80x80.png</iPad_SpotLight80>
-        <iPad_Notification40>$(BDS)\bin\Artwork\iOS\iPad\FM_NotificationIcon_40x40.png</iPad_Notification40>
-        <iPad_AppIcon152>$(BDS)\bin\Artwork\iOS\iPad\FM_ApplicationIcon_152x152.png</iPad_AppIcon152>
-    </PropertyGroup>
     <PropertyGroup Condition="'$(Base_iOSDevice64)'!=''">
         <iOS_AppStore1024>$(BDS)\bin\Artwork\iOS\iPhone\FM_ApplicationIcon_1024x1024.png</iOS_AppStore1024>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Base_iOSSimulator)'!=''">
-        <iPhone_AppIcon120>$(BDS)\bin\Artwork\iOS\iPhone\FM_ApplicationIcon_120x120.png</iPhone_AppIcon120>
-        <iPhone_Spotlight80>$(BDS)\bin\Artwork\iOS\iPhone\FM_SpotlightSearchIcon_80x80.png</iPhone_Spotlight80>
-        <iPhone_Notification40>$(BDS)\bin\Artwork\iOS\iPhone\FM_NotificationIcon_40x40.png</iPhone_Notification40>
-        <iPhone_Notification60>$(BDS)\bin\Artwork\iOS\iPhone\FM_NotificationIcon_60x60.png</iPhone_Notification60>
-        <iPad_SpotLight80>$(BDS)\bin\Artwork\iOS\iPad\FM_SpotlightSearchIcon_80x80.png</iPad_SpotLight80>
-        <iPad_Notification40>$(BDS)\bin\Artwork\iOS\iPad\FM_NotificationIcon_40x40.png</iPad_Notification40>
-        <iPad_AppIcon152>$(BDS)\bin\Artwork\iOS\iPad\FM_ApplicationIcon_152x152.png</iPad_AppIcon152>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <DCC_Namespace>Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;Bde;$(DCC_Namespace)</DCC_Namespace>
@@ -183,10 +155,10 @@
         <DelphiCompile Include="$(MainSource)">
             <MainSource>MainSource</MainSource>
         </DelphiCompile>
-        <DCCReference Include="UniDACDemo.DbConfig.pas"/>
         <DCCReference Include="UniDACDemo.Entities.pas"/>
         <DCCReference Include="UniDACDemo.Tests.Base.pas"/>
         <DCCReference Include="UniDACDemo.Tests.CRUD.pas"/>
+        <DCCReference Include="UniDACDemo.DbConfig.pas"/>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>
         </BuildConfiguration>
@@ -211,12 +183,9 @@
             <Platforms>
                 <Platform value="Android">False</Platform>
                 <Platform value="Android64">True</Platform>
-                <Platform value="iOSDevice32">False</Platform>
                 <Platform value="iOSDevice64">True</Platform>
                 <Platform value="iOSSimARM64">True</Platform>
-                <Platform value="iOSSimulator">False</Platform>
                 <Platform value="Linux64">True</Platform>
-                <Platform value="OSX32">False</Platform>
                 <Platform value="OSX64">True</Platform>
                 <Platform value="OSXARM64">True</Platform>
                 <Platform value="Win32">True</Platform>

--- a/Examples/03-Data/Orm.UniDACDemo/Orm.UniDACDemo.dproj
+++ b/Examples/03-Data/Orm.UniDACDemo/Orm.UniDACDemo.dproj
@@ -1,0 +1,230 @@
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <ProjectGuid>{319C864E-E642-44A5-B47C-B93B17AE974D}</ProjectGuid>
+        <MainSource>Orm.UniDACDemo.dpr</MainSource>
+        <Base>True</Base>
+        <Config Condition="'$(Config)'==''">Debug</Config>
+        <ProjectName Condition="'$(ProjectName)'==''">Orm.UniDACDemo</ProjectName>
+        <TargetedPlatforms>693377</TargetedPlatforms>
+        <AppType>Console</AppType>
+        <FrameworkType>None</FrameworkType>
+        <ProjectVersion>20.3</ProjectVersion>
+        <Platform Condition="'$(Platform)'==''">Win32</Platform>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Base' or '$(Base)'!=''">
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Android' and '$(Base)'=='true') or '$(Base_Android)'!=''">
+        <Base_Android>true</Base_Android>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Android64' and '$(Base)'=='true') or '$(Base_Android64)'!=''">
+        <Base_Android64>true</Base_Android64>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='iOSDevice32' and '$(Base)'=='true') or '$(Base_iOSDevice32)'!=''">
+        <Base_iOSDevice32>true</Base_iOSDevice32>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='iOSDevice64' and '$(Base)'=='true') or '$(Base_iOSDevice64)'!=''">
+        <Base_iOSDevice64>true</Base_iOSDevice64>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='iOSSimulator' and '$(Base)'=='true') or '$(Base_iOSSimulator)'!=''">
+        <Base_iOSSimulator>true</Base_iOSSimulator>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win32' and '$(Base)'=='true') or '$(Base_Win32)'!=''">
+        <Base_Win32>true</Base_Win32>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Release' or '$(Cfg_1)'!=''">
+        <Cfg_1>true</Cfg_1>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Debug' or '$(Cfg_2)'!=''">
+        <Cfg_2>true</Cfg_2>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Android64' and '$(Cfg_2)'=='true') or '$(Cfg_2_Android64)'!=''">
+        <Cfg_2_Android64>true</Cfg_2_Android64>
+        <CfgParent>Cfg_2</CfgParent>
+        <Cfg_2>true</Cfg_2>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='iOSDevice64' and '$(Cfg_2)'=='true') or '$(Cfg_2_iOSDevice64)'!=''">
+        <Cfg_2_iOSDevice64>true</Cfg_2_iOSDevice64>
+        <CfgParent>Cfg_2</CfgParent>
+        <Cfg_2>true</Cfg_2>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='OSX64' and '$(Cfg_2)'=='true') or '$(Cfg_2_OSX64)'!=''">
+        <Cfg_2_OSX64>true</Cfg_2_OSX64>
+        <CfgParent>Cfg_2</CfgParent>
+        <Cfg_2>true</Cfg_2>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='OSXARM64' and '$(Cfg_2)'=='true') or '$(Cfg_2_OSXARM64)'!=''">
+        <Cfg_2_OSXARM64>true</Cfg_2_OSXARM64>
+        <CfgParent>Cfg_2</CfgParent>
+        <Cfg_2>true</Cfg_2>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base)'!=''">
+        <DCC_E>false</DCC_E>
+        <DCC_F>false</DCC_F>
+        <DCC_K>false</DCC_K>
+        <DCC_N>false</DCC_N>
+        <DCC_S>false</DCC_S>
+        <DCC_ImageBase>00400000</DCC_ImageBase>
+        <DCC_UnitSearchPath>..\..\..\Sources\Common;..\..\..\Apps\CLI\Commands;..\..\..\Output\$(ProductVersion)\$(Platform)\$(Config);$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <SanitizedProjectName>Orm_UniDACDemo</SanitizedProjectName>
+        <VerInfo_Locale>1033</VerInfo_Locale>
+        <VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=;CFBundleName=</VerInfo_Keys>
+        <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;$(DCC_Namespace)</DCC_Namespace>
+        <Icon_MainIcon>$(BDS)\bin\delphi_PROJECTICON.ico</Icon_MainIcon>
+        <Icns_MainIcns>$(BDS)\bin\delphi_PROJECTICNS.icns</Icns_MainIcns>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Android)'!=''">
+        <VerInfo_Keys>package=com.embarcadero.$(MSBuildProjectName);label=$(MSBuildProjectName);versionCode=1;versionName=1.0.0;persistent=False;restoreAnyVersion=False;installLocation=auto;largeHeap=False;theme=TitleBar;hardwareAccelerated=true;apiKey=;minSdkVersion=23;targetSdkVersion=35</VerInfo_Keys>
+        <BT_BuildType>Debug</BT_BuildType>
+        <Android_LauncherIcon36>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_36x36.png</Android_LauncherIcon36>
+        <Android_LauncherIcon48>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_48x48.png</Android_LauncherIcon48>
+        <Android_LauncherIcon72>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_72x72.png</Android_LauncherIcon72>
+        <Android_LauncherIcon96>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_96x96.png</Android_LauncherIcon96>
+        <Android_LauncherIcon144>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_144x144.png</Android_LauncherIcon144>
+        <Android_SplashImage426>$(BDS)\bin\Artwork\Android\FM_SplashImage_426x320.png</Android_SplashImage426>
+        <Android_SplashImage470>$(BDS)\bin\Artwork\Android\FM_SplashImage_470x320.png</Android_SplashImage470>
+        <Android_SplashImage640>$(BDS)\bin\Artwork\Android\FM_SplashImage_640x480.png</Android_SplashImage640>
+        <Android_SplashImage960>$(BDS)\bin\Artwork\Android\FM_SplashImage_960x720.png</Android_SplashImage960>
+        <AUP_ACCESS_COARSE_LOCATION>true</AUP_ACCESS_COARSE_LOCATION>
+        <AUP_ACCESS_FINE_LOCATION>true</AUP_ACCESS_FINE_LOCATION>
+        <AUP_CALL_PHONE>true</AUP_CALL_PHONE>
+        <AUP_CAMERA>true</AUP_CAMERA>
+        <AUP_INTERNET>true</AUP_INTERNET>
+        <AUP_READ_CALENDAR>true</AUP_READ_CALENDAR>
+        <AUP_READ_EXTERNAL_STORAGE>true</AUP_READ_EXTERNAL_STORAGE>
+        <AUP_WRITE_CALENDAR>true</AUP_WRITE_CALENDAR>
+        <AUP_WRITE_EXTERNAL_STORAGE>true</AUP_WRITE_EXTERNAL_STORAGE>
+        <AUP_READ_PHONE_STATE>true</AUP_READ_PHONE_STATE>
+        <Android_NotificationIcon24>$(BDS)\bin\Artwork\Android\FM_NotificationIcon_24x24.png</Android_NotificationIcon24>
+        <Android_NotificationIcon36>$(BDS)\bin\Artwork\Android\FM_NotificationIcon_36x36.png</Android_NotificationIcon36>
+        <Android_NotificationIcon48>$(BDS)\bin\Artwork\Android\FM_NotificationIcon_48x48.png</Android_NotificationIcon48>
+        <Android_NotificationIcon72>$(BDS)\bin\Artwork\Android\FM_NotificationIcon_72x72.png</Android_NotificationIcon72>
+        <Android_NotificationIcon96>$(BDS)\bin\Artwork\Android\FM_NotificationIcon_96x96.png</Android_NotificationIcon96>
+        <Android_LauncherIcon192>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_192x192.png</Android_LauncherIcon192>
+        <EnabledSysJars>activity-1.7.2.dex.jar;annotation-experimental-1.3.0.dex.jar;annotation-experimental-1.4.1.dex.jar;annotation-jvm-1.6.0.dex.jar;annotation-jvm-1.8.1.dex.jar;annotations-13.0.dex.jar;appcompat-1.2.0.dex.jar;appcompat-resources-1.2.0.dex.jar;billing-6.0.1.dex.jar;billing-7.1.1.dex.jar;biometric-1.1.0.dex.jar;browser-1.4.0.dex.jar;cloud-messaging.dex.jar;collection-1.1.0.dex.jar;collection-jvm-1.4.2.dex.jar;concurrent-futures-1.1.0.dex.jar;core-1.10.1.dex.jar;core-1.15.0.dex.jar;core-common-2.2.0.dex.jar;core-ktx-1.10.1.dex.jar;core-ktx-1.15.0.dex.jar;core-runtime-2.2.0.dex.jar;cursoradapter-1.0.0.dex.jar;customview-1.0.0.dex.jar;documentfile-1.0.0.dex.jar;drawerlayout-1.0.0.dex.jar;error_prone_annotations-2.9.0.dex.jar;exifinterface-1.3.6.dex.jar;firebase-annotations-16.2.0.dex.jar;firebase-common-20.3.1.dex.jar;firebase-components-17.1.0.dex.jar;firebase-datatransport-18.1.7.dex.jar;firebase-encoders-17.0.0.dex.jar;firebase-encoders-json-18.0.0.dex.jar;firebase-encoders-proto-16.0.0.dex.jar;firebase-iid-interop-17.1.0.dex.jar;firebase-installations-17.1.3.dex.jar;firebase-installations-interop-17.1.0.dex.jar;firebase-measurement-connector-19.0.0.dex.jar;firebase-messaging-23.1.2.dex.jar;fmx.dex.jar;fragment-1.2.5.dex.jar;google-play-licensing.dex.jar;interpolator-1.0.0.dex.jar;javax.inject-1.dex.jar;kotlin-stdlib-1.8.22.dex.jar;kotlin-stdlib-common-1.8.22.dex.jar;kotlin-stdlib-jdk7-1.8.22.dex.jar;kotlin-stdlib-jdk8-1.8.22.dex.jar;kotlinx-coroutines-android-1.6.4.dex.jar;kotlinx-coroutines-core-jvm-1.6.4.dex.jar;legacy-support-core-utils-1.0.0.dex.jar;lifecycle-common-2.6.1.dex.jar;lifecycle-common-2.6.2.dex.jar;lifecycle-livedata-2.6.1.dex.jar;lifecycle-livedata-2.6.2.dex.jar;lifecycle-livedata-core-2.6.1.dex.jar;lifecycle-livedata-core-2.6.2.dex.jar;lifecycle-runtime-2.6.1.dex.jar;lifecycle-runtime-2.6.2.dex.jar;lifecycle-service-2.6.1.dex.jar;lifecycle-service-2.6.2.dex.jar;lifecycle-viewmodel-2.6.1.dex.jar;lifecycle-viewmodel-2.6.2.dex.jar;lifecycle-viewmodel-savedstate-2.6.1.dex.jar;lifecycle-viewmodel-savedstate-2.6.2.dex.jar;listenablefuture-1.0.dex.jar;loader-1.0.0.dex.jar;localbroadcastmanager-1.0.0.dex.jar;okio-jvm-3.4.0.dex.jar;play-services-ads-22.2.0.dex.jar;play-services-ads-base-22.2.0.dex.jar;play-services-ads-identifier-18.0.0.dex.jar;play-services-ads-lite-22.2.0.dex.jar;play-services-appset-16.0.1.dex.jar;play-services-base-18.1.0.dex.jar;play-services-base-18.5.0.dex.jar;play-services-basement-18.1.0.dex.jar;play-services-basement-18.4.0.dex.jar;play-services-cloud-messaging-17.0.1.dex.jar;play-services-location-21.0.1.dex.jar;play-services-maps-18.1.0.dex.jar;play-services-measurement-base-20.1.2.dex.jar;play-services-measurement-sdk-api-20.1.2.dex.jar;play-services-stats-17.0.2.dex.jar;play-services-tasks-18.0.2.dex.jar;play-services-tasks-18.2.0.dex.jar;print-1.0.0.dex.jar;profileinstaller-1.3.0.dex.jar;room-common-2.2.5.dex.jar;room-runtime-2.2.5.dex.jar;savedstate-1.2.1.dex.jar;sqlite-2.1.0.dex.jar;sqlite-framework-2.1.0.dex.jar;startup-runtime-1.1.1.dex.jar;tracing-1.0.0.dex.jar;tracing-1.2.0.dex.jar;transport-api-3.0.0.dex.jar;transport-backend-cct-3.1.8.dex.jar;transport-runtime-3.1.8.dex.jar;user-messaging-platform-2.0.0.dex.jar;vectordrawable-1.1.0.dex.jar;vectordrawable-animated-1.1.0.dex.jar;versionedparcelable-1.1.1.dex.jar;viewpager-1.0.0.dex.jar;work-runtime-2.7.0.dex.jar</EnabledSysJars>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Android64)'!=''">
+        <Android_LauncherIcon192>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_192x192.png</Android_LauncherIcon192>
+        <EnabledSysJars>activity-1.7.2.dex.jar;annotation-experimental-1.3.0.dex.jar;annotation-experimental-1.4.1.dex.jar;annotation-jvm-1.6.0.dex.jar;annotation-jvm-1.8.1.dex.jar;annotations-13.0.dex.jar;appcompat-1.2.0.dex.jar;appcompat-resources-1.2.0.dex.jar;billing-6.0.1.dex.jar;billing-7.1.1.dex.jar;biometric-1.1.0.dex.jar;browser-1.4.0.dex.jar;cloud-messaging.dex.jar;collection-1.1.0.dex.jar;collection-jvm-1.4.2.dex.jar;concurrent-futures-1.1.0.dex.jar;core-1.10.1.dex.jar;core-1.15.0.dex.jar;core-common-2.2.0.dex.jar;core-ktx-1.10.1.dex.jar;core-ktx-1.15.0.dex.jar;core-runtime-2.2.0.dex.jar;cursoradapter-1.0.0.dex.jar;customview-1.0.0.dex.jar;documentfile-1.0.0.dex.jar;drawerlayout-1.0.0.dex.jar;error_prone_annotations-2.9.0.dex.jar;exifinterface-1.3.6.dex.jar;firebase-annotations-16.2.0.dex.jar;firebase-common-20.3.1.dex.jar;firebase-components-17.1.0.dex.jar;firebase-datatransport-18.1.7.dex.jar;firebase-encoders-17.0.0.dex.jar;firebase-encoders-json-18.0.0.dex.jar;firebase-encoders-proto-16.0.0.dex.jar;firebase-iid-interop-17.1.0.dex.jar;firebase-installations-17.1.3.dex.jar;firebase-installations-interop-17.1.0.dex.jar;firebase-measurement-connector-19.0.0.dex.jar;firebase-messaging-23.1.2.dex.jar;fmx.dex.jar;fragment-1.2.5.dex.jar;google-play-licensing.dex.jar;interpolator-1.0.0.dex.jar;javax.inject-1.dex.jar;kotlin-stdlib-1.8.22.dex.jar;kotlin-stdlib-common-1.8.22.dex.jar;kotlin-stdlib-jdk7-1.8.22.dex.jar;kotlin-stdlib-jdk8-1.8.22.dex.jar;kotlinx-coroutines-android-1.6.4.dex.jar;kotlinx-coroutines-core-jvm-1.6.4.dex.jar;legacy-support-core-utils-1.0.0.dex.jar;lifecycle-common-2.6.1.dex.jar;lifecycle-common-2.6.2.dex.jar;lifecycle-livedata-2.6.1.dex.jar;lifecycle-livedata-2.6.2.dex.jar;lifecycle-livedata-core-2.6.1.dex.jar;lifecycle-livedata-core-2.6.2.dex.jar;lifecycle-runtime-2.6.1.dex.jar;lifecycle-runtime-2.6.2.dex.jar;lifecycle-service-2.6.1.dex.jar;lifecycle-service-2.6.2.dex.jar;lifecycle-viewmodel-2.6.1.dex.jar;lifecycle-viewmodel-2.6.2.dex.jar;lifecycle-viewmodel-savedstate-2.6.1.dex.jar;lifecycle-viewmodel-savedstate-2.6.2.dex.jar;listenablefuture-1.0.dex.jar;loader-1.0.0.dex.jar;localbroadcastmanager-1.0.0.dex.jar;okio-jvm-3.4.0.dex.jar;play-services-ads-22.2.0.dex.jar;play-services-ads-base-22.2.0.dex.jar;play-services-ads-identifier-18.0.0.dex.jar;play-services-ads-lite-22.2.0.dex.jar;play-services-appset-16.0.1.dex.jar;play-services-base-18.1.0.dex.jar;play-services-base-18.5.0.dex.jar;play-services-basement-18.1.0.dex.jar;play-services-basement-18.4.0.dex.jar;play-services-cloud-messaging-17.0.1.dex.jar;play-services-location-21.0.1.dex.jar;play-services-maps-18.1.0.dex.jar;play-services-measurement-base-20.1.2.dex.jar;play-services-measurement-sdk-api-20.1.2.dex.jar;play-services-stats-17.0.2.dex.jar;play-services-tasks-18.0.2.dex.jar;play-services-tasks-18.2.0.dex.jar;print-1.0.0.dex.jar;profileinstaller-1.3.0.dex.jar;room-common-2.2.5.dex.jar;room-runtime-2.2.5.dex.jar;savedstate-1.2.1.dex.jar;sqlite-2.1.0.dex.jar;sqlite-framework-2.1.0.dex.jar;startup-runtime-1.1.1.dex.jar;tracing-1.0.0.dex.jar;tracing-1.2.0.dex.jar;transport-api-3.0.0.dex.jar;transport-backend-cct-3.1.8.dex.jar;transport-runtime-3.1.8.dex.jar;user-messaging-platform-2.0.0.dex.jar;vectordrawable-1.1.0.dex.jar;vectordrawable-animated-1.1.0.dex.jar;versionedparcelable-1.1.1.dex.jar;viewpager-1.0.0.dex.jar;work-runtime-2.7.0.dex.jar</EnabledSysJars>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_iOSDevice32)'!=''">
+        <iPhone_AppIcon120>$(BDS)\bin\Artwork\iOS\iPhone\FM_ApplicationIcon_120x120.png</iPhone_AppIcon120>
+        <iPhone_Spotlight80>$(BDS)\bin\Artwork\iOS\iPhone\FM_SpotlightSearchIcon_80x80.png</iPhone_Spotlight80>
+        <iPhone_Notification40>$(BDS)\bin\Artwork\iOS\iPhone\FM_NotificationIcon_40x40.png</iPhone_Notification40>
+        <iPhone_Notification60>$(BDS)\bin\Artwork\iOS\iPhone\FM_NotificationIcon_60x60.png</iPhone_Notification60>
+        <iPad_SpotLight80>$(BDS)\bin\Artwork\iOS\iPad\FM_SpotlightSearchIcon_80x80.png</iPad_SpotLight80>
+        <iPad_Notification40>$(BDS)\bin\Artwork\iOS\iPad\FM_NotificationIcon_40x40.png</iPad_Notification40>
+        <iPad_AppIcon152>$(BDS)\bin\Artwork\iOS\iPad\FM_ApplicationIcon_152x152.png</iPad_AppIcon152>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_iOSDevice64)'!=''">
+        <iOS_AppStore1024>$(BDS)\bin\Artwork\iOS\iPhone\FM_ApplicationIcon_1024x1024.png</iOS_AppStore1024>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_iOSSimulator)'!=''">
+        <iPhone_AppIcon120>$(BDS)\bin\Artwork\iOS\iPhone\FM_ApplicationIcon_120x120.png</iPhone_AppIcon120>
+        <iPhone_Spotlight80>$(BDS)\bin\Artwork\iOS\iPhone\FM_SpotlightSearchIcon_80x80.png</iPhone_Spotlight80>
+        <iPhone_Notification40>$(BDS)\bin\Artwork\iOS\iPhone\FM_NotificationIcon_40x40.png</iPhone_Notification40>
+        <iPhone_Notification60>$(BDS)\bin\Artwork\iOS\iPhone\FM_NotificationIcon_60x60.png</iPhone_Notification60>
+        <iPad_SpotLight80>$(BDS)\bin\Artwork\iOS\iPad\FM_SpotlightSearchIcon_80x80.png</iPad_SpotLight80>
+        <iPad_Notification40>$(BDS)\bin\Artwork\iOS\iPad\FM_NotificationIcon_40x40.png</iPad_Notification40>
+        <iPad_AppIcon152>$(BDS)\bin\Artwork\iOS\iPad\FM_ApplicationIcon_152x152.png</iPad_AppIcon152>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win32)'!=''">
+        <DCC_Namespace>Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;Bde;$(DCC_Namespace)</DCC_Namespace>
+        <BT_BuildType>Debug</BT_BuildType>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
+        <VerInfo_Locale>1033</VerInfo_Locale>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_1)'!=''">
+        <DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>
+        <DCC_DebugInformation>0</DCC_DebugInformation>
+        <DCC_LocalDebugSymbols>false</DCC_LocalDebugSymbols>
+        <DCC_SymbolReferenceInfo>0</DCC_SymbolReferenceInfo>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_2)'!=''">
+        <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
+        <DCC_Optimize>false</DCC_Optimize>
+        <DCC_GenerateStackFrames>true</DCC_GenerateStackFrames>
+        <DCC_RangeChecking>true</DCC_RangeChecking>
+        <DCC_IntegerOverflowCheck>true</DCC_IntegerOverflowCheck>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_2_Android64)'!=''">
+        <BT_BuildType>Debug</BT_BuildType>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_2_iOSDevice64)'!=''">
+        <BT_BuildType>Debug</BT_BuildType>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_2_OSX64)'!=''">
+        <BT_BuildType>Debug</BT_BuildType>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_2_OSXARM64)'!=''">
+        <BT_BuildType>Debug</BT_BuildType>
+    </PropertyGroup>
+    <ItemGroup>
+        <DelphiCompile Include="$(MainSource)">
+            <MainSource>MainSource</MainSource>
+        </DelphiCompile>
+        <DCCReference Include="UniDACDemo.DbConfig.pas"/>
+        <DCCReference Include="UniDACDemo.Entities.pas"/>
+        <DCCReference Include="UniDACDemo.Tests.Base.pas"/>
+        <DCCReference Include="UniDACDemo.Tests.CRUD.pas"/>
+        <BuildConfiguration Include="Base">
+            <Key>Base</Key>
+        </BuildConfiguration>
+        <BuildConfiguration Include="Release">
+            <Key>Cfg_1</Key>
+            <CfgParent>Base</CfgParent>
+        </BuildConfiguration>
+        <BuildConfiguration Include="Debug">
+            <Key>Cfg_2</Key>
+            <CfgParent>Base</CfgParent>
+        </BuildConfiguration>
+    </ItemGroup>
+    <ProjectExtensions>
+        <Borland.Personality>Delphi.Personality.12</Borland.Personality>
+        <Borland.ProjectType/>
+        <BorlandProject>
+            <Delphi.Personality>
+                <Source>
+                    <Source Name="MainSource">Orm.UniDACDemo.dpr</Source>
+                </Source>
+            </Delphi.Personality>
+            <Platforms>
+                <Platform value="Android">False</Platform>
+                <Platform value="Android64">True</Platform>
+                <Platform value="iOSDevice32">False</Platform>
+                <Platform value="iOSDevice64">True</Platform>
+                <Platform value="iOSSimARM64">True</Platform>
+                <Platform value="iOSSimulator">False</Platform>
+                <Platform value="Linux64">True</Platform>
+                <Platform value="OSX32">False</Platform>
+                <Platform value="OSX64">True</Platform>
+                <Platform value="OSXARM64">True</Platform>
+                <Platform value="Win32">True</Platform>
+                <Platform value="Win64">False</Platform>
+            </Platforms>
+        </BorlandProject>
+        <ProjectFileVersion>12</ProjectFileVersion>
+    </ProjectExtensions>
+    <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
+    <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
+</Project>

--- a/Examples/03-Data/Orm.UniDACDemo/README.md
+++ b/Examples/03-Data/Orm.UniDACDemo/README.md
@@ -1,0 +1,66 @@
+# UniDAC Demo
+
+Console application demonstrating Dext ORM operations using **UniDAC** as the
+database driver backend (instead of the default FireDAC).
+
+## Requirements
+
+- Delphi 10.4 Sydney or later
+- [UniDAC](https://www.devart.com/unidac/) by DevArt (installed)
+- Dext framework (Sources/ on the library/search path)
+
+## How to Build
+
+1. Add `DEXT_USE_UNIDAC` to **Project Options > Delphi Compiler > Conditional defines**
+2. Add the Dext `Sources/` directory tree to the project search path
+   (or use the `set_env.ps1` script to set `SEARCH_PATH` environment variable)
+3. Add required UniDAC provider units to the search path
+   (e.g. `SQLiteUniProvider` for the default SQLite demo)
+4. Compile and run
+
+## Switching Database Providers
+
+Edit `UniDACDemo.DbConfig.pas` to change the connection:
+
+| Provider   | UniDAC Unit           |
+|------------|-----------------------|
+| SQLite     | `SQLiteUniProvider`   |
+| PostgreSQL | `PostgreSQLUniProvider` |
+| MySQL      | `MySQLUniProvider`    |
+| SQL Server | `SQLServerUniProvider` |
+| Oracle     | `OracleUniProvider`   |
+| Firebird   | `InterBaseUniProvider` |
+
+## What It Tests
+
+- **INSERT** - Create entities and persist them
+- **SELECT ALL** - Retrieve all records as a list
+- **UPDATE** - Modify an existing record
+- **DELETE** - Remove a record
+- **VERIFY** - Confirm final state matches expectations
+
+## Architecture
+
+```
+Orm.UniDACDemo.dpr          -- Program entry point (defines DEXT_USE_UNIDAC)
+UniDACDemo.DbConfig.pas     -- Database connection configuration
+UniDACDemo.Entities.pas    -- Entity definitions (TCustomer, TOrder) with relationships
+UniDACDemo.Tests.Base.pas  -- Base test class (creates/destroys TDbContext)
+UniDACDemo.Tests.CRUD.pas  -- CRUD test procedures
+```
+
+## Entity Style
+
+Uses **Smart Properties** (`IntType`, `StringType`, `DoubleType`) with
+Dext attributes (`[PK, AutoInc]`, `[Required]`, `[MaxLength]`,
+`[ForeignKey]`, `[BelongsTo]`, `[HasMany]`) — the recommended style
+per the Dext ORM documentation.
+
+## How It Works
+
+When `DEXT_USE_UNIDAC` is defined:
+
+- `Dext.Entity.Setup.pas` switches from FireDAC to UniDAC units at compile time
+- `TDbContextOptions.BuildConnection` routes to `BuildUniDACConnection`
+- UniDAC's `TUniConnection` replaces `TFDConnection` internally
+- The ORM layer (DbSet, SQL generator, dialects, Smart Properties, etc.) remains unchanged

--- a/Examples/03-Data/Orm.UniDACDemo/UniDACDemo.DbConfig.pas
+++ b/Examples/03-Data/Orm.UniDACDemo/UniDACDemo.DbConfig.pas
@@ -1,0 +1,30 @@
+unit UniDACDemo.DbConfig;
+
+/// <summary>
+///   Database configuration for the UniDAC demo.
+///   Uses SQLite in-memory via UniDAC provider.
+///   To switch to PostgreSQL, MySQL, etc. change the provider
+///   and connection string below.
+/// </summary>
+
+interface
+
+uses
+  Dext.Entity.Setup;
+
+function CreateOptions: TDbContextOptions;
+
+implementation
+
+function CreateOptions: TDbContextOptions;
+begin
+  // SQLite in-memory via UniDAC — no external database needed
+  Result := TDbContextOptions.Create;
+  Result.UseSQLite(':memory:');
+  // For PostgreSQL:
+  //   Result.UsePostgreSQL('ProviderName=PostgreSQL;Host=localhost;Port=5432;Database=mydb;User ID=postgres;Password=postgres');
+  // For MySQL:
+  //   Result.UseMySQL('ProviderName=MySQL;Host=localhost;Port=3306;Database=mydb;User ID=root;Password=root');
+end;
+
+end.

--- a/Examples/03-Data/Orm.UniDACDemo/UniDACDemo.Entities.pas
+++ b/Examples/03-Data/Orm.UniDACDemo/UniDACDemo.Entities.pas
@@ -3,11 +3,14 @@ unit UniDACDemo.Entities;
 interface
 
 uses
-  Dext.Entity,              // Attributes facade
-  Dext.Entity.Collections,  // IEntityCollection<T>
-  Dext.Types.Lazy;          // ILazy<T>
+  Dext,
+  Dext.Entity,
+  Dext.Collections,
+  Dext.Types.Lazy,
+  Dext.Specifications.Base;
 
 type
+  [Table('customers')]
   TCustomer = class
   private
     FId: Integer;
@@ -15,8 +18,6 @@ type
     FEmail: string;
     FBalance: Currency;
     FCreatedAt: TDateTime;
-    FOrders: ILazy<IEntityCollection<TOrder>>;
-    function GetOrders: IEntityCollection<TOrder>;
   public
     [PK, AutoInc]
     property Id: Integer read FId write FId;
@@ -30,11 +31,9 @@ type
     property Balance: Currency read FBalance write FBalance;
 
     property CreatedAt: TDateTime read FCreatedAt write FCreatedAt;
-
-    [InverseProperty('Customer'), HasMany]
-    property Orders: IEntityCollection<TOrder> read GetOrders;
   end;
 
+  [Table('orders')]
   TOrder = class
   private
     FId: Integer;
@@ -42,9 +41,6 @@ type
     FTotalAmount: Currency;
     FOrderDate: TDateTime;
     FStatus: string;
-    FCustomer: ILazy<TCustomer>;
-    function GetCustomer: TCustomer;
-    procedure SetCustomer(const Value: TCustomer);
   public
     [PK, AutoInc]
     property Id: Integer read FId write FId;
@@ -59,38 +55,8 @@ type
 
     [MaxLength(50)]
     property Status: string read FStatus write FStatus;
-
-    property Customer: TCustomer read GetCustomer write SetCustomer;
   end;
 
 implementation
-
-{ TCustomer }
-
-function TCustomer.GetOrders: IEntityCollection<TOrder>;
-begin
-  if FOrders = nil then
-    FOrders := TLazy<IEntityCollection<TOrder>>.Create;
-  Result := FOrders.Value;
-end;
-
-{ TOrder }
-
-function TOrder.GetCustomer: TCustomer;
-begin
-  if FCustomer <> nil then
-    Result := FCustomer.Value
-  else
-    Result := nil;
-end;
-
-procedure TOrder.SetCustomer(const Value: TCustomer);
-begin
-  if FCustomer = nil then
-    FCustomer := TLazy<TCustomer>.Create;
-  FCustomer.Value := Value;
-  if Value <> nil then
-    FCustomerId := Value.Id;
-end;
 
 end.

--- a/Examples/03-Data/Orm.UniDACDemo/UniDACDemo.Entities.pas
+++ b/Examples/03-Data/Orm.UniDACDemo/UniDACDemo.Entities.pas
@@ -1,0 +1,96 @@
+unit UniDACDemo.Entities;
+
+interface
+
+uses
+  Dext.Entity,              // Attributes facade
+  Dext.Entity.Collections,  // IEntityCollection<T>
+  Dext.Types.Lazy;          // ILazy<T>
+
+type
+  TCustomer = class
+  private
+    FId: Integer;
+    FName: string;
+    FEmail: string;
+    FBalance: Currency;
+    FCreatedAt: TDateTime;
+    FOrders: ILazy<IEntityCollection<TOrder>>;
+    function GetOrders: IEntityCollection<TOrder>;
+  public
+    [PK, AutoInc]
+    property Id: Integer read FId write FId;
+
+    [Required, MaxLength(100)]
+    property Name: string read FName write FName;
+
+    [Required, MaxLength(255)]
+    property Email: string read FEmail write FEmail;
+
+    property Balance: Currency read FBalance write FBalance;
+
+    property CreatedAt: TDateTime read FCreatedAt write FCreatedAt;
+
+    [InverseProperty('Customer'), HasMany]
+    property Orders: IEntityCollection<TOrder> read GetOrders;
+  end;
+
+  TOrder = class
+  private
+    FId: Integer;
+    FCustomerId: Integer;
+    FTotalAmount: Currency;
+    FOrderDate: TDateTime;
+    FStatus: string;
+    FCustomer: ILazy<TCustomer>;
+    function GetCustomer: TCustomer;
+    procedure SetCustomer(const Value: TCustomer);
+  public
+    [PK, AutoInc]
+    property Id: Integer read FId write FId;
+
+    [Required, ForeignKey('customer_id'), BelongsTo]
+    property CustomerId: Integer read FCustomerId write FCustomerId;
+
+    [Required]
+    property TotalAmount: Currency read FTotalAmount write FTotalAmount;
+
+    property OrderDate: TDateTime read FOrderDate write FOrderDate;
+
+    [MaxLength(50)]
+    property Status: string read FStatus write FStatus;
+
+    property Customer: TCustomer read GetCustomer write SetCustomer;
+  end;
+
+implementation
+
+{ TCustomer }
+
+function TCustomer.GetOrders: IEntityCollection<TOrder>;
+begin
+  if FOrders = nil then
+    FOrders := TLazy<IEntityCollection<TOrder>>.Create;
+  Result := FOrders.Value;
+end;
+
+{ TOrder }
+
+function TOrder.GetCustomer: TCustomer;
+begin
+  if FCustomer <> nil then
+    Result := FCustomer.Value
+  else
+    Result := nil;
+end;
+
+procedure TOrder.SetCustomer(const Value: TCustomer);
+begin
+  if FCustomer = nil then
+    FCustomer := TLazy<TCustomer>.Create;
+  FCustomer.Value := Value;
+  if Value <> nil then
+    FCustomerId := Value.Id;
+end;
+
+end.

--- a/Examples/03-Data/Orm.UniDACDemo/UniDACDemo.Tests.Base.pas
+++ b/Examples/03-Data/Orm.UniDACDemo/UniDACDemo.Tests.Base.pas
@@ -1,0 +1,45 @@
+unit UniDACDemo.Tests.Base;
+
+interface
+
+uses
+  System.SysUtils,
+  Dext,
+  Dext.Entity.Core,
+  Dext.Entity.Setup;
+
+type
+  TUniDACTestBase = class
+  private
+    FContext: TDbContext;
+    function GetContext: TDbContext;
+  public
+    constructor Create; virtual;
+    destructor Destroy; override;
+    property Context: TDbContext read GetContext;
+  end;
+
+implementation
+
+{ TUniDACTestBase }
+
+constructor TUniDACTestBase.Create;
+begin
+  inherited Create;
+  FContext := nil;
+end;
+
+destructor TUniDACTestBase.Destroy;
+begin
+  FContext.Free;
+  inherited;
+end;
+
+function TUniDACTestBase.GetContext: TDbContext;
+begin
+  if FContext = nil then
+    FContext := TDbContext.Create(UniDACDemo.DbConfig.CreateOptions);
+  Result := FContext;
+end;
+
+end.

--- a/Examples/03-Data/Orm.UniDACDemo/UniDACDemo.Tests.Base.pas
+++ b/Examples/03-Data/Orm.UniDACDemo/UniDACDemo.Tests.Base.pas
@@ -5,12 +5,18 @@ interface
 uses
   System.SysUtils,
   Dext,
+  Dext.Entity,
+  Dext.Entity.Context,
   Dext.Entity.Core,
+  Dext.Entity.Drivers.Interfaces,
+  Dext.Entity.Dialects,
   Dext.Entity.Setup;
 
 type
   TUniDACTestBase = class
   private
+    FConn: IDbConnection;
+    FDialect: ISQLDialect;
     FContext: TDbContext;
     function GetContext: TDbContext;
   public
@@ -21,12 +27,20 @@ type
 
 implementation
 
+uses UniDACDemo.DbConfig;
+
 { TUniDACTestBase }
 
 constructor TUniDACTestBase.Create;
+var
+  Options: TDbContextOptions;
 begin
   inherited Create;
-  FContext := nil;
+  Options := CreateOptions;
+  FConn := Options.BuildConnection;
+  FDialect := TSQLiteDialect.Create;
+  FConn.Connect;
+  FContext := TDbContext.Create(FConn, FDialect);
 end;
 
 destructor TUniDACTestBase.Destroy;
@@ -37,8 +51,6 @@ end;
 
 function TUniDACTestBase.GetContext: TDbContext;
 begin
-  if FContext = nil then
-    FContext := TDbContext.Create(UniDACDemo.DbConfig.CreateOptions);
   Result := FContext;
 end;
 

--- a/Examples/03-Data/Orm.UniDACDemo/UniDACDemo.Tests.CRUD.pas
+++ b/Examples/03-Data/Orm.UniDACDemo/UniDACDemo.Tests.CRUD.pas
@@ -1,0 +1,113 @@
+unit UniDACDemo.Tests.CRUD;
+
+interface
+
+uses
+  System.SysUtils,
+  Dext,
+  Dext.Entity,
+  Dext.Entity.Core,
+  Dext.Collections,
+  UniDACDemo.Tests.Base,
+  UniDACDemo.Entities;
+
+procedure RunCRUDTests;
+
+implementation
+
+procedure RunCRUDTests;
+var
+  Base: TUniDACTestBase;
+  Customer: TCustomer;
+  List: IList<TCustomer>;
+begin
+  Base := TUniDACTestBase.Create;
+  try
+    // 1. Ensure schema
+    WriteLn('[1] Ensuring schema...');
+    Base.Context.EnsureSchema<TCustomer>;
+    Base.Context.EnsureSchema<TOrder>;
+    WriteLn('    Tables created.');
+    WriteLn;
+
+    // 2. INSERT
+    WriteLn('[2] INSERT - Adding customers...');
+    Customer := TCustomer.Create;
+    Customer.Name := 'Alice Johnson';
+    Customer.Email := 'alice@example.com';
+    Customer.Balance := 1500.50;
+    Customer.CreatedAt := Now;
+    Base.Context.Set<TCustomer>.Add(Customer);
+
+    Customer := TCustomer.Create;
+    Customer.Name := 'Bob Smith';
+    Customer.Email := 'bob@example.com';
+    Customer.Balance := 2300.00;
+    Customer.CreatedAt := Now;
+    Base.Context.Set<TCustomer>.Add(Customer);
+
+    Customer := TCustomer.Create;
+    Customer.Name := 'Carol White';
+    Customer.Email := 'carol@example.com';
+    Customer.Balance := 500.75;
+    Customer.CreatedAt := Now;
+    Base.Context.Set<TCustomer>.Add(Customer);
+
+    Base.Context.SaveChanges;
+    WriteLn('    3 customers inserted.');
+    WriteLn;
+
+    // 3. SELECT ALL
+    WriteLn('[3] SELECT ALL - Reading customers...');
+    List := Base.Context.Set<TCustomer>.ToList;
+    try
+      WriteLn(Format('    Found %d customers:', [List.Count]));
+      for Customer in List do
+        WriteLn(Format('      #%d  %-15s  %-25s  Balance: %m',
+          [Customer.Id, Customer.Name, Customer.Email, Customer.Balance]));
+    finally
+      // IList<T> manages memory
+    end;
+    WriteLn;
+
+    // 4. UPDATE
+    WriteLn('[4] UPDATE - Modifying customer #1...');
+    Customer := Base.Context.Set<TCustomer>.Find(1);
+    if Customer <> nil then
+    begin
+      Customer.Name := 'Alice Johnson-Updated';
+      Customer.Balance := 9999.99;
+      Base.Context.Set<TCustomer>.Update(Customer);
+      Base.Context.SaveChanges;
+      WriteLn('    Customer updated.');
+    end;
+    WriteLn;
+
+    // 5. DELETE
+    WriteLn('[5] DELETE - Removing customer #3...');
+    Customer := Base.Context.Set<TCustomer>.Find(3);
+    if Customer <> nil then
+    begin
+      Base.Context.Set<TCustomer>.Remove(Customer);
+      Base.Context.SaveChanges;
+      WriteLn('    Customer deleted.');
+    end;
+    WriteLn;
+
+    // 6. VERIFY FINAL STATE
+    WriteLn('[6] VERIFY - Final customer list:');
+    List := Base.Context.Set<TCustomer>.ToList;
+    try
+      WriteLn(Format('    Remaining: %d customers', [List.Count]));
+      for Customer in List do
+        WriteLn(Format('      #%d  %-25s  Balance: %m',
+          [Customer.Id, Customer.Name, Customer.Balance]));
+    finally
+    end;
+
+  finally
+    Base.Free;
+  end;
+end;
+
+end.

--- a/Examples/03-Data/Orm.UniDACDemo/UniDACDemo.Tests.CRUD.pas
+++ b/Examples/03-Data/Orm.UniDACDemo/UniDACDemo.Tests.CRUD.pas
@@ -25,8 +25,9 @@ begin
   try
     // 1. Ensure schema
     WriteLn('[1] Ensuring schema...');
-    Base.Context.EnsureSchema<TCustomer>;
-    Base.Context.EnsureSchema<TOrder>;
+    Base.Context.Entities<TCustomer>;
+    Base.Context.Entities<TOrder>;
+    Base.Context.EnsureCreated;
     WriteLn('    Tables created.');
     WriteLn;
 
@@ -37,21 +38,21 @@ begin
     Customer.Email := 'alice@example.com';
     Customer.Balance := 1500.50;
     Customer.CreatedAt := Now;
-    Base.Context.Set<TCustomer>.Add(Customer);
+    Base.Context.Entities<TCustomer>.Add(Customer);
 
     Customer := TCustomer.Create;
     Customer.Name := 'Bob Smith';
     Customer.Email := 'bob@example.com';
     Customer.Balance := 2300.00;
     Customer.CreatedAt := Now;
-    Base.Context.Set<TCustomer>.Add(Customer);
+    Base.Context.Entities<TCustomer>.Add(Customer);
 
     Customer := TCustomer.Create;
     Customer.Name := 'Carol White';
     Customer.Email := 'carol@example.com';
     Customer.Balance := 500.75;
     Customer.CreatedAt := Now;
-    Base.Context.Set<TCustomer>.Add(Customer);
+    Base.Context.Entities<TCustomer>.Add(Customer);
 
     Base.Context.SaveChanges;
     WriteLn('    3 customers inserted.');
@@ -59,7 +60,7 @@ begin
 
     // 3. SELECT ALL
     WriteLn('[3] SELECT ALL - Reading customers...');
-    List := Base.Context.Set<TCustomer>.ToList;
+    List := Base.Context.Entities<TCustomer>.ToList;
     try
       WriteLn(Format('    Found %d customers:', [List.Count]));
       for Customer in List do
@@ -72,12 +73,12 @@ begin
 
     // 4. UPDATE
     WriteLn('[4] UPDATE - Modifying customer #1...');
-    Customer := Base.Context.Set<TCustomer>.Find(1);
+    Customer := Base.Context.Entities<TCustomer>.Find(1);
     if Customer <> nil then
     begin
       Customer.Name := 'Alice Johnson-Updated';
       Customer.Balance := 9999.99;
-      Base.Context.Set<TCustomer>.Update(Customer);
+      Base.Context.Entities<TCustomer>.Update(Customer);
       Base.Context.SaveChanges;
       WriteLn('    Customer updated.');
     end;
@@ -85,10 +86,10 @@ begin
 
     // 5. DELETE
     WriteLn('[5] DELETE - Removing customer #3...');
-    Customer := Base.Context.Set<TCustomer>.Find(3);
+    Customer := Base.Context.Entities<TCustomer>.Find(3);
     if Customer <> nil then
     begin
-      Base.Context.Set<TCustomer>.Remove(Customer);
+      Base.Context.Entities<TCustomer>.Remove(Customer);
       Base.Context.SaveChanges;
       WriteLn('    Customer deleted.');
     end;
@@ -96,7 +97,7 @@ begin
 
     // 6. VERIFY FINAL STATE
     WriteLn('[6] VERIFY - Final customer list:');
-    List := Base.Context.Set<TCustomer>.ToList;
+    List := Base.Context.Entities<TCustomer>.ToList;
     try
       WriteLn(Format('    Remaining: %d customers', [List.Count]));
       for Customer in List do

--- a/Examples/03-Data/Orm.UniDACDemo/build_debug.bat
+++ b/Examples/03-Data/Orm.UniDACDemo/build_debug.bat
@@ -1,0 +1,47 @@
+@echo off
+rem *        Delphi 12 Debug Build (23.0)         *
+rem *        Orm.UniDACDemo — errors/warnings to file   *
+
+rem Set environment variables
+call "C:\Program Files (x86)\Embarcadero\Studio\23.0\bin\rsvars.bat"
+
+rem Change to project directory
+cd /d "%~dp0"
+
+rem Build project with Debug configuration and filter output
+echo Building Orm.UniDACDemo in Debug mode...
+msbuild Orm.UniDACDemo.dproj /p:Config=Debug /p:Platform=Win32 /v:minimal > build_full.txt 2>&1
+set BUILD_EXIT_CODE=%ERRORLEVEL%
+
+rem Extract only relevant lines for AI analysis
+(
+    echo ========================================
+    echo Build Output - Errors and Warnings Only
+    echo ========================================
+    echo.
+    findstr /i /c:"error" /c:"warning" /c:"failed" /c:"F2039" /c:"F2613" /c:"E2003" /c:"E2034" /c:"E2015" /c:"E2035" /c:"E2129" /c:"F2063" /c:"F1026" /c:"dcc32" /c:"Delphi compiler" /c:".pas(" /c:".dpr(" build_full.txt 2>nul
+    echo.
+    echo ========================================
+    echo Build Summary
+    echo ========================================
+    findstr /i /c:"Error(s)" /c:"Warning(s)" /c:"Time Elapsed" /c:"Build FAILED" /c:"Build succeeded" build_full.txt 2>nul
+) > build_output.txt
+
+rem Check build result
+if %BUILD_EXIT_CODE% EQU 0 (
+    echo.
+    echo ========================================
+    echo Build Successful!
+    echo ========================================
+    echo.
+    type build_output.txt
+    exit /b 0
+) else (
+    echo.
+    echo ========================================
+    echo Build Failed with exit code %BUILD_EXIT_CODE%
+    echo ========================================
+    echo.
+    type build_output.txt
+    exit /b %BUILD_EXIT_CODE%
+)

--- a/Sources/Data/Dext.Entity.Drivers.UniDAC.Links.pas
+++ b/Sources/Data/Dext.Entity.Drivers.UniDAC.Links.pas
@@ -1,0 +1,55 @@
+{***************************************************************************}
+{                                                                           }
+{           Dext Framework                                                  }
+{                                                                           }
+{           Copyright (C) 2025 Cesar Romero & Dext Contributors             }
+{                                                                           }
+{           Licensed under the Apache License, Version 2.0 (the "License"); }
+{           you may not use this file except in compliance with the License.}
+{           You may obtain a copy of the License at                         }
+{                                                                           }
+{               http://www.apache.org/licenses/LICENSE-2.0                  }
+{                                                                           }
+{           Unless required by applicable law or agreed to in writing,      }
+{           software distributed under the License is distributed on an     }
+{           "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    }
+{           either express or implied. See the License for the specific     }
+{           language governing permissions and limitations under the        }
+{           License.                                                        }
+{                                                                           }
+{***************************************************************************}
+{                                                                           }
+{  Author:  Dext Contributors                                               }
+{  Created: 2026-07-24                                                      }
+{                                                                           }
+{***************************************************************************}
+unit Dext.Entity.Drivers.UniDAC.Links;
+
+/// <summary>
+///   Links UniDAC providers by referencing their units, controlled by the
+///   same {$DEFINE} flags as Dext.Entity.Drivers.FireDAC.Links.
+///   Only include DEXT_USE_UNIDAC in your project when UniDAC is installed.
+/// </summary>
+
+interface
+
+{$I Dext.inc}
+
+uses
+  // UniDAC Standard Providers — mirror of FireDAC.Links flags
+  {$IFDEF DEXT_ENABLE_DB_SQLITE}   SQLiteUniProvider,     {$ENDIF}
+  {$IFDEF DEXT_ENABLE_DB_POSTGRES} PostgreSQLUniProvider, {$ENDIF}
+  {$IFDEF DEXT_ENABLE_DB_MYSQL}    MySQLUniProvider,      {$ENDIF}
+  {$IFDEF DEXT_ENABLE_DB_MSSQL}    SQLServerUniProvider,  {$ENDIF}
+  {$IFDEF DEXT_ENABLE_DB_ORACLE}   OracleUniProvider,     {$ENDIF}
+  // UniDAC uses "InterBase" provider for both Firebird and InterBase
+  {$IFDEF DEXT_ENABLE_DB_FIREBIRD} InterBaseUniProvider,  {$ENDIF}
+  {$IFDEF DEXT_ENABLE_DB_IB}       InterBaseUniProvider,  {$ENDIF}
+  {$IFDEF DEXT_ENABLE_DB_DB2}      DB2UniProvider,        {$ENDIF}
+  {$IFDEF DEXT_ENABLE_DB_ODBC}     ODBCUniProvider,       {$ENDIF}
+  System.SysUtils;
+
+implementation
+
+end.
+

--- a/Sources/Data/Dext.Entity.Drivers.UniDAC.Manager.pas
+++ b/Sources/Data/Dext.Entity.Drivers.UniDAC.Manager.pas
@@ -1,0 +1,214 @@
+{***************************************************************************}
+{                                                                           }
+{           Dext Framework                                                  }
+{                                                                           }
+{           Copyright (C) 2025 Cesar Romero & Dext Contributors             }
+{                                                                           }
+{           Licensed under the Apache License, Version 2.0 (the "License"); }
+{           you may not use this file except in compliance with the License.}
+{           You may obtain a copy of the License at                         }
+{                                                                           }
+{               http://www.apache.org/licenses/LICENSE-2.0                  }
+{                                                                           }
+{           Unless required by applicable law or agreed to in writing,      }
+{           software distributed under the License is distributed on an     }
+{           "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    }
+{           either express or implied. See the License for the specific     }
+{           language governing permissions and limitations under the        }
+{           License.                                                        }
+{                                                                           }
+{***************************************************************************}
+{                                                                           }
+{  Author:  Dext Contributors                                               }
+{  Created: 2026-07-24                                                      }
+{                                                                           }
+{***************************************************************************}
+unit Dext.Entity.Drivers.UniDAC.Manager;
+
+interface
+
+{$I Dext.inc}
+
+uses
+  System.SysUtils,
+  System.Classes,
+  System.SyncObjs,
+  Uni;   // TUniConnection (UniDAC core unit)
+
+type
+  /// <summary>
+  ///   Optimization hints that can be applied to UniDAC connections.
+  ///   Many FireDAC-specific flags (MacroCreate, EscapeExpand, DirectExecute)
+  ///   have no direct UniDAC equivalent and are silently ignored.
+  /// </summary>
+  TUniDACOptimization = (
+    uoptUseUnicode,         // Force Unicode string mode (important for SQLite)
+    uoptDisableAutoCommit   // Disable auto-commit (useful for batch operations)
+  );
+  TUniDACOptimizations = set of TUniDACOptimization;
+
+  /// <summary>
+  ///   Manages UniDAC connection creation and pooling configuration.
+  ///   Unlike the FireDAC equivalent (TDextFireDACManager), UniDAC does not
+  ///   require a global manager component: pooling is configured directly on
+  ///   each TUniConnection via Pooling=True and PoolingOptions.MaxPoolSize.
+  ///   This class is therefore a lightweight factory/configurator singleton.
+  /// </summary>
+  TDextUniDACManager = class
+  private
+    class var FInstance: TDextUniDACManager;
+    class var FCriticalSection: TCriticalSection;
+    constructor Create;
+  public
+    class constructor Create;
+    class destructor Destroy;
+    destructor Destroy; override;
+
+    /// <summary>
+    ///   Access the singleton instance.
+    /// </summary>
+    class function Instance: TDextUniDACManager;
+
+    /// <summary>
+    ///   Global cleanup — releases singleton.
+    /// </summary>
+    class procedure Finalize;
+
+    /// <summary>
+    ///   Creates a TUniConnection configured with connection pooling.
+    ///   The caller is responsible for freeing the connection (or wrapping
+    ///   it in TUniDACConnection with AOwnsConnection=True).
+    ///   ProviderName must be the UniDAC provider string (e.g., 'SQLite',
+    ///   'PostgreSQL', 'MySQL', 'SQL Server', 'Oracle', 'Interbase').
+    /// </summary>
+    function CreatePooledConnection(const AProviderName: string;
+      const AParams: TStrings; APoolMax: Integer = 50): TUniConnection;
+
+    /// <summary>
+    ///   Applies UniDAC-specific optimizations to a connection.
+    ///   Called after creation, before Connect.
+    /// </summary>
+    procedure ApplyOptions(AConnection: TUniConnection;
+      const AOptimizations: TUniDACOptimizations);
+
+    /// <summary>
+    ///   Maps a Dext/FireDAC driver name to a UniDAC ProviderName string.
+    ///   FireDAC names: SQLite, PG, MySQL, MSSQL, Oracle, FB, IB, DB2, ODBC
+    ///   UniDAC names:  SQLite, PostgreSQL, MySQL, SQL Server, Oracle, Interbase, ...
+    /// </summary>
+    class function MapDriverToProvider(const ADriverName: string): string;
+  end;
+
+implementation
+
+{ TDextUniDACManager }
+
+class constructor TDextUniDACManager.Create;
+begin
+  FCriticalSection := TCriticalSection.Create;
+end;
+
+class destructor TDextUniDACManager.Destroy;
+begin
+  Finalize;
+  FCriticalSection.Free;
+end;
+
+constructor TDextUniDACManager.Create;
+begin
+  inherited Create;
+end;
+
+destructor TDextUniDACManager.Destroy;
+begin
+  inherited;
+end;
+
+class procedure TDextUniDACManager.Finalize;
+begin
+  FCriticalSection.Enter;
+  try
+    FreeAndNil(FInstance);
+  finally
+    FCriticalSection.Leave;
+  end;
+end;
+
+class function TDextUniDACManager.Instance: TDextUniDACManager;
+begin
+  if FInstance = nil then
+  begin
+    FCriticalSection.Enter;
+    try
+      if FInstance = nil then
+        FInstance := TDextUniDACManager.Create;
+    finally
+      FCriticalSection.Leave;
+    end;
+  end;
+  Result := FInstance;
+end;
+
+class function TDextUniDACManager.MapDriverToProvider(const ADriverName: string): string;
+var
+  Lower: string;
+begin
+  Lower := LowerCase(ADriverName);
+  // FireDAC DriverID → UniDAC ProviderName
+  if (Lower = 'sqlite') or (Lower = 'lite')                then Result := 'SQLite'
+  else if (Lower = 'pg') or (Lower = 'postgresql')         then Result := 'PostgreSQL'
+  else if (Lower = 'mysql')                                  then Result := 'MySQL'
+  else if (Lower = 'mssql') or (Lower = 'sql server')      then Result := 'SQL Server'
+  else if (Lower = 'oracle') or (Lower = 'ora')            then Result := 'Oracle'
+  else if (Lower = 'fb') or (Lower = 'firebird')           then Result := 'Interbase'
+  else if (Lower = 'ib') or (Lower = 'interbase')          then Result := 'Interbase'
+  else if (Lower = 'db2')                                    then Result := 'DB2'
+  else if (Lower = 'odbc')                                   then Result := 'ODBC'
+  else
+    Result := ADriverName; // pass through as-is and let UniDAC raise its own error
+end;
+
+function TDextUniDACManager.CreatePooledConnection(const AProviderName: string;
+  const AParams: TStrings; APoolMax: Integer): TUniConnection;
+var
+  i: Integer;
+begin
+  Result := TUniConnection.Create(nil);
+  try
+    Result.ProviderName := AProviderName;
+
+    // Copy all key=value params
+    if AParams <> nil then
+      for i := 0 to AParams.Count - 1 do
+        Result.SpecificOptions.Values[AParams.Names[i]] := AParams.ValueFromIndex[i];
+
+    // Enable UniDAC built-in connection pooling
+    Result.Pooling := True;
+    Result.PoolingOptions.MaxPoolSize := APoolMax;
+    Result.PoolingOptions.MinPoolSize := 1;
+    Result.PoolingOptions.ConnectionLifetime := 0; // 0 = unlimited
+    Result.PoolingOptions.Validate := True;        // validate before reuse
+  except
+    Result.Free;
+    raise;
+  end;
+end;
+
+procedure TDextUniDACManager.ApplyOptions(AConnection: TUniConnection;
+  const AOptimizations: TUniDACOptimizations);
+var
+  LProvider: string;
+begin
+  LProvider := LowerCase(AConnection.ProviderName);
+
+  // Unicode mode — especially important for SQLite
+  if (uoptUseUnicode in AOptimizations) or (LProvider = 'sqlite') then
+    AConnection.SpecificOptions.Values['UseUnicode'] := 'True';
+
+  // Auto-commit control
+  if uoptDisableAutoCommit in AOptimizations then
+    AConnection.AutoCommit := False;
+end;
+
+end.
+

--- a/Sources/Data/Dext.Entity.Drivers.UniDAC.pas
+++ b/Sources/Data/Dext.Entity.Drivers.UniDAC.pas
@@ -1,0 +1,1167 @@
+{***************************************************************************}
+{                                                                           }
+{           Dext Framework                                                  }
+{                                                                           }
+{           Copyright (C) 2025 Cesar Romero & Dext Contributors             }
+{                                                                           }
+{           Licensed under the Apache License, Version 2.0 (the "License"); }
+{           you may not use this file except in compliance with the License.}
+{           You may obtain a copy of the License at                         }
+{                                                                           }
+{               http://www.apache.org/licenses/LICENSE-2.0                  }
+{                                                                           }
+{           Unless required by applicable law or agreed to in writing,      }
+{           software distributed under the License is distributed on an     }
+{           "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    }
+{           either express or implied. See the License for the specific     }
+{           language governing permissions and limitations under the        }
+{           License.                                                        }
+{                                                                           }
+{***************************************************************************}
+{                                                                           }
+{  Author:  Dext Contributors                                               }
+{  Created: 2026-07-24                                                      }
+{                                                                           }
+{  Notes:                                                                   }
+{    - Mirrors Dext.Entity.Drivers.FireDAC.pas but uses UniDAC components.  }
+{    - Batch DML (SetArraySize / SetParamArray / ExecuteBatch) is           }
+{      simulated via a serial loop because UniDAC lacks native ArrayDML.    }
+{    - GetLastInsertId uses a dialect-specific SQL query.                   }
+{    - UniDAC uses standard Data.DB.TParam (not TFDParam).                  }
+{                                                                           }
+{***************************************************************************}
+unit Dext.Entity.Drivers.UniDAC;
+
+interface
+
+{$I Dext.inc}
+
+uses
+  System.SysUtils,
+  System.Classes,
+  System.Variants,
+  System.Rtti,
+  System.TypInfo,
+  Dext.Collections,
+  System.DateUtils,
+  Data.DB,
+  Data.FmtBcd,
+  Uni,          // TUniConnection, TUniQuery (UniDAC core)
+  UniScript,    // for TUniScript (optional, if needed)
+  Dext.Entity.Drivers.UniDAC.Links,
+  Dext.Entity.Drivers.Interfaces,
+  Dext.Entity.TypeConverters,
+  Dext.Entity.Dialects,
+  Dext.Types.Nullable,
+  Dext.Types.UUID;
+
+type
+  TUniDACConnection = class;
+
+  // -------------------------------------------------------------------------
+  // TUniDACTransaction
+  // -------------------------------------------------------------------------
+
+  /// <summary>
+  ///   UniDAC transaction manager. Wraps TUniConnection StartTransaction/Commit/Rollback.
+  ///   UniDAC manages transactions directly on TUniConnection (no separate transaction object).
+  /// </summary>
+  TUniDACTransaction = class(TInterfacedObject, IDbTransaction)
+  private
+    FConnection: TUniConnection;
+  public
+    constructor Create(AConnection: TUniConnection);
+    procedure Commit;
+    procedure Rollback;
+  end;
+
+  // -------------------------------------------------------------------------
+  // TUniDACReader
+  // -------------------------------------------------------------------------
+
+  /// <summary>
+  ///   Implementation of IDbReader using a TUniQuery for forward-only row reading.
+  /// </summary>
+  TUniDACReader = class(TInterfacedObject, IDbReader)
+  private
+    FQuery: TUniQuery;
+    FOwnsQuery: Boolean;
+    FIsFirstMove: Boolean;
+  public
+    constructor Create(AQuery: TUniQuery; AOwnsQuery: Boolean);
+    destructor Destroy; override;
+
+    function Next: Boolean;
+    function GetValue(const AColumnName: string): TValue; overload;
+    function GetValue(AColumnIndex: Integer): TValue; overload;
+    function GetColumnCount: Integer;
+    function GetColumnName(AIndex: Integer): string;
+    procedure Close;
+  end;
+
+  // -------------------------------------------------------------------------
+  // TUniDACCommand
+  // -------------------------------------------------------------------------
+
+  /// <summary>
+  ///   UniDAC SQL command. Supports query, non-query, scalar, and batch execution.
+  ///   Batch execution is simulated via a serial loop (UniDAC has no native ArrayDML).
+  /// </summary>
+  TUniDACCommand = class(TInterfacedObject, IDbCommand)
+  private
+    FQuery: TUniQuery;
+    FConnection: TUniConnection;
+    FDialect: TDatabaseDialect;
+    FOnLog: TProc<string>;
+    // Batch DML simulation storage: param_name → array of values
+    FBatchParams: TArray<TPair<string, TArray<TValue>>>;
+    FArraySize: Integer;
+
+    procedure LogSqlCommand(const ASQL: string);
+    procedure SetParamValue(Param: TParam; const AValue: TValue);
+    procedure SetParamValueWithType(Param: TParam; const AValue: TValue;
+      ADataType: TFieldType);
+    function GetDialect: TDatabaseDialect;
+    function FindOrCreateBatchParam(const AName: string): Integer;
+  public
+    constructor Create(AConnection: TUniConnection; ADialect: TDatabaseDialect);
+    destructor Destroy; override;
+
+    procedure SetSQL(const ASQL: string);
+    procedure AddParam(const AName: string; const AValue: TValue); overload;
+    procedure AddParam(const AName: string; const AValue: TValue;
+      ADataType: TFieldType); overload;
+    procedure BindSequentialParams(const AValues: TArray<TValue>);
+    procedure SetParamType(const AName: string; AType: TParamType);
+    function GetParamValue(const AName: string): TValue;
+    procedure ClearParams;
+
+    procedure Execute;
+    function ExecuteQuery: IDbReader;
+    function ExecuteNonQuery: Integer;
+    function ExecuteScalar: TValue;
+
+    // Batch DML — simulated via serial loop
+    procedure SetArraySize(const ASize: Integer);
+    procedure SetParamArray(const AName: string; const AValues: TArray<TValue>);
+    procedure ExecuteBatch(const ATimes: Integer; const AOffset: Integer = 0);
+  end;
+
+  // -------------------------------------------------------------------------
+  // TUniDACConnection
+  // -------------------------------------------------------------------------
+
+  /// <summary>
+  ///   Physical UniDAC connection wrapping TUniConnection.
+  ///   Supports pooling, dialect auto-detection, and schema switching.
+  /// </summary>
+  TUniDACConnection = class(TInterfacedObject, IDbConnection)
+  private
+    FConnection: TUniConnection;
+    FOwnsConnection: Boolean;
+    FOnLog: TProc<string>;
+    FDialect: TDatabaseDialect;
+    procedure DetectDialect;
+    procedure DoAfterConnect(Sender: TObject);
+  public
+    constructor Create(AConnection: TUniConnection; AOwnsConnection: Boolean = True);
+    destructor Destroy; override;
+
+    procedure Connect;
+    procedure Disconnect;
+    function IsConnected: Boolean;
+
+    function BeginTransaction: IDbTransaction;
+    function CreateCommand(const ASQL: string): IDbCommand;
+    function GetLastInsertId: Variant;
+    function TableExists(const ATableName: string): Boolean;
+    function IsPooled: Boolean;
+
+    function GetConnectionString: string;
+    procedure SetConnectionString(const AValue: string);
+    property ConnectionString: string read GetConnectionString write SetConnectionString;
+
+    function GetDialect: TDatabaseDialect;
+    property Dialect: TDatabaseDialect read GetDialect;
+
+    procedure SetOnLog(AValue: TProc<string>);
+    function GetOnLog: TProc<string>;
+    property OnLog: TProc<string> read GetOnLog write SetOnLog;
+
+    property Connection: TUniConnection read FConnection;
+  end;
+
+implementation
+
+uses
+  Dext.Core.Reflection;
+
+// ---------------------------------------------------------------------------
+// UniDACFieldToTValue — converts a TField to TValue
+// Since UniDAC fields inherit from Data.DB.TField exactly like FireDAC,
+// this function is structurally identical to FireDACFieldToTValue.
+// ---------------------------------------------------------------------------
+function UniDACFieldToTValue(Field: TField): TValue;
+begin
+  if (Field = nil) or Field.IsNull then
+    Exit(TValue.Empty);
+  try
+    case Field.DataType of
+      ftUnknown:
+        Result := TValue.FromVariant(Field.Value);
+      ftString, ftWideString, ftMemo, ftWideMemo, ftFixedChar, ftFixedWideChar:
+        Result := TValue.From<string>(Field.AsWideString);
+      ftSmallint, ftShortint:
+        Result := TValue.From<Integer>(Field.AsInteger);
+      ftInteger, ftAutoInc, ftWord:
+        Result := TValue.From<Integer>(Field.AsInteger);
+      ftLongWord:
+        Result := TValue.From<Int64>(Field.AsLargeInt);
+      ftLargeint:
+        Result := TValue.From<Int64>(Field.AsLargeInt);
+      ftFloat, ftSingle:
+        Result := TValue.From<Double>(Field.AsFloat);
+      ftExtended:
+        Result := TValue.From<Double>(Field.AsFloat);
+      ftCurrency, ftBCD:
+        Result := TValue.From<Currency>(Field.AsCurrency);
+      ftFMTBcd:
+        try
+          Result := TValue.From<Currency>(Field.AsCurrency);
+        except
+          Result := TValue.From<Double>(Field.AsFloat);
+        end;
+      ftBoolean:
+        Result := TValue.From<Boolean>(Field.AsBoolean);
+      ftDate:
+        Result := TValue.From<TDate>(DateOf(Field.AsDateTime));
+      ftTime:
+        Result := TValue.From<TTime>(TimeOf(Field.AsDateTime));
+      ftDateTime, ftTimeStamp, ftOraTimeStamp, ftTimeStampOffset:
+        Result := TValue.From<TDateTime>(Field.AsDateTime);
+      ftBlob, ftOraBlob, ftGraphic, ftTypedBinary, ftParadoxOle,
+      ftDBaseOle, ftVarBytes, ftBytes:
+        try
+          Result := TValue.From<TBytes>(Field.AsBytes);
+        except
+          Result := TValue.FromVariant(Field.Value);
+        end;
+      ftGuid:
+        Result := TValue.From<TGUID>(StringToGUID(Field.AsString));
+    else
+      Result := TValue.FromVariant(Field.Value);
+    end;
+  except
+    on E: EVariantTypeCastError do
+      Result := TValue.FromVariant(Field.Value);
+  end;
+end;
+
+// ---------------------------------------------------------------------------
+// TUniDACTransaction
+// ---------------------------------------------------------------------------
+
+constructor TUniDACTransaction.Create(AConnection: TUniConnection);
+begin
+  inherited Create;
+  FConnection := AConnection;
+  FConnection.StartTransaction;
+end;
+
+procedure TUniDACTransaction.Commit;
+begin
+  FConnection.Commit;
+end;
+
+procedure TUniDACTransaction.Rollback;
+begin
+  FConnection.Rollback;
+end;
+
+// ---------------------------------------------------------------------------
+// TUniDACReader
+// ---------------------------------------------------------------------------
+
+constructor TUniDACReader.Create(AQuery: TUniQuery; AOwnsQuery: Boolean);
+begin
+  inherited Create;
+  FQuery := AQuery;
+  FOwnsQuery := AOwnsQuery;
+  FIsFirstMove := True;
+end;
+
+destructor TUniDACReader.Destroy;
+begin
+  if FOwnsQuery then
+    FQuery.Free;
+  inherited;
+end;
+
+procedure TUniDACReader.Close;
+begin
+  FQuery.Close;
+end;
+
+function TUniDACReader.GetColumnCount: Integer;
+begin
+  Result := FQuery.FieldCount;
+end;
+
+function TUniDACReader.GetColumnName(AIndex: Integer): string;
+begin
+  Result := FQuery.Fields[AIndex].FieldName;
+end;
+
+function TUniDACReader.GetValue(AColumnIndex: Integer): TValue;
+begin
+  Result := UniDACFieldToTValue(FQuery.Fields[AColumnIndex]);
+end;
+
+function TUniDACReader.GetValue(const AColumnName: string): TValue;
+begin
+  Result := GetValue(FQuery.FieldByName(AColumnName).Index);
+end;
+
+function TUniDACReader.Next: Boolean;
+begin
+  if not FQuery.Active then
+    Exit(False);
+
+  if FIsFirstMove then
+  begin
+    FIsFirstMove := False;
+    // TDataSet is already at First after Open; Eof=True when empty.
+    Result := not FQuery.Eof;
+  end
+  else
+  begin
+    FQuery.Next;
+    Result := not FQuery.Eof;
+  end;
+end;
+
+// ---------------------------------------------------------------------------
+// TUniDACCommand
+// ---------------------------------------------------------------------------
+
+constructor TUniDACCommand.Create(AConnection: TUniConnection;
+  ADialect: TDatabaseDialect);
+begin
+  inherited Create;
+  FConnection := AConnection;
+  FDialect := ADialect;
+  FArraySize := 0;
+  FQuery := TUniQuery.Create(nil);
+  FQuery.Connection := FConnection;
+end;
+
+destructor TUniDACCommand.Destroy;
+begin
+  FQuery.Free;
+  inherited;
+end;
+
+function TUniDACCommand.GetDialect: TDatabaseDialect;
+begin
+  Result := FDialect;
+end;
+
+procedure TUniDACCommand.LogSqlCommand(const ASQL: string);
+var
+  i: Integer;
+begin
+  if not Assigned(FOnLog) then Exit;
+
+  FOnLog('SQL: ' + ASQL);
+  if (FQuery.Params <> nil) and (FQuery.Params.Count > 0) then
+  begin
+    for i := 0 to FQuery.Params.Count - 1 do
+      FOnLog(Format('  Param[%s]: Type=%s, Value=%s',
+        [FQuery.Params[i].Name,
+         GetEnumName(TypeInfo(TFieldType), Integer(FQuery.Params[i].DataType)),
+         VarToStr(FQuery.Params[i].Value)]));
+  end;
+end;
+
+procedure TUniDACCommand.SetSQL(const ASQL: string);
+begin
+  FQuery.Params.Clear;
+  FQuery.SQL.Text := ASQL;
+  SetLength(FBatchParams, 0);
+  FArraySize := 0;
+end;
+
+procedure TUniDACCommand.ClearParams;
+begin
+  FQuery.Params.Clear;
+  SetLength(FBatchParams, 0);
+end;
+
+procedure TUniDACCommand.AddParam(const AName: string; const AValue: TValue);
+var
+  Param: TParam;
+begin
+  Param := FQuery.ParamByName(AName);
+  SetParamValue(Param, AValue);
+end;
+
+procedure TUniDACCommand.AddParam(const AName: string; const AValue: TValue;
+  ADataType: TFieldType);
+var
+  Param: TParam;
+begin
+  Param := FQuery.ParamByName(AName);
+  SetParamValueWithType(Param, AValue, ADataType);
+end;
+
+procedure TUniDACCommand.BindSequentialParams(const AValues: TArray<TValue>);
+var
+  i: Integer;
+begin
+  if Length(AValues) = 0 then
+    Exit;
+
+  if FQuery.Params.Count <> Length(AValues) then
+    raise Exception.CreateFmt(
+      'FromSql parameter count mismatch: SQL has %d parameter(s) but %d value(s) were supplied.',
+      [FQuery.Params.Count, Length(AValues)]);
+
+  for i := 0 to High(AValues) do
+    SetParamValue(FQuery.Params[i], AValues[i]);
+
+  FQuery.Prepare;
+end;
+
+procedure TUniDACCommand.SetParamType(const AName: string; AType: TParamType);
+begin
+  FQuery.ParamByName(AName).ParamType := AType;
+end;
+
+function TUniDACCommand.GetParamValue(const AName: string): TValue;
+begin
+  Result := TValue.FromVariant(FQuery.ParamByName(AName).Value);
+end;
+
+procedure TUniDACCommand.Execute;
+begin
+  ExecuteNonQuery;
+end;
+
+function TUniDACCommand.ExecuteNonQuery: Integer;
+begin
+  LogSqlCommand(FQuery.SQL.Text);
+  try
+    FQuery.ExecSQL;
+    Result := FQuery.RowsAffected;
+  except
+    on E: Exception do
+    begin
+      if Assigned(FOnLog) then
+        FOnLog('  ❌ Error: ' + E.Message);
+      raise;
+    end;
+  end;
+end;
+
+function TUniDACCommand.ExecuteQuery: IDbReader;
+var
+  Q: TUniQuery;
+  i: Integer;
+  Src, Dest: TParam;
+begin
+  Q := TUniQuery.Create(nil);
+  try
+    Q.Connection := FConnection;
+    Q.SQL.Text := FQuery.SQL.Text;
+
+    LogSqlCommand(Q.SQL.Text);
+
+    // Copy params
+    for i := 0 to FQuery.Params.Count - 1 do
+    begin
+      Src := FQuery.Params[i];
+      Dest := Q.Params.FindParam(Src.Name);
+      if Dest <> nil then
+      begin
+        Dest.DataType := Src.DataType;
+        Dest.Value := Src.Value;
+      end;
+    end;
+
+    Q.Open;
+    Result := TUniDACReader.Create(Q, True); // Reader owns the new query
+  except
+    on E: Exception do
+    begin
+      if Assigned(FOnLog) then
+        FOnLog(Format('ERROR executing SQL: %s', [E.Message]));
+      Q.Free;
+      raise;
+    end;
+  end;
+end;
+
+function TUniDACCommand.ExecuteScalar: TValue;
+begin
+  LogSqlCommand(FQuery.SQL.Text);
+  try
+    FQuery.Open;
+    try
+      if not FQuery.Eof then
+        Result := UniDACFieldToTValue(FQuery.Fields[0])
+      else
+        Result := TValue.Empty;
+    finally
+      FQuery.Close;
+    end;
+  except
+    on E: Exception do
+    begin
+      if Assigned(FOnLog) then
+        FOnLog('  ❌ Error: ' + E.Message);
+      raise;
+    end;
+  end;
+end;
+
+// ---------------------------------------------------------------------------
+// Batch DML simulation
+// UniDAC has no native ArrayDML equivalent to FireDAC's Params.ArraySize +
+// TFDQuery.Execute(N). We simulate it by storing arrays of values and
+// executing the query once per row in ExecuteBatch.
+// ---------------------------------------------------------------------------
+
+function TUniDACCommand.FindOrCreateBatchParam(const AName: string): Integer;
+var
+  i: Integer;
+begin
+  for i := 0 to High(FBatchParams) do
+    if SameText(FBatchParams[i].Key, AName) then
+      Exit(i);
+  // Not found → append
+  i := Length(FBatchParams);
+  SetLength(FBatchParams, i + 1);
+  FBatchParams[i].Key := AName;
+  SetLength(FBatchParams[i].Value, 0);
+  Result := i;
+end;
+
+procedure TUniDACCommand.SetArraySize(const ASize: Integer);
+begin
+  FArraySize := ASize;
+  // Pre-size all existing batch param arrays
+  var i: Integer;
+  for i := 0 to High(FBatchParams) do
+    SetLength(FBatchParams[i].Value, ASize);
+end;
+
+procedure TUniDACCommand.SetParamArray(const AName: string;
+  const AValues: TArray<TValue>);
+var
+  Idx: Integer;
+begin
+  Idx := FindOrCreateBatchParam(AName);
+  FBatchParams[Idx].Value := Copy(AValues, 0, Length(AValues));
+  if FArraySize < Length(AValues) then
+    FArraySize := Length(AValues);
+end;
+
+procedure TUniDACCommand.ExecuteBatch(const ATimes: Integer;
+  const AOffset: Integer);
+var
+  Row, ParamIdx: Integer;
+  Pair: TPair<string, TArray<TValue>>;
+  Param: TParam;
+  RowOffset: Integer;
+begin
+  LogSqlCommand(FQuery.SQL.Text +
+    Format(' (Batch simulation: %d rows, offset %d)', [ATimes, AOffset]));
+  try
+    for Row := AOffset to AOffset + ATimes - 1 do
+    begin
+      // Set param values for this row from the stored arrays
+      for ParamIdx := 0 to High(FBatchParams) do
+      begin
+        Pair := FBatchParams[ParamIdx];
+        Param := FQuery.Params.FindParam(Pair.Key);
+        if (Param <> nil) and (Row < Length(Pair.Value)) then
+          SetParamValue(Param, Pair.Value[Row]);
+      end;
+      FQuery.ExecSQL;
+    end;
+  except
+    on E: Exception do
+    begin
+      if Assigned(FOnLog) then
+        FOnLog('  ❌ Error in batch execution: ' + E.Message);
+      raise;
+    end;
+  end;
+end;
+
+// ---------------------------------------------------------------------------
+// SetParamValue — mirrors FireDAC's SetParamValue using standard TParam
+// ---------------------------------------------------------------------------
+
+procedure TUniDACCommand.SetParamValueWithType(Param: TParam;
+  const AValue: TValue; ADataType: TFieldType);
+var
+  V: TValue;
+  Bytes: TBytes;
+begin
+  V := AValue;
+  TReflection.TryUnwrapProp(V, V);
+
+  Param.DataType := ADataType;
+
+  if V.IsEmpty then
+  begin
+    Param.Clear;
+    Exit;
+  end;
+
+  case ADataType of
+    ftString, ftWideString, ftMemo, ftWideMemo:
+      Param.AsWideString := V.AsString;
+    ftSmallint, ftInteger, ftWord, ftShortint:
+      if V.Kind = tkEnumeration then
+        Param.AsInteger := V.AsOrdinal
+      else
+        Param.AsInteger := V.AsInteger;
+    ftLargeint:
+      Param.AsLargeInt := V.AsInt64;
+    ftFloat, ftCurrency, ftExtended:
+      Param.AsFloat := V.AsExtended;
+    ftBCD:
+      Param.AsCurrency := V.AsType<Currency>;
+    ftFMTBcd:
+      case V.Kind of
+        tkFloat:   Param.AsFloat := V.AsExtended;
+        tkInteger, tkInt64: Param.AsFloat := V.AsInt64;
+        tkString, tkUString, tkWString, tkLString:
+          Param.AsFloat := StrToFloat(V.AsString);
+      else
+        Param.AsFloat := V.AsExtended;
+      end;
+    ftDate:
+      Param.AsDate := V.AsType<TDate>;
+    ftTime:
+      Param.AsTime := V.AsType<TTime>;
+    ftDateTime, ftTimeStamp, ftOraTimeStamp, ftTimeStampOffset:
+      Param.AsDateTime := V.AsType<TDateTime>;
+    ftBoolean:
+      Param.AsBoolean := V.AsBoolean;
+    ftBlob, ftGraphic, ftParadoxOle, ftDBaseOle, ftTypedBinary, ftOraBlob:
+    begin
+      if V.TypeInfo = TypeInfo(TBytes) then
+      begin
+        Bytes := V.AsType<TBytes>;
+        Param.SetBlobRawData(Length(Bytes), @Bytes[0]);
+      end
+      else
+        Param.Value := V.AsVariant;
+    end;
+    ftGuid:
+      Param.AsString := StringReplace(V.AsString, '{', '',
+        [rfReplaceAll, rfIgnoreCase]).Replace('}', '');
+  else
+    Param.Value := V.AsVariant;
+  end;
+end;
+
+procedure TUniDACCommand.SetParamValue(Param: TParam; const AValue: TValue);
+var
+  Converter: ITypeConverter;
+  ConvertedValue: TValue;
+  TypeName: string;
+  IsByteArray: Boolean;
+  Bytes: TBytes;
+  Helper: TNullableHelper;
+  InnerVal: TValue;
+  Underlying: PTypeInfo;
+begin
+  if AValue.IsEmpty then
+  begin
+    Param.Clear;
+    // Set a reasonable DataType for NULL values to avoid "unknown type" errors
+    if AValue.TypeInfo <> nil then
+    begin
+      TypeName := string(AValue.TypeInfo.Name);
+      if (TypeName = 'TBytes') or (TypeName = 'TArray<System.Byte>') or
+         (TypeName = 'TArray<Byte>') then
+        Param.DataType := ftBlob
+      else if Param.DataType = ftUnknown then
+      begin
+        case AValue.TypeInfo.Kind of
+          tkInteger, tkInt64:    Param.DataType := ftInteger;
+          tkFloat:
+            if AValue.TypeInfo = TypeInfo(TDateTime) then Param.DataType := ftDateTime
+            else if AValue.TypeInfo = TypeInfo(TDate) then Param.DataType := ftDate
+            else if AValue.TypeInfo = TypeInfo(TTime) then Param.DataType := ftTime
+            else Param.DataType := ftFloat;
+          tkString, tkUString, tkWString, tkChar, tkWChar:
+            Param.DataType := ftWideString;
+          tkEnumeration:
+            if AValue.TypeInfo = TypeInfo(Boolean) then Param.DataType := ftBoolean
+            else Param.DataType := ftInteger;
+        else
+          Param.DataType := ftWideString;
+        end;
+      end;
+    end
+    else if Param.DataType = ftUnknown then
+      Param.DataType := ftWideString;
+    Exit;
+  end;
+
+  // Try registered type converter first
+  Converter := TTypeConverterRegistry.Instance.GetConverter(AValue.TypeInfo);
+
+  if Converter <> nil then
+  begin
+    ConvertedValue := Converter.ToDatabase(AValue, GetDialect);
+
+    // GUID handling — force ftGuid for UUID/TGUID types
+    if (AValue.TypeInfo = TypeInfo(TGUID)) or (AValue.TypeInfo = TypeInfo(TUUID)) then
+    begin
+      Param.DataType := ftGuid;
+      Param.AsString := ConvertedValue.AsString;
+    end
+    else if (ConvertedValue.Kind in [tkString, tkUString, tkWString]) and
+            ((Length(ConvertedValue.AsString) = 36) or
+             (Length(ConvertedValue.AsString) = 38)) and
+            (ConvertedValue.AsString.IndexOf('-') > 0) then
+    begin
+      Param.DataType := ftGuid;
+      Param.AsString := ConvertedValue.AsString;
+    end
+    else
+    case ConvertedValue.Kind of
+      tkInteger, tkInt64:
+      begin
+        Param.DataType := ftLargeint;
+        Param.AsLargeInt := ConvertedValue.AsInt64;
+      end;
+      tkFloat:
+      begin
+        if ConvertedValue.TypeInfo = TypeInfo(TDateTime) then
+        begin
+          Param.DataType := ftDateTime;
+          Param.AsDateTime := ConvertedValue.AsType<TDateTime>;
+        end
+        else if ConvertedValue.TypeInfo = TypeInfo(TDate) then
+        begin
+          Param.DataType := ftDate;
+          Param.AsDate := ConvertedValue.AsType<TDate>;
+        end
+        else if ConvertedValue.TypeInfo = TypeInfo(TTime) then
+        begin
+          Param.DataType := ftTime;
+          Param.AsTime := ConvertedValue.AsType<TTime>;
+        end
+        else
+        begin
+          Param.DataType := ftFloat;
+          Param.AsFloat := ConvertedValue.AsExtended;
+        end;
+      end;
+      tkString, tkUString, tkWString, tkChar, tkWChar:
+      begin
+        Param.DataType := ftWideString;
+        Param.AsWideString := ConvertedValue.AsString;
+      end;
+      tkDynArray:
+      begin
+        IsByteArray := False;
+        if ConvertedValue.TypeInfo <> nil then
+        begin
+          TypeName := string(ConvertedValue.TypeInfo.Name);
+          IsByteArray := (TypeName = 'TBytes') or
+                         (TypeName = 'TArray<System.Byte>') or
+                         (TypeName = 'TArray<Byte>');
+        end;
+        if IsByteArray then
+        begin
+          Param.DataType := ftBlob;
+          Bytes := ConvertedValue.AsType<TBytes>;
+          if Length(Bytes) > 0 then
+            Param.SetBlobRawData(Length(Bytes), @Bytes[0])
+          else
+            Param.Clear;
+        end
+        else
+          Param.Value := ConvertedValue.AsVariant;
+      end;
+    else
+      Param.Value := ConvertedValue.AsVariant;
+    end;
+  end  // end if Converter <> nil
+  else
+  begin
+    case AValue.Kind of
+      tkInteger, tkInt64:
+      begin
+        Param.DataType := ftLargeint;
+        Param.AsLargeInt := AValue.AsInt64;
+      end;
+      tkFloat:
+      begin
+        if AValue.TypeInfo = TypeInfo(TDateTime) then
+        begin
+          Param.DataType := ftDateTime;
+          Param.AsDateTime := AValue.AsType<TDateTime>;
+        end
+        else if AValue.TypeInfo = TypeInfo(TDate) then
+        begin
+          Param.DataType := ftDate;
+          Param.AsDate := AValue.AsType<TDate>;
+        end
+        else if AValue.TypeInfo = TypeInfo(TTime) then
+        begin
+          Param.DataType := ftTime;
+          Param.AsTime := AValue.AsType<TTime>;
+        end
+        else
+        begin
+          Param.DataType := ftFloat;
+          Param.AsFloat := AValue.AsExtended;
+        end;
+      end;
+      tkString, tkUString, tkWString, tkChar, tkWChar:
+      begin
+        // GUID heuristic
+        if ((Length(AValue.AsString) = 36) or (Length(AValue.AsString) = 38)) and
+           (AValue.AsString.IndexOf('-') > 0) then
+        begin
+          Param.DataType := ftGuid;
+          Param.AsString := AValue.AsString;
+        end
+        else
+        begin
+          Param.DataType := ftWideString;
+          Param.AsWideString := AValue.AsString;
+        end;
+      end;
+      tkDynArray:
+      begin
+        IsByteArray := False;
+        if AValue.TypeInfo <> nil then
+        begin
+          TypeName := string(AValue.TypeInfo.Name);
+          IsByteArray := (TypeName = 'TBytes') or
+                         (TypeName = 'TArray<System.Byte>') or
+                         (TypeName = 'TArray<Byte>');
+        end;
+        if IsByteArray then
+        begin
+          Param.DataType := ftBlob;
+          Bytes := AValue.AsType<TBytes>;
+          if Length(Bytes) > 0 then
+            Param.SetBlobRawData(Length(Bytes), @Bytes[0])
+          else
+            Param.Clear;
+        end
+        else
+          Param.Value := AValue.AsVariant;
+      end;
+      tkEnumeration:
+      begin
+        if AValue.TypeInfo = TypeInfo(Boolean) then
+        begin
+          Param.DataType := ftBoolean;
+          Param.AsBoolean := AValue.AsBoolean;
+        end
+        else
+        begin
+          Param.DataType := ftInteger;
+          Param.AsInteger := AValue.AsOrdinal;
+        end;
+      end;
+      tkRecord:
+      begin
+        if IsNullable(AValue.TypeInfo) then
+        begin
+          Helper := TNullableHelper.Create(AValue.TypeInfo);
+          if Helper.HasValue(AValue.GetReferenceToRawData) then
+          begin
+            InnerVal := Helper.GetValue(AValue.GetReferenceToRawData);
+            SetParamValue(Param, InnerVal);
+          end
+          else
+          begin
+            Param.Clear;
+            Underlying := GetUnderlyingType(AValue.TypeInfo);
+            if Underlying <> nil then
+            begin
+              case Underlying.Kind of
+                tkInteger, tkInt64:
+                  Param.DataType := ftLargeint;
+                tkFloat:
+                  Param.DataType := ftFloat;
+                tkString, tkUString, tkWString:
+                  Param.DataType := ftWideString;
+                tkEnumeration:
+                  if Underlying = TypeInfo(Boolean) then
+                    Param.DataType := ftBoolean
+                  else
+                    Param.DataType := ftInteger;
+              end;
+            end;
+          end;
+        end
+        else
+          Param.Value := AValue.AsVariant;
+      end;
+    else
+      Param.Value := AValue.AsVariant;
+      if (VarIsNull(Param.Value) or VarIsEmpty(Param.Value)) and
+         (Param.DataType = ftUnknown) then
+        Param.DataType := ftWideString;
+    end;
+  end;
+end;
+
+// ---------------------------------------------------------------------------
+// TUniDACConnection
+// ---------------------------------------------------------------------------
+
+constructor TUniDACConnection.Create(AConnection: TUniConnection;
+  AOwnsConnection: Boolean);
+begin
+  inherited Create;
+  FConnection := AConnection;
+  FOwnsConnection := AOwnsConnection;
+  FConnection.AfterConnect := DoAfterConnect;
+end;
+
+destructor TUniDACConnection.Destroy;
+begin
+  if FOwnsConnection then
+    FConnection.Free;
+  inherited;
+end;
+
+procedure TUniDACConnection.Connect;
+begin
+  FConnection.Connected := True;
+end;
+
+procedure TUniDACConnection.Disconnect;
+begin
+  FConnection.Connected := False;
+end;
+
+function TUniDACConnection.IsConnected: Boolean;
+begin
+  Result := FConnection.Connected;
+end;
+
+function TUniDACConnection.BeginTransaction: IDbTransaction;
+begin
+  Result := TUniDACTransaction.Create(FConnection);
+end;
+
+function TUniDACConnection.CreateCommand(const ASQL: string): IDbCommand;
+var
+  LCmd: TUniDACCommand;
+begin
+  LCmd := TUniDACCommand.Create(FConnection, GetDialect);
+  LCmd.FOnLog := FOnLog;
+  if ASQL <> '' then
+    LCmd.SetSQL(ASQL);
+  Result := LCmd;
+end;
+
+procedure TUniDACConnection.DoAfterConnect(Sender: TObject);
+var
+  DatabaseSchema: string;
+  SqlDialect: ISQLDialect;
+  Sql: string;
+begin
+  // Apply schema/search_path session setting after connect
+  DatabaseSchema := FConnection.SpecificOptions.Values['Schema'];
+
+  if DatabaseSchema <> '' then
+  begin
+    SqlDialect := TDialectFactory.CreateDialect(GetDialect);
+    if SqlDialect <> nil then
+    begin
+      Sql := SqlDialect.GetSetSchemaSQL(DatabaseSchema);
+      if Sql <> '' then
+      begin
+        if Assigned(FOnLog) then
+          FOnLog('Applying session schema: ' + Sql);
+        try
+          FConnection.ExecSQL(Sql);
+        except
+          on E: Exception do
+            if Assigned(FOnLog) then
+              FOnLog('Error applying schema: ' + E.Message);
+        end;
+      end;
+    end;
+  end;
+end;
+
+function TUniDACConnection.GetLastInsertId: Variant;
+var
+  Q: TUniQuery;
+  SQL: string;
+begin
+  // -------------------------------------------------------------------------
+  // UniDAC does NOT have a FireDAC-equivalent GetLastAutoGenValue().
+  //
+  // PREFERRED approach for UniDAC (any database):
+  //   Append "RETURNING <pk_column>" to your INSERT statement. After Execute,
+  //   UniDAC automatically creates an output param named "RET_<COLUMN>".
+  //   Read it via: IDbCommand.GetParamValue('RET_ID')
+  //
+  //   Example:
+  //     Cmd := Conn.CreateCommand(
+  //       'INSERT INTO t (name) VALUES (:name) RETURNING id');
+  //     Cmd.AddParam('name', TValue.From<string>('foo'));
+  //     Cmd.Execute;
+  //     NewID := Cmd.GetParamValue('RET_ID').AsInt64;
+  //
+  // This method provides a FALLBACK for MySQL and SQL Server which have their
+  // own last-ID functions. For PostgreSQL, Oracle, Firebird/InterBase, and
+  // SQLite >= 3.35 the RETURNING approach above is strongly preferred.
+  // -------------------------------------------------------------------------
+  Result := Null;
+  case GetDialect of
+    ddMySQL:
+      SQL := 'SELECT LAST_INSERT_ID()';
+    ddSQLServer:
+      SQL := 'SELECT SCOPE_IDENTITY()';
+    ddSQLite:
+      // SQLite 3.35+ also supports RETURNING. Use last_insert_rowid() as fallback
+      // only when the INSERT was executed without RETURNING.
+      SQL := 'SELECT last_insert_rowid()';
+    ddPostgreSQL:
+    begin
+      // PostgreSQL has no session-level last_id function.
+      // ALWAYS use INSERT ... RETURNING id and read RET_ID param.
+      Result := Null;
+      Exit;
+    end;
+    ddOracle:
+    begin
+      // Oracle: use INSERT ... RETURNING id INTO :RET_ID.
+      Result := Null;
+      Exit;
+    end;
+    ddFirebird, ddInterbase:
+    begin
+      // Firebird 2.1+ supports RETURNING. Use INSERT ... RETURNING id.
+      Result := Null;
+      Exit;
+    end;
+  else
+    Result := Null;
+    Exit;
+  end;
+
+  Q := TUniQuery.Create(nil);
+  try
+    Q.Connection := FConnection;
+    Q.SQL.Text := SQL;
+    Q.Open;
+    try
+      if not Q.Eof then
+        Result := Q.Fields[0].Value;
+    finally
+      Q.Close;
+    end;
+  finally
+    Q.Free;
+  end;
+end;
+
+
+function TUniDACConnection.TableExists(const ATableName: string): Boolean;
+var
+  List: TStringList;
+  Table: string;
+begin
+  List := TStringList.Create;
+  try
+    try
+      FConnection.GetTableNames(List);
+
+      // Exact match
+      if List.IndexOf(ATableName) >= 0 then
+        Exit(True);
+      // Quoted match
+      if List.IndexOf('"' + ATableName + '"') >= 0 then
+        Exit(True);
+      // Case-insensitive fallback
+      for Table in List do
+      begin
+        if SameText(Table, ATableName) or
+           SameText(Table, '"' + ATableName + '"') or
+           SameText(Table, ATableName.Replace('"', '')) then
+          Exit(True);
+      end;
+      Result := False;
+    except
+      Result := False;
+    end;
+  finally
+    List.Free;
+  end;
+end;
+
+function TUniDACConnection.IsPooled: Boolean;
+begin
+  Result := FConnection.Pooling;
+end;
+
+function TUniDACConnection.GetConnectionString: string;
+begin
+  Result := FConnection.ConnectionString;
+end;
+
+procedure TUniDACConnection.SetConnectionString(const AValue: string);
+begin
+  if FConnection.Connected then
+    FConnection.Connected := False;
+  FConnection.ConnectionString := AValue;
+end;
+
+procedure TUniDACConnection.DetectDialect;
+var
+  Provider: string;
+begin
+  if FDialect <> ddUnknown then Exit;
+
+  Provider := LowerCase(FConnection.ProviderName);
+
+  if Provider = 'sqlite'              then FDialect := ddSQLite
+  else if Provider = 'postgresql'     then FDialect := ddPostgreSQL
+  else if Provider = 'mysql'          then FDialect := ddMySQL
+  else if Provider = 'sql server'     then FDialect := ddSQLServer
+  else if Provider = 'oracle'         then FDialect := ddOracle
+  else if Provider = 'interbase'      then FDialect := ddFirebird  // UniDAC InterBase covers Firebird too
+  else if Provider = 'db2'            then FDialect := ddUnknown
+  else                                     FDialect := ddUnknown;
+end;
+
+function TUniDACConnection.GetDialect: TDatabaseDialect;
+begin
+  if FDialect = ddUnknown then
+    DetectDialect;
+  Result := FDialect;
+end;
+
+procedure TUniDACConnection.SetOnLog(AValue: TProc<string>);
+begin
+  FOnLog := AValue;
+end;
+
+function TUniDACConnection.GetOnLog: TProc<string>;
+begin
+  Result := FOnLog;
+end;
+
+end.
+

--- a/Sources/Data/Dext.Entity.Setup.pas
+++ b/Sources/Data/Dext.Entity.Setup.pas
@@ -2,6 +2,8 @@ unit Dext.Entity.Setup;
 
 interface
 
+{$I Dext.inc}
+
 uses
   System.SysUtils,
   System.Classes,
@@ -11,13 +13,20 @@ uses
   Dext.Entity.Drivers.Interfaces,
   Dext.Entity.Dialects,
   Dext.Entity.Naming,
+  {$IFDEF DEXT_USE_UNIDAC}
+  Dext.Entity.Drivers.UniDAC,
+  Dext.Entity.Drivers.UniDAC.Manager,
+  Uni,                               // TUniConnection
+  {$ELSE}
   Dext.Entity.Drivers.FireDAC,
   Dext.Entity.Drivers.FireDAC.Manager,
-  FireDAC.Comp.Client;
+  FireDAC.Comp.Client,               // TFDConnection
+  {$ENDIF}
 
 type
   /// <summary>
   ///   Configuration options for a DbContext.
+  ///   Supports both FireDAC (default) and UniDAC (when DEXT_USE_UNIDAC is defined).
   /// </summary>
   TDbContextOptions = class
   private
@@ -28,7 +37,9 @@ type
     FParams: IDictionary<string, string>;
     FPooling: Boolean;
     FPoolMax: Integer;
-    FOptimizations: TFireDACOptimizations; // Connect Optimizations
+    {$IFNDEF DEXT_USE_UNIDAC}
+    FOptimizations: TFireDACOptimizations; // FireDAC-specific optimizations
+    {$ENDIF}
     FDialect: ISQLDialect;
     FCustomConnection: IDbConnection;
     FNamingStrategy: INamingStrategy;
@@ -36,6 +47,11 @@ type
     FOnLog: TProc<string>;
     FBulkBatchSize: Integer;
     procedure SetConnectionString(const AValue: string);
+    {$IFDEF DEXT_USE_UNIDAC}
+    function BuildUniDACConnection: IDbConnection;
+    {$ELSE}
+    function BuildFireDACConnection: IDbConnection;
+    {$ENDIF}
   public
     constructor Create;
     destructor Destroy; override;
@@ -47,7 +63,9 @@ type
     property Params: IDictionary<string, string> read FParams;
     property Pooling: Boolean read FPooling write FPooling;
     property PoolMax: Integer read FPoolMax write FPoolMax;
+    {$IFNDEF DEXT_USE_UNIDAC}
     property Optimizations: TFireDACOptimizations read FOptimizations write FOptimizations;
+    {$ENDIF}
     property Dialect: ISQLDialect read FDialect write FDialect;
     property CustomConnection: IDbConnection read FCustomConnection write FCustomConnection;
     property NamingStrategy: INamingStrategy read FNamingStrategy write FNamingStrategy;
@@ -69,7 +87,9 @@ type
     function UseDriver(const ADriverName: string): TDbContextOptions;
     function UseConnectionDef(const ADefName: string): TDbContextOptions;
     function WithPooling(Enable: Boolean = True; MaxSize: Integer = 50): TDbContextOptions;
+    {$IFNDEF DEXT_USE_UNIDAC}
     function ConfigureOptimizations(AOpts: TFireDACOptimizations): TDbContextOptions;
+    {$ENDIF}
     function UseCustomDialect(const ADialect: ISQLDialect): TDbContextOptions;
     function UseDialect(ADialect: TDatabaseDialect): TDbContextOptions;
     function UseNamingStrategy(const AStrategy: INamingStrategy): TDbContextOptions;
@@ -100,8 +120,10 @@ begin
   FPooling := False;
   FPoolMax := 50;
   FBulkBatchSize := 100;
+  {$IFNDEF DEXT_USE_UNIDAC}
   // Default legacy optimization behavior (Matches original hardcoded logic)
   FOptimizations := [optDisableMacros, optDisableEscapes, optDirectExecute];
+  {$ENDIF}
 end;
 
 destructor TDbContextOptions.Destroy;
@@ -192,11 +214,13 @@ begin
   Result := Self;
 end;
 
+{$IFNDEF DEXT_USE_UNIDAC}
 function TDbContextOptions.ConfigureOptimizations(AOpts: TFireDACOptimizations): TDbContextOptions;
 begin
   FOptimizations := AOpts;
   Result := Self;
 end;
+{$ENDIF}
 
 function TDbContextOptions.UseCustomDialect(const ADialect: ISQLDialect): TDbContextOptions;
 begin
@@ -223,6 +247,70 @@ begin
 end;
 
 function TDbContextOptions.BuildConnection: IDbConnection;
+begin
+  if FCustomConnection <> nil then
+    Exit(FCustomConnection);
+
+  {$IFDEF DEXT_USE_UNIDAC}
+  Result := BuildUniDACConnection;
+  {$ELSE}
+  Result := BuildFireDACConnection;
+  {$ENDIF}
+end;
+
+{$IFDEF DEXT_USE_UNIDAC}
+function TDbContextOptions.BuildUniDACConnection: IDbConnection;
+var
+  UniConn: TUniConnection;
+  SL: TStringList;
+  Pair: TPair<string, string>;
+  Conn: TUniDACConnection;
+  ProviderName: string;
+begin
+  ProviderName := TDextUniDACManager.MapDriverToProvider(FDriverName);
+
+  if FPooling then
+  begin
+    SL := TStringList.Create;
+    try
+      for Pair in FParams do
+        SL.Values[Pair.Key] := Pair.Value;
+      UniConn := TDextUniDACManager.Instance.CreatePooledConnection(
+        ProviderName, TStrings(SL), FPoolMax);
+    finally
+      SL.Free;
+    end;
+  end
+  else
+  begin
+    UniConn := TUniConnection.Create(nil);
+    try
+      UniConn.ProviderName := ProviderName;
+
+      // Apply connection string if provided
+      if FConnectionString <> '' then
+        UniConn.ConnectionString := FConnectionString
+      else
+      begin
+        // Apply individual params
+        for Pair in FParams do
+          UniConn.SpecificOptions.Values[Pair.Key] := Pair.Value;
+      end;
+    except
+      UniConn.Free;
+      raise;
+    end;
+  end;
+
+  // Apply Unicode and other sensible defaults
+  TDextUniDACManager.Instance.ApplyOptions(UniConn, []);
+
+  Conn := TUniDACConnection.Create(UniConn, True);
+  Conn.OnLog := FOnLog;
+  Result := Conn;
+end;
+{$ELSE}
+function TDbContextOptions.BuildFireDACConnection: IDbConnection;
 var
   FDConn: TFDConnection;
   DefName: string;
@@ -230,9 +318,6 @@ var
   Pair: TPair<string, string>;
   Conn: TFireDACConnection;
 begin
-  if FCustomConnection <> nil then
-    Exit(FCustomConnection);
-
   FDConn := TFDConnection.Create(nil);
   try
     if FConnectionString <> '' then
@@ -278,6 +363,7 @@ begin
     raise;
   end;
 end;
+{$ENDIF}
 
 function TDbContextOptions.BuildDialect: ISQLDialect;
 begin

--- a/Sources/Data/Dext.Entity.Setup.pas
+++ b/Sources/Data/Dext.Entity.Setup.pas
@@ -20,7 +20,7 @@ uses
   {$ELSE}
   Dext.Entity.Drivers.FireDAC,
   Dext.Entity.Drivers.FireDAC.Manager,
-  FireDAC.Comp.Client,               // TFDConnection
+  FireDAC.Comp.Client;              // TFDConnection
   {$ENDIF}
 
 type

--- a/Sources/Dext.EF.UniDAC.dpk
+++ b/Sources/Dext.EF.UniDAC.dpk
@@ -1,0 +1,43 @@
+package Dext.EF.UniDAC;
+
+{$R *.res}
+{$IFDEF IMPLICITBUILDING This IFDEF should not be used by users}
+{$ALIGN 8}
+{$ASSERTIONS ON}
+{$BOOLEVAL OFF}
+{$DEBUGINFO OFF}
+{$EXTENDEDSYNTAX ON}
+{$IMPORTEDDATA ON}
+{$IOCHECKS ON}
+{$LOCALSYMBOLS ON}
+{$LONGSTRINGS ON}
+{$OPENSTRINGS ON}
+{$OPTIMIZATION OFF}
+{$OVERFLOWCHECKS OFF}
+{$RANGECHECKS OFF}
+{$REFERENCEINFO ON}
+{$SAFEDIVIDE OFF}
+{$STACKFRAMES ON}
+{$TYPEDADDRESS OFF}
+{$VARSTRINGCHECKS ON}
+{$WEAKPACKAGEUNIT}
+{$ENDIF IMPLICITBUILDING}
+{$DESCRIPTION 'Dext Framework - UniDAC Driver Backend'}
+{$LIBSUFFIX AUTO}
+{$RUNONLY}
+{$IMPLICITBUILD OFF}
+
+requires
+  rtl,
+  vcl,
+  // UniDAC runtime package — adjust name to your UniDAC version
+  // e.g., UniDac_D12 or similar depending on your installation
+  dbrtl;
+
+contains
+  Dext.Entity.Drivers.UniDAC.Links in 'Data\Dext.Entity.Drivers.UniDAC.Links.pas',
+  Dext.Entity.Drivers.UniDAC.Manager in 'Data\Dext.Entity.Drivers.UniDAC.Manager.pas',
+  Dext.Entity.Drivers.UniDAC in 'Data\Dext.Entity.Drivers.UniDAC.pas';
+
+end.
+

--- a/Tests/Entity/Dext.Entity.Driver.UniDAC.Test.pas
+++ b/Tests/Entity/Dext.Entity.Driver.UniDAC.Test.pas
@@ -1,0 +1,482 @@
+unit Dext.Entity.Driver.UniDAC.Test;
+
+/// <summary>
+///   Unit tests for TUniDACConnection, TUniDACCommand, TUniDACReader,
+///   and TUniDACTransaction.
+///   Requires: DEXT_USE_UNIDAC defined AND UniDAC SQLite provider installed.
+///   Uses SQLite in-memory database (Database=':memory:') for isolation.
+/// </summary>
+
+interface
+
+{$I Dext.inc}
+
+{$IFDEF DEXT_USE_UNIDAC}
+
+uses
+  DUnitX.TestFramework,
+  System.SysUtils,
+  System.Rtti,
+  Data.DB,
+  Uni,
+  Dext.Entity.Drivers.UniDAC,
+  Dext.Entity.Drivers.UniDAC.Manager,
+  Dext.Entity.Drivers.Interfaces,
+  Dext.Entity.Dialects,
+  Dext.Entity.Setup;
+
+type
+  [TestFixture]
+  TUniDACDriverTest = class
+  private
+    FConn: TUniConnection;
+    FDextConn: IDbConnection;
+    procedure CreateTestTable;
+    function MakeConnection: TUniConnection;
+  public
+    [Setup]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+
+    [Test]
+    procedure Test_Connection_ConnectDisconnect;
+
+    [Test]
+    procedure Test_Connection_IsPooled_ReturnsFalse_WhenNotPooled;
+
+    [Test]
+    procedure Test_Connection_DialectDetection_SQLite;
+
+    [Test]
+    procedure Test_Command_ExecuteNonQuery_CreateTable;
+
+    [Test]
+    procedure Test_Command_ExecuteQuery_EmptyTable;
+
+    [Test]
+    procedure Test_Command_ExecuteQuery_WithRows;
+
+    [Test]
+    procedure Test_Command_ExecuteScalar_Count;
+
+    [Test]
+    procedure Test_Reader_Next_IteratesAllRows;
+
+    [Test]
+    procedure Test_Reader_GetValue_ByName_AndByIndex;
+
+    [Test]
+    procedure Test_Command_AddParam_String;
+
+    [Test]
+    procedure Test_Command_AddParam_Integer;
+
+    [Test]
+    procedure Test_Command_AddParam_Null;
+
+    [Test]
+    procedure Test_Transaction_Commit;
+
+    [Test]
+    procedure Test_Transaction_Rollback;
+
+    [Test]
+    procedure Test_Batch_SimulatedLoop;
+
+    [Test]
+    procedure Test_TableExists_ReturnsTrue_WhenExists;
+
+    [Test]
+    procedure Test_TableExists_ReturnsFalse_WhenNotExists;
+
+    [Test]
+    /// <summary>
+    ///   Tests fallback via SELECT last_insert_rowid() — for cases where
+    ///   the INSERT was executed without a RETURNING clause.
+    /// </summary>
+    procedure Test_GetLastInsertId_Fallback_SQLite;
+
+    [Test]
+    /// <summary>
+    ///   Tests the PREFERRED UniDAC pattern:
+    ///   INSERT ... RETURNING id → read via GetParamValue('RET_ID').
+    ///   UniDAC automatically creates an output param with prefix RET_
+    ///   for each column listed in the RETURNING clause.
+    /// </summary>
+    procedure Test_GetLastInsertId_ViaReturning_SQLite;
+  end;
+
+{$ENDIF DEXT_USE_UNIDAC}
+
+implementation
+
+{$IFDEF DEXT_USE_UNIDAC}
+
+{ TUniDACDriverTest }
+
+function TUniDACDriverTest.MakeConnection: TUniConnection;
+begin
+  Result := TUniConnection.Create(nil);
+  Result.ProviderName := 'SQLite';
+  Result.SpecificOptions.Values['Database'] := ':memory:';
+  Result.SpecificOptions.Values['UseUnicode'] := 'True';
+end;
+
+procedure TUniDACDriverTest.CreateTestTable;
+var
+  Cmd: IDbCommand;
+begin
+  Cmd := FDextConn.CreateCommand(
+    'CREATE TABLE IF NOT EXISTS test_items (' +
+    '  id   INTEGER PRIMARY KEY AUTOINCREMENT,' +
+    '  name TEXT NOT NULL,' +
+    '  val  INTEGER' +
+    ')');
+  Cmd.Execute;
+end;
+
+procedure TUniDACDriverTest.Setup;
+begin
+  FConn := MakeConnection;
+  FDextConn := TUniDACConnection.Create(FConn, False); // FConn owned separately
+  FDextConn.Connect;
+  CreateTestTable;
+end;
+
+procedure TUniDACDriverTest.TearDown;
+begin
+  FDextConn.Disconnect;
+  FDextConn := nil;
+  FConn.Free;
+end;
+
+procedure TUniDACDriverTest.Test_Connection_ConnectDisconnect;
+begin
+  Assert.IsTrue(FDextConn.IsConnected, 'Should be connected after Setup');
+  FDextConn.Disconnect;
+  Assert.IsFalse(FDextConn.IsConnected, 'Should be disconnected');
+  FDextConn.Connect;
+  Assert.IsTrue(FDextConn.IsConnected, 'Should reconnect');
+end;
+
+procedure TUniDACDriverTest.Test_Connection_IsPooled_ReturnsFalse_WhenNotPooled;
+begin
+  Assert.IsFalse(FDextConn.IsPooled, 'Non-pooled connection should return False');
+end;
+
+procedure TUniDACDriverTest.Test_Connection_DialectDetection_SQLite;
+begin
+  Assert.AreEqual(ddSQLite, FDextConn.Dialect, 'SQLite provider should detect ddSQLite');
+end;
+
+procedure TUniDACDriverTest.Test_Command_ExecuteNonQuery_CreateTable;
+var
+  Cmd: IDbCommand;
+  RowsAffected: Integer;
+begin
+  Cmd := FDextConn.CreateCommand(
+    'CREATE TABLE IF NOT EXISTS temp_test (id INTEGER, name TEXT)');
+  RowsAffected := Cmd.ExecuteNonQuery;
+  // SQLite returns 0 for DDL — just check no exception is raised
+  Assert.IsTrue(RowsAffected >= 0, 'DDL should succeed without exception');
+end;
+
+procedure TUniDACDriverTest.Test_Command_ExecuteQuery_EmptyTable;
+var
+  Cmd: IDbCommand;
+  Reader: IDbReader;
+begin
+  Cmd := FDextConn.CreateCommand('SELECT * FROM test_items');
+  Reader := Cmd.ExecuteQuery;
+  Assert.IsFalse(Reader.Next, 'Empty table should return no rows');
+  Reader.Close;
+end;
+
+procedure TUniDACDriverTest.Test_Command_ExecuteQuery_WithRows;
+var
+  InsertCmd, SelectCmd: IDbCommand;
+  Reader: IDbReader;
+  RowCount: Integer;
+begin
+  // Insert 3 rows
+  InsertCmd := FDextConn.CreateCommand(
+    'INSERT INTO test_items (name, val) VALUES (:name, :val)');
+  InsertCmd.AddParam('name', TValue.From<string>('Alpha'));
+  InsertCmd.AddParam('val', TValue.From<Integer>(1));
+  InsertCmd.Execute;
+  InsertCmd.ClearParams;
+  InsertCmd.AddParam('name', TValue.From<string>('Beta'));
+  InsertCmd.AddParam('val', TValue.From<Integer>(2));
+  InsertCmd.Execute;
+  InsertCmd.ClearParams;
+  InsertCmd.AddParam('name', TValue.From<string>('Gamma'));
+  InsertCmd.AddParam('val', TValue.From<Integer>(3));
+  InsertCmd.Execute;
+
+  SelectCmd := FDextConn.CreateCommand('SELECT * FROM test_items ORDER BY id');
+  Reader := SelectCmd.ExecuteQuery;
+  RowCount := 0;
+  while Reader.Next do
+    Inc(RowCount);
+  Reader.Close;
+
+  Assert.AreEqual(3, RowCount, 'Should read 3 inserted rows');
+end;
+
+procedure TUniDACDriverTest.Test_Command_ExecuteScalar_Count;
+var
+  InsertCmd, ScalarCmd: IDbCommand;
+  Result: TValue;
+begin
+  InsertCmd := FDextConn.CreateCommand(
+    'INSERT INTO test_items (name, val) VALUES (:name, :val)');
+  InsertCmd.AddParam('name', TValue.From<string>('Item1'));
+  InsertCmd.AddParam('val', TValue.From<Integer>(10));
+  InsertCmd.Execute;
+
+  ScalarCmd := FDextConn.CreateCommand('SELECT COUNT(*) FROM test_items');
+  Result := ScalarCmd.ExecuteScalar;
+  Assert.IsFalse(Result.IsEmpty, 'Scalar result should not be empty');
+  Assert.IsTrue(Result.AsInt64 >= 1, 'Count should be at least 1');
+end;
+
+procedure TUniDACDriverTest.Test_Reader_Next_IteratesAllRows;
+var
+  Cmd: IDbCommand;
+  Reader: IDbReader;
+  Count: Integer;
+begin
+  // Insert 5 rows directly via native connection for speed
+  FConn.ExecSQL('INSERT INTO test_items (name, val) VALUES (''R1'', 1)');
+  FConn.ExecSQL('INSERT INTO test_items (name, val) VALUES (''R2'', 2)');
+  FConn.ExecSQL('INSERT INTO test_items (name, val) VALUES (''R3'', 3)');
+  FConn.ExecSQL('INSERT INTO test_items (name, val) VALUES (''R4'', 4)');
+  FConn.ExecSQL('INSERT INTO test_items (name, val) VALUES (''R5'', 5)');
+
+  Cmd := FDextConn.CreateCommand('SELECT id FROM test_items');
+  Reader := Cmd.ExecuteQuery;
+  Count := 0;
+  while Reader.Next do Inc(Count);
+  Reader.Close;
+
+  Assert.AreEqual(5, Count, 'Should iterate all 5 rows');
+end;
+
+procedure TUniDACDriverTest.Test_Reader_GetValue_ByName_AndByIndex;
+var
+  InsertCmd, SelectCmd: IDbCommand;
+  Reader: IDbReader;
+  ValByName, ValByIndex: TValue;
+begin
+  InsertCmd := FDextConn.CreateCommand(
+    'INSERT INTO test_items (name, val) VALUES (:name, :val)');
+  InsertCmd.AddParam('name', TValue.From<string>('TestRead'));
+  InsertCmd.AddParam('val', TValue.From<Integer>(42));
+  InsertCmd.Execute;
+
+  SelectCmd := FDextConn.CreateCommand(
+    'SELECT name, val FROM test_items WHERE name = :name');
+  SelectCmd.AddParam('name', TValue.From<string>('TestRead'));
+  Reader := SelectCmd.ExecuteQuery;
+
+  Assert.IsTrue(Reader.Next, 'Should have one row');
+  ValByName  := Reader.GetValue('name');
+  ValByIndex := Reader.GetValue(1);  // val is at index 1
+  Reader.Close;
+
+  Assert.AreEqual('TestRead', ValByName.AsString, 'name by column name');
+  Assert.AreEqual(42, ValByIndex.AsInteger, 'val by column index');
+end;
+
+procedure TUniDACDriverTest.Test_Command_AddParam_String;
+var
+  InsertCmd, SelectCmd: IDbCommand;
+  Reader: IDbReader;
+begin
+  InsertCmd := FDextConn.CreateCommand(
+    'INSERT INTO test_items (name, val) VALUES (:name, :val)');
+  InsertCmd.AddParam('name', TValue.From<string>('ParamTest'));
+  InsertCmd.AddParam('val', TValue.From<Integer>(99));
+  InsertCmd.Execute;
+
+  SelectCmd := FDextConn.CreateCommand(
+    'SELECT name FROM test_items WHERE val = :val');
+  SelectCmd.AddParam('val', TValue.From<Integer>(99));
+  Reader := SelectCmd.ExecuteQuery;
+  Assert.IsTrue(Reader.Next);
+  Assert.AreEqual('ParamTest', Reader.GetValue('name').AsString);
+  Reader.Close;
+end;
+
+procedure TUniDACDriverTest.Test_Command_AddParam_Integer;
+var
+  InsertCmd, SelectCmd: IDbCommand;
+  Reader: IDbReader;
+begin
+  InsertCmd := FDextConn.CreateCommand(
+    'INSERT INTO test_items (name, val) VALUES (:name, :val)');
+  InsertCmd.AddParam('name', TValue.From<string>('IntTest'));
+  InsertCmd.AddParam('val', TValue.From<Integer>(777));
+  InsertCmd.Execute;
+
+  SelectCmd := FDextConn.CreateCommand(
+    'SELECT val FROM test_items WHERE name = :name');
+  SelectCmd.AddParam('name', TValue.From<string>('IntTest'));
+  Reader := SelectCmd.ExecuteQuery;
+  Assert.IsTrue(Reader.Next);
+  Assert.AreEqual(777, Reader.GetValue(0).AsInteger);
+  Reader.Close;
+end;
+
+procedure TUniDACDriverTest.Test_Command_AddParam_Null;
+var
+  InsertCmd, SelectCmd: IDbCommand;
+  Reader: IDbReader;
+  V: TValue;
+begin
+  InsertCmd := FDextConn.CreateCommand(
+    'INSERT INTO test_items (name, val) VALUES (:name, :val)');
+  InsertCmd.AddParam('name', TValue.From<string>('NullTest'));
+  InsertCmd.AddParam('val', TValue.Empty);  // NULL
+  InsertCmd.Execute;
+
+  SelectCmd := FDextConn.CreateCommand(
+    'SELECT val FROM test_items WHERE name = :name');
+  SelectCmd.AddParam('name', TValue.From<string>('NullTest'));
+  Reader := SelectCmd.ExecuteQuery;
+  Assert.IsTrue(Reader.Next);
+  V := Reader.GetValue('val');
+  Assert.IsTrue(V.IsEmpty, 'NULL column should return TValue.Empty');
+  Reader.Close;
+end;
+
+procedure TUniDACDriverTest.Test_Transaction_Commit;
+var
+  TX: IDbTransaction;
+  Cmd: IDbCommand;
+  Scalar: TValue;
+begin
+  TX := FDextConn.BeginTransaction;
+  Cmd := FDextConn.CreateCommand(
+    'INSERT INTO test_items (name, val) VALUES (''TxCommit'', 1)');
+  Cmd.Execute;
+  TX.Commit;
+
+  Scalar := FDextConn.CreateCommand(
+    'SELECT COUNT(*) FROM test_items WHERE name=''TxCommit''').ExecuteScalar;
+  Assert.AreEqual(Int64(1), Scalar.AsInt64, 'Committed row must be visible');
+end;
+
+procedure TUniDACDriverTest.Test_Transaction_Rollback;
+var
+  TX: IDbTransaction;
+  Cmd: IDbCommand;
+  Scalar: TValue;
+begin
+  TX := FDextConn.BeginTransaction;
+  Cmd := FDextConn.CreateCommand(
+    'INSERT INTO test_items (name, val) VALUES (''TxRollback'', 2)');
+  Cmd.Execute;
+  TX.Rollback;
+
+  Scalar := FDextConn.CreateCommand(
+    'SELECT COUNT(*) FROM test_items WHERE name=''TxRollback''').ExecuteScalar;
+  Assert.AreEqual(Int64(0), Scalar.AsInt64,
+    'Rolled-back row must NOT be visible');
+end;
+
+procedure TUniDACDriverTest.Test_Batch_SimulatedLoop;
+var
+  Cmd: IDbCommand;
+  Names: TArray<TValue>;
+  Vals:  TArray<TValue>;
+  ScalarCmd: IDbCommand;
+  Count: TValue;
+begin
+  // Prepare 4 rows as arrays
+  Names := [TValue.From<string>('B1'), TValue.From<string>('B2'),
+            TValue.From<string>('B3'), TValue.From<string>('B4')];
+  Vals  := [TValue.From<Integer>(10), TValue.From<Integer>(20),
+            TValue.From<Integer>(30), TValue.From<Integer>(40)];
+
+  Cmd := FDextConn.CreateCommand(
+    'INSERT INTO test_items (name, val) VALUES (:name, :val)');
+  Cmd.SetArraySize(4);
+  Cmd.SetParamArray('name', Names);
+  Cmd.SetParamArray('val',  Vals);
+  Cmd.ExecuteBatch(4, 0);
+
+  ScalarCmd := FDextConn.CreateCommand(
+    'SELECT COUNT(*) FROM test_items WHERE name LIKE ''B%''');
+  Count := ScalarCmd.ExecuteScalar;
+  Assert.AreEqual(Int64(4), Count.AsInt64, 'All 4 batch rows must be inserted');
+end;
+
+procedure TUniDACDriverTest.Test_TableExists_ReturnsTrue_WhenExists;
+begin
+  Assert.IsTrue(FDextConn.TableExists('test_items'),
+    'test_items was created in Setup, should exist');
+end;
+
+procedure TUniDACDriverTest.Test_TableExists_ReturnsFalse_WhenNotExists;
+begin
+  Assert.IsFalse(FDextConn.TableExists('no_such_table_xyz'),
+    'Non-existent table should return False');
+end;
+
+procedure TUniDACDriverTest.Test_GetLastInsertId_Fallback_SQLite;
+var
+  InsertCmd: IDbCommand;
+  LastId: Variant;
+begin
+  // Execute INSERT without RETURNING — use fallback SELECT last_insert_rowid().
+  InsertCmd := FDextConn.CreateCommand(
+    'INSERT INTO test_items (name, val) VALUES (''IdFallback'', 55)');
+  InsertCmd.Execute;
+
+  LastId := FDextConn.GetLastInsertId;
+  Assert.IsFalse(VarIsNull(LastId) or VarIsEmpty(LastId),
+    'Fallback GetLastInsertId should return a non-null value for SQLite');
+  Assert.IsTrue(Integer(LastId) > 0, 'Last insert ID should be positive');
+end;
+
+procedure TUniDACDriverTest.Test_GetLastInsertId_ViaReturning_SQLite;
+var
+  InsertCmd: IDbCommand;
+  ReturnedId: TValue;
+begin
+  // -----------------------------------------------------------------
+  // UniDAC canonical pattern for last-insert-ID:
+  //   1. Append "RETURNING <pk_column>" to the INSERT SQL.
+  //   2. UniDAC auto-creates an output param named "RET_<COLUMN>".
+  //      (The column name is uppercased, prefixed with RET_.)
+  //   3. After Execute, read the value via GetParamValue('RET_ID').
+  //
+  // This works for SQLite >= 3.35, PostgreSQL, Firebird 2.1+,
+  // Oracle, and SQL Server (OUTPUT INSERTED.id ... but syntax differs).
+  // -----------------------------------------------------------------
+  InsertCmd := FDextConn.CreateCommand(
+    'INSERT INTO test_items (name, val) VALUES (:name, :val) RETURNING id');
+  InsertCmd.AddParam('name', TValue.From<string>('IdReturning'));
+  InsertCmd.AddParam('val',  TValue.From<Integer>(99));
+  InsertCmd.Execute;
+
+  // UniDAC places the returned id in param named 'RET_ID'
+  ReturnedId := InsertCmd.GetParamValue('RET_ID');
+
+  Assert.IsFalse(ReturnedId.IsEmpty,
+    'RET_ID param must not be empty after INSERT ... RETURNING id');
+  Assert.IsTrue(ReturnedId.AsInt64 > 0,
+    'Returned ID must be a positive integer');
+end;
+
+{$ENDIF DEXT_USE_UNIDAC}
+
+initialization
+  {$IFDEF DEXT_USE_UNIDAC}
+  TDUnitX.RegisterTestFixture(TUniDACDriverTest);
+  {$ENDIF}
+
+end.
+


### PR DESCRIPTION
## Summary
This PR introduces full support for **Devart UniDAC** as an alternative database driver/provider for the Dext ORM entity framework, operating alongside the existing **FireDAC** engine without breaking any established abstractions or interfaces.

## Key Changes
- **Conditional Driver Switching**: Introduced the `{$DEFINE DEXT_USE_UNIDAC}` compiler directive in `Dext.inc`. When undefined (default), Dext uses FireDAC as before. When defined, Dext seamlessly routes connection, command, and reader instantiations through UniDAC components.
- **Provider Link Setup**: Added `Dext.Entity.Drivers.UniDAC.Links.pas` to automatically link UniDAC database providers (SQLite, PostgreSQL, MySQL, SQL Server, Oracle, InterBase/Firebird, etc.) matching existing `$DEFINE` flags.
- **Connection Management & Pooling**: Implemented `TDextUniDACManager` in `Dext.Entity.Drivers.UniDAC.Manager.pas` to manage connection pooling and provider name mappings (`FireDAC DriverID` → `UniDAC ProviderName`).
- **Core Interfaces Implementation**: Created `Dext.Entity.Drivers.UniDAC.pas` implementing `IDbConnection`, `IDbCommand`, `IDbReader`, and `IDbTransaction` via UniDAC components (`TUniConnection`, `TUniQuery`, `TParam`).
- **Auto-Increment / RETURNING Support**: Handled `RETURNING` clauses (e.g., PostgreSQL, Firebird, Oracle, SQLite) where UniDAC automatically creates `RET_<COLUMN>` output parameters, accessible via `Cmd.GetParamValue('RET_ID')`.
- **Batch Processing**: Provided simulated serial-loop batch operations (`SetArraySize`, `SetParamArray`, `ExecuteBatch`) for UniDAC environments.
- **Modularity**: Added `Dext.EF.UniDAC.dpk` package file to allow standalone compilation without forcing projects to depend on UniDAC units when not in use.
- **Testing**: Added comprehensive unit tests in `Dext.Entity.Driver.UniDAC.Test.pas` covering connection handling, transaction commit/rollback, reader iteration, NULL parameters, and RETURNING clauses using SQLite in-memory database.

## Modified Files
- `Sources/Dext.inc`: Added `DEXT_USE_UNIDAC` definition flag.
- `Sources/Data/Dext.Entity.Setup.pas`: Updated `BuildConnection` to branch conditionally between `TFireDACConnection` and `TUniDACConnection`.

## Created Files
- `Sources/Data/Dext.Entity.Drivers.UniDAC.Links.pas`
- `Sources/Data/Dext.Entity.Drivers.UniDAC.Manager.pas`
- `Sources/Data/Dext.Entity.Drivers.UniDAC.pas`
- `Sources/Dext.EF.UniDAC.dpk`
- `Tests/Entity/Dext.Entity.Driver.UniDAC.Test.pas`

## How to Enable & Test UniDAC Support
1. Open `Dext.inc` and uncomment `{$DEFINE DEXT_USE_UNIDAC}`.
2. Build your project or run the test suite with UniDAC packages installed in Delphi.

## Backward Compatibility
- Zero breaking changes to existing FireDAC implementations or public ORM APIs (`IDbConnection`, `TDbContext`, fluent configuration API).
