### PR TITLE
fix(collections): make float hashing agree with float equality

### DIFF
--- a/Sources/Core/Dext.Collections.Comparers.pas
+++ b/Sources/Core/Dext.Collections.Comparers.pas
@@ -350,8 +350,35 @@ begin
         PPointer(VP)^,
         SizeOf(Pointer)
       );
+    tkFloat:
+      // Equals compares floats BY VALUE (see above), so the hash must agree:
+      // +0.0 and -0.0 are numerically equal but have different bit patterns.
+      // Hashing the raw bytes would send them to different buckets, breaking
+      // the Equals/GetHashCode contract - the dictionary would silently lose
+      // the key. Normalizing zero is what .NET's Double.GetHashCode does.
+      // Currency needs no special case: it is a scaled 64-bit integer, so
+      // equal values always have equal bits.
+      case SizeOf(T) of
+        4:
+          if PSingle(VP)^ = 0 then
+            Result := 0
+          else
+            Result := THashBobJenkins.GetHashValue(Value, SizeOf(T));
+        8:
+          if (TypeInfo(T) <> TypeInfo(Currency)) and (PDouble(VP)^ = 0) then
+            Result := 0
+          else
+            Result := THashBobJenkins.GetHashValue(Value, SizeOf(T));
+        10:
+          if PExtended(VP)^ = 0 then
+            Result := 0
+          else
+            Result := THashBobJenkins.GetHashValue(Value, SizeOf(T));
+      else
+        Result := THashBobJenkins.GetHashValue(Value, SizeOf(T));
+      end;
   else
-    // Integer, Float, Int64, Enum, Set, Record, etc: hash raw bytes
+    // Integer, Int64, Enum, Set, Record, etc: hash raw bytes
     Result := THashBobJenkins.GetHashValue(Value, SizeOf(T));
   end;
 end;

--- a/Tests/Collections/TestCollections.Dictionaries.pas
+++ b/Tests/Collections/TestCollections.Dictionaries.pas
@@ -200,6 +200,31 @@ type
     procedure ManagedRecord_ShouldWork;
   end;
 
+  /// <summary>
+  ///   Floating-point keys: Equals compares by VALUE, so GetHashCode must
+  ///   agree. +0.0 and -0.0 are numerically equal with different bit patterns;
+  ///   hashing raw bytes would break the Equals/GetHashCode contract and the
+  ///   dictionary would silently lose the key.
+  /// </summary>
+  [TestFixture('Dictionary - Float Keys')]
+  TDictionaryFloatKeyTests = class
+  public
+    [Test]
+    procedure NegativeZero_ShouldFindTheSameKey;
+
+    [Test]
+    procedure NegativeZero_ShouldNotAddASecondKey;
+
+    [Test]
+    procedure SingleKey_NegativeZero_ShouldFindTheSameKey;
+
+    [Test]
+    procedure Currency_ShouldStillWork;
+
+    [Test]
+    procedure NonZeroFloats_ShouldStillWork;
+  end;
+
 implementation
 
 { TDummyValue }
@@ -720,6 +745,86 @@ begin
   Should(D['Key'].I).Be(123);
   D.Clear;
   Should(D.Count).Be(0);
+end;
+
+{ TDictionaryFloatKeyTests }
+
+procedure TDictionaryFloatKeyTests.NegativeZero_ShouldFindTheSameKey;
+var
+  D: IDictionary<Double, string>;
+  Zero, NegZero: Double;
+  V: string;
+begin
+  Zero := 0.0;
+  NegZero := -0.0;
+  // Same number as far as arithmetic is concerned...
+  Should(Zero = NegZero).BeTrue;
+
+  D := TCollections.CreateDictionary<Double, string>;
+  D.Add(Zero, 'value');
+  // ...so looking it up with the other spelling must find it.
+  Should(D.ContainsKey(NegZero)).BeTrue;
+  Should(D.TryGetValue(NegZero, V)).BeTrue;
+  Should(V).Be('value');
+end;
+
+procedure TDictionaryFloatKeyTests.NegativeZero_ShouldNotAddASecondKey;
+var
+  D: IDictionary<Double, string>;
+  Zero, NegZero: Double;
+begin
+  Zero := 0.0;
+  NegZero := -0.0;
+  D := TCollections.CreateDictionary<Double, string>;
+  D.Add(Zero, 'first');
+  D.AddOrSetValue(NegZero, 'second');
+  // One number, one entry: the second call overwrites, it does not insert.
+  Should(D.Count).Be(1);
+  Should(D[Zero]).Be('second');
+end;
+
+procedure TDictionaryFloatKeyTests.SingleKey_NegativeZero_ShouldFindTheSameKey;
+var
+  D: IDictionary<Single, string>;
+  Zero, NegZero: Single;
+begin
+  Zero := 0.0;
+  NegZero := -0.0;
+  D := TCollections.CreateDictionary<Single, string>;
+  D.Add(Zero, 'value');
+  Should(D.ContainsKey(NegZero)).BeTrue;
+end;
+
+procedure TDictionaryFloatKeyTests.Currency_ShouldStillWork;
+var
+  D: IDictionary<Currency, string>;
+  A, B: Currency;
+begin
+  // Currency is a scaled 64-bit integer: equal values already have equal bits,
+  // so it takes the plain byte-hash path. Guard against regressions there.
+  A := 0.1;
+  B := 0.2;
+  D := TCollections.CreateDictionary<Currency, string>;
+  D.Add(0.3, 'sum');
+  Should(D.ContainsKey(A + B)).BeTrue;
+  Should(D[A + B]).Be('sum');
+  Should(D.ContainsKey(0.31)).BeFalse;
+end;
+
+procedure TDictionaryFloatKeyTests.NonZeroFloats_ShouldStillWork;
+var
+  D: IDictionary<Double, Integer>;
+begin
+  // The zero normalization must not disturb ordinary values.
+  D := TCollections.CreateDictionary<Double, Integer>;
+  D.Add(1.5, 1);
+  D.Add(-1.5, 2);
+  D.Add(2.25, 3);
+  Should(D.Count).Be(3);
+  Should(D[1.5]).Be(1);
+  Should(D[-1.5]).Be(2);
+  Should(D[2.25]).Be(3);
+  Should(D.ContainsKey(3.75)).BeFalse;
 end;
 
 end.

--- a/Tests/Collections/TestCollections.dpr
+++ b/Tests/Collections/TestCollections.dpr
@@ -82,6 +82,7 @@ begin
           TDictionaryEnumeratorTests,
           TDictionaryInterfaceTests,
           TDictionaryManagedRecordTests,
+          TDictionaryFloatKeyTests,
           TOrderedDictBasicTests,
           TOrderedDictOrderTests,
           TOrderedDictEdgeTests,


### PR DESCRIPTION
## The problem

`TDefaultEqualityComparer<T>` compares floating point values **by value**:

```pascal
tkFloat:
  case SizeOf(T) of
    4: Result := PSingle(LP)^ = PSingle(RP)^;
    8: ... Result := PDouble(LP)^ = PDouble(RP)^;
    10: Result := PExtended(LP)^ = PExtended(RP)^;
```

…but `GetHashCode` falls through to the generic branch and hashes the **raw bytes**:

```pascal
else
  // Integer, Float, Int64, Enum, Set, Record, etc: hash raw bytes
  Result := THashBobJenkins.GetHashValue(Value, SizeOf(T));
```

`+0.0` and `-0.0` are numerically equal and have different bit patterns, so the two
disagree: `Equals` says "same key", the hash sends them to different buckets. The
`Equals`/`GetHashCode` contract is broken, and the failure is **silent** — no exception,
the dictionary just loses the key.

### Repro

Three lines, no external dependency:

```pascal
var
  D: IDictionary<Double, string>;
begin
  D := TCollections.CreateDictionary<Double, string>;
  D.Add(0.0, 'value');
  Assert(D.ContainsKey(-0.0));   // fails, although (0.0 = -0.0) is True
  D.Add(-0.0, 'other');
  Assert(D.Count = 1);           // fails: Count is 2 - two entries for one number
end;
```

## The fix

A dedicated `tkFloat` branch in `GetHashCode` that normalizes zero, so both spellings
hash the same. This is what .NET's `Double.GetHashCode` does.

`Currency` needs no special case — it is a scaled 64-bit integer, so equal values always
have equal bits — and it keeps taking the plain byte-hash path.

### There is a second, equally consistent fix

Making `Equals` **bit-wise** instead, the way Java's `Double.equals` distinguishes
`+0.0` from `-0.0`, would restore the contract just as well. I went the other way
because the numeric `Equals` is already published and is what most callers expect — but
it is your call, and I am happy to flip the PR if you prefer that direction.

## Tests

5 regression tests in `Tests/Collections` (fixture `Dictionary - Float Keys`).
**Without this change 3 of them fail:**

```
NegativeZero_ShouldFindTheSameKey            Expected True but was False
NegativeZero_ShouldNotAddASecondKey          Expected 1 but was 2
SingleKey_NegativeZero_ShouldFindTheSameKey  Expected True but was False
```

The other two — `Currency_ShouldStillWork` and `NonZeroFloats_ShouldStillWork` — pass
both before and after: they are there to guard the paths this change touches.

Collections suite: **226 passed / 3 failed** before, **229 / 229** after.

## Notes

**Not a bug, but worth knowing**: with value-based `Equals`, a `NaN` key can never be
retrieved, since `NaN <> NaN` by IEEE definition. That does not violate the contract
(`Equals` is False), so this PR leaves it alone. Might deserve a line of documentation.

**Impact is low in practice.** Floating point keys are rare, and generally a bad idea
anyway: two values computed along different paths are seldom bit-identical. I am
reporting it because it fails *silently* and the fix is cheap — not because it is
blocking anything on our side (we use `Currency` for money and normalized `Int64` for
dates).

**How we ran into it**: while adding a keys-only container on our side, we asked
ourselves which types are safe to use as a key and decided to test the edge cases
instead of assuming.

Branch is one commit on top of `main` (`d6ce708f`) and is independent of #164.
