### PR TITLE
fix(collections): count tombstones in the load factor to stop an unbounded probe loop

### DIFF
--- a/Sources/Core/Dext.Collections.RawDict.pas
+++ b/Sources/Core/Dext.Collections.RawDict.pas
@@ -62,6 +62,12 @@ type
     FSlots: Pointer;         // Array of [Key|Value] pairs, contiguous
     FMetadata: PByte;        // Array of slot states (1 byte each)
     FCount: Integer;
+    // Tombstones (removed slots) still consume probe positions, so they MUST be
+    // taken into account by the load factor: only a rehash clears them. Without
+    // this, a long-running Add/Remove cycle fills the table with tombstones
+    // without ever growing, until no SLOT_EMPTY is left and FindSlot cannot
+    // terminate.
+    FTombstones: Integer;
     FCapacity: Integer;      // Always power of 2
     FKeySize: Integer;
     FValueSize: Integer;
@@ -377,6 +383,7 @@ var
   FirstTombstone: Integer;
   MetaPtr: PByte;
   Meta, H2: Byte;
+  Probes: Integer;
 begin
   Hash := FHashFunc(Key, FKeySize);
   H2 := Byte(Hash shr 24) or $80; // H2 Metadata: store high bits of hash
@@ -384,8 +391,13 @@ begin
   Idx := Integer(Hash and Cardinal(Mask));
   FirstTombstone := -1;
   Result := False;
+  // Safety net: never probe more than the whole table. With the load factor
+  // accounting for tombstones there is always a SLOT_EMPTY to stop at, so this
+  // can only trigger if that invariant is ever broken again -- and returning
+  // "not found" is infinitely better than spinning forever.
+  Probes := 0;
 
-  while True do
+  while Probes <= FCapacity do
   begin
     MetaPtr := FMetadata + Idx;
     Meta := MetaPtr^;
@@ -416,7 +428,15 @@ begin
     end;
 
     Idx := (Idx + 1) and Mask;
+    Inc(Probes);
   end;
+
+  // Table exhausted without finding the key: report a reusable tombstone if we
+  // saw one, otherwise signal "no slot" with -1 (insertions check for it).
+  if FirstTombstone >= 0 then
+    SlotIndex := FirstTombstone
+  else
+    SlotIndex := -1;
 end;
 
 procedure TRawDictionary.Grow;
@@ -450,6 +470,7 @@ begin
   FSlots := System.AllocMem(FCapacity * FSlotSize);
   FMetadata := System.AllocMem(FCapacity);
   FillChar(FMetadata^, FCapacity, SLOT_EMPTY);
+  FTombstones := 0; // only occupied entries are carried over below
 
   // Re-insert all occupied entries
   Mask := FCapacity - 1;
@@ -493,10 +514,14 @@ var
   H2: Byte;
 begin
   // Check load factor before insertion
-  if (FCount + 1) * 100 > FCapacity * MAX_LOAD_FACTOR then
+  // Tombstones count towards the load: they occupy probe positions until the
+  // next rehash, and ignoring them lets an Add/Remove cycle saturate the table.
+  if (FCount + FTombstones + 1) * 100 > FCapacity * MAX_LOAD_FACTOR then
     Grow;
 
   Found := FindSlot(Key, SlotIndex);
+  if not Found and (SlotIndex < 0) then
+    raise Exception.Create('TRawDictionary: no free slot available (internal invariant violated)');
   SlotPtr := GetSlotPtr(SlotIndex);
 
   if Found then
@@ -538,13 +563,17 @@ var
   Hash: Cardinal;
   H2: Byte;
 begin
-  if (FCount + 1) * 100 > FCapacity * MAX_LOAD_FACTOR then
+  // Tombstones count towards the load: they occupy probe positions until the
+  // next rehash, and ignoring them lets an Add/Remove cycle saturate the table.
+  if (FCount + FTombstones + 1) * 100 > FCapacity * MAX_LOAD_FACTOR then
     Grow;
 
   Found := FindSlot(Key, SlotIndex);
 
   if Found then
     raise Exception.Create('An item with the same key has already been added.');
+  if SlotIndex < 0 then
+    raise Exception.Create('TRawDictionary: no free slot available (internal invariant violated)');
 
   SlotPtr := GetSlotPtr(SlotIndex);
 
@@ -595,6 +624,7 @@ begin
   FreeSlotContent(SlotPtr);
   PByte(NativeUInt(FMetadata) + NativeUInt(SlotIndex))^ := SLOT_TOMBSTONE;
   Dec(FCount);
+  Inc(FTombstones); // cleared only by Rehash/Clear -- see the field's comment
 end;
 
 procedure TRawDictionary.Clear;
@@ -622,6 +652,7 @@ begin
     FillChar(FMetadata^, FCapacity, SLOT_EMPTY);
   end;
   FCount := 0;
+  FTombstones := 0; // every slot is SLOT_EMPTY again
 end;
 
 procedure TRawDictionary.ForEachRaw(Callback: TFunc<Pointer, Pointer, Boolean>);

--- a/Sources/Core/Dext.Collections.RawDict.pas
+++ b/Sources/Core/Dext.Collections.RawDict.pas
@@ -442,7 +442,18 @@ end;
 procedure TRawDictionary.Grow;
 begin
   if FCapacity = 0 then
-    Rehash(DEFAULT_CAPACITY)
+  begin
+    Rehash(DEFAULT_CAPACITY);
+    Exit;
+  end;
+  // The load factor now counts tombstones, so Grow can also be reached while the
+  // number of LIVE entries is nowhere near the limit -- e.g. a steady add/remove
+  // cycle, where every round leaves a tombstone behind. Doubling there would make
+  // the table grow without bound for a constant working set: rehashing at the
+  // SAME capacity is enough, since a rehash carries over occupied slots only and
+  // drops every tombstone. Grow only when the live entries really need the room.
+  if (FCount + 1) * 100 <= FCapacity * (MAX_LOAD_FACTOR div 2) then
+    Rehash(FCapacity)
   else
     Rehash(FCapacity * 2);
 end;

--- a/Tests/Collections/TestCollections.Dictionaries.pas
+++ b/Tests/Collections/TestCollections.Dictionaries.pas
@@ -151,6 +151,22 @@ type
 
     [Test]
     procedure Rehash_ShouldPreserveAllEntries;
+
+    /// <summary>
+    ///   Regression: a plain add/remove/add cycle used to saturate the table with
+    ///   occupied+tombstone slots (tombstones were not counted by the load factor,
+    ///   so the rehash that clears them never happened). FindSlot only stops on
+    ///   SLOT_EMPTY, so the next lookup for an absent key never returned.
+    /// </summary>
+    [Test]
+    procedure AddRemoveAdd_LookupOfRemovedKey_ShouldNotHang;
+
+    /// <summary>
+    ///   Regression: a long-lived dictionary under a remove/insert cycle must stay
+    ///   correct -- tombstones must not accumulate until the table is exhausted.
+    /// </summary>
+    [Test]
+    procedure LongAddRemoveCycle_ShouldStayConsistent;
   end;
 
   /// <summary>TCollections factory method tests</summary>
@@ -576,6 +592,51 @@ begin
     D.Remove(I);
 
   Should(D.Count).Be(0);
+end;
+
+procedure TDictionaryStressTests.AddRemoveAdd_LookupOfRemovedKey_ShouldNotHang;
+var
+  D: IDictionary<Int64, Integer>;
+  V: Integer;
+begin
+  // Five operations are enough with DEFAULT_CAPACITY = 4.
+  D := TCollections.CreateDictionary<Int64, Integer>;
+  D.Add(100, 1);
+  D.Add(200, 2);
+  D.Add(300, 3); // 3 occupied, load 75% -> no grow
+  D.Remove(100); // 2 occupied + 1 tombstone
+  D.Add(900, 4); // 3 occupied + 1 tombstone -> table used to be saturated here
+
+  Should(D.TryGetValue(100, V)).BeFalse; // used to spin forever
+  Should(D.ContainsKey(900)).BeTrue;
+  Should(D.ContainsKey(200)).BeTrue;
+  Should(D.ContainsKey(300)).BeTrue;
+  Should(D.Count).Be(3);
+end;
+
+procedure TDictionaryStressTests.LongAddRemoveCycle_ShouldStayConsistent;
+var
+  D: IDictionary<Integer, Integer>;
+  I, V: Integer;
+begin
+  // Keeps a handful of live entries while churning thousands of insert/remove:
+  // without counting tombstones the table fills up and never grows.
+  D := TCollections.CreateDictionary<Integer, Integer>;
+  for I := 0 to 9 do
+    D.Add(I, I);
+
+  for I := 10 to 5000 do
+  begin
+    D.Add(I, I);
+    D.Remove(I - 10); // steady state: 10 live entries, one tombstone per round
+    Should(D.Count).Be(10);
+  end;
+
+  // The live window is intact and absent keys are reported as absent.
+  for I := 4991 to 5000 do
+    Should(D.ContainsKey(I)).BeTrue;
+  Should(D.TryGetValue(0, V)).BeFalse;
+  Should(D.TryGetValue(4990, V)).BeFalse;
 end;
 
 procedure TDictionaryStressTests.Rehash_ShouldPreserveAllEntries;


### PR DESCRIPTION
## Problem

`TRawDictionary` marks removed slots as `SLOT_TOMBSTONE` but never counts them, while `Grow` is decided on `FCount` alone. Tombstones keep occupying probe positions until a rehash clears them, so a plain add/remove cycle can fill the table with occupied+tombstone slots **without ever growing**. `FindSlot` only stops on `SLOT_EMPTY`, so once no empty slot is left it spins forever and the process hangs.

With `DEFAULT_CAPACITY = 4`, five operations are enough:

```pascal
D := TCollections.CreateDictionary<Int64, Integer>;
D.Add(100, 1);
D.Add(200, 2);
D.Add(300, 3);            // 3 occupied, load 75% -> no grow
D.Remove(100);            // 2 occupied + 1 tombstone
D.Add(900, 4);            // 3 occupied + 1 tombstone -> saturated, still no grow
D.TryGetValue(100, V);    // <-- never returns
```

This is not specific to one container: everything built on `TRawDictionary` (`TDictionary`, the ordered dictionary, hash sets, …) is affected. Any long-lived map with a remove/insert cycle eventually hangs on a lookup for a key that isn't there — silently, with no exception and no corruption, just a spinning thread.

## Fix

- track `FTombstones` and include it in the load factor of `AddRaw`/`AddOrSetRaw`, so the rehash that clears tombstones actually happens;
- reset `FTombstones` in `Rehash` and `Clear`;
- bound `FindSlot` to `FCapacity` probes as a safety net: if the invariant is ever broken again it returns "not found" (`SlotIndex = -1`) instead of spinning, and insertions raise instead of writing to a bogus slot.

## Tests

Added to `Tests/Collections/TestCollections.Dictionaries.pas`:

- `AddRemoveAdd_LookupOfRemovedKey_ShouldNotHang` — the five-operation repro above;
- `LongAddRemoveCycle_ShouldStayConsistent` — 5000 insert/remove rounds keeping a 10-entry live window, which is what actually exercises the load factor (the safety net alone would mask it).

Collections suite: **226/226 green** (Win64, Delphi 12).

## How we hit it

Found while adding composite typed keys to an in-memory entity index built on `IOrderedDictionary`: when the key of an indexed entity changes, the entity is extracted from the old key and re-added under the new one — exactly the pattern above. It surfaced as a hard hang in our own test run, which is how we traced it back down to `TRawDictionary`.
