### PR TITLE
perf(net): stop copying the response body up to four times

### DIFF
--- a/Sources/Net/Dext.Net.Engine.pas
+++ b/Sources/Net/Dext.Net.Engine.pas
@@ -93,10 +93,29 @@ type
   private
     FStatusCode: Integer;
     FStatusText: string;
-    FContentStream: TMemoryStream;
+    FContentStream: TStream;
+    /// True when this instance owns FContentStream and must free it. False when
+    /// the stream belongs to someone else, kept alive by FKeepAlive.
+    FOwnsStream: Boolean;
+    /// Holds a reference to whoever owns the content stream (the RTL's
+    /// IHTTPResponse), so the bytes stay valid for as long as this response does.
+    FKeepAlive: IInterface;
     FHeaders: TDextNetHeaders;
   public
-    constructor Create(AStatusCode: Integer; const AStatusText: string; AStream: TStream; const AHeaders: TDextNetHeaders);
+    /// <summary>Takes the response over WITHOUT copying its content.</summary>
+    /// <param name="AOwnsStream">
+    ///   True: this instance frees AStream (caller must not).
+    ///   False: AKeepAlive must reference the owner, so the memory outlives us.
+    /// </param>
+    /// <remarks>
+    ///   The payload used to be copied into a private TMemoryStream, which meant
+    ///   every response existed twice in RAM at once -- a 500 MB download peaked
+    ///   at a gigabyte. Nothing here needs a copy: the bytes are already in a
+    ///   stream that we can either adopt or keep alive.
+    /// </remarks>
+    constructor Create(AStatusCode: Integer; const AStatusText: string;
+      AStream: TStream; const AHeaders: TDextNetHeaders;
+      AOwnsStream: Boolean; const AKeepAlive: IInterface = nil);
     destructor Destroy; override;
     function GetStatusCode: Integer;
     function GetStatusText: string;
@@ -106,24 +125,26 @@ type
 
 { TDextHttpResponseImpl }
 
-constructor TDextHttpResponseImpl.Create(AStatusCode: Integer; const AStatusText: string; AStream: TStream; const AHeaders: TDextNetHeaders);
+constructor TDextHttpResponseImpl.Create(AStatusCode: Integer;
+  const AStatusText: string; AStream: TStream; const AHeaders: TDextNetHeaders;
+  AOwnsStream: Boolean; const AKeepAlive: IInterface);
 begin
   inherited Create;
   FStatusCode := AStatusCode;
   FStatusText := AStatusText;
   FHeaders := AHeaders;
-  FContentStream := TMemoryStream.Create;
-  if Assigned(AStream) then
-  begin
-    AStream.Position := 0;
-    FContentStream.CopyFrom(AStream, AStream.Size);
+  FContentStream := AStream;
+  FOwnsStream := AOwnsStream;
+  FKeepAlive := AKeepAlive;
+  if Assigned(FContentStream) then
     FContentStream.Position := 0;
-  end;
 end;
 
 destructor TDextHttpResponseImpl.Destroy;
 begin
-  FContentStream.Free;
+  if FOwnsStream then
+    FContentStream.Free;
+  FKeepAlive := nil;
   inherited;
 end;
 
@@ -267,15 +288,18 @@ begin
             Line.Substring(Pos + 1).Trim
           ));
       end;
+      // The response ADOPTS the stream (no copy, and we must not free it here).
       Result := TDextHttpResponseImpl.Create(
         FIdHttp.ResponseCode,
         FIdHttp.ResponseText,
         ResponseStream,
-        HeadersList.ToArray
+        HeadersList.ToArray,
+        True { AOwnsStream }
       );
+      ResponseStream := nil; // ownership transferred
     finally
       HeadersList.Free;
-      ResponseStream.Free;
+      ResponseStream.Free; // only reached if the line above never ran
     end;
   except
     raise;
@@ -345,11 +369,15 @@ begin
       NetHeadersList.Add(TNetHeader.Create(AHeaders[i].Name, AHeaders[i].Value));
 
     Response := FClient.Execute(AMethod, TURI.Create(AUrl), ABody, nil, NetHeadersList.ToArray) as IHTTPResponse;
+    // No copy: the RTL already buffered the payload. We hand the same stream over
+    // and keep the IHTTPResponse referenced, so its memory stays valid.
     Result := TDextHttpResponseImpl.Create(
       Response.StatusCode,
       Response.StatusText,
       Response.ContentStream,
-      Response.Headers
+      Response.Headers,
+      False { AOwnsStream },
+      Response { AKeepAlive }
     );
   finally
     NetHeadersList.Free;

--- a/Sources/Net/Dext.Net.RestClient.pas
+++ b/Sources/Net/Dext.Net.RestClient.pas
@@ -98,7 +98,10 @@ uses
   private
     FStatusCode: Integer;
     FStatusText: string;
-    FContentStream: TMemoryStream;
+    /// Decoded content. When the response is NOT compressed this is a read-only
+    /// view over FRawContentStream's memory (same bytes, own Position) instead
+    /// of a second copy of it.
+    FContentStream: TStream;
     FRawContentStream: TMemoryStream;
     FHeaders: TDextNetHeaders;
   protected
@@ -400,6 +403,34 @@ begin
   Result := TRestClient.Create(ABaseUrl);
 end;
 
+type
+  /// <summary>
+  ///   Read-only view over memory owned by another stream: same bytes, no copy,
+  ///   but an independent Position so callers can read both views concurrently.
+  /// </summary>
+  /// <remarks>
+  ///   Used when the response is not compressed and the decoded content is
+  ///   byte-for-byte the raw content: duplicating it would double the memory of
+  ///   every response for no benefit. The view never outlives the stream that
+  ///   owns the memory (both are fields of the same TRestResponse).
+  /// </remarks>
+  TDextMemoryView = class(TCustomMemoryStream)
+  public
+    constructor Create(AMemory: Pointer; ASize: NativeInt);
+    function Write(const Buffer; Count: Longint): Longint; override;
+  end;
+
+constructor TDextMemoryView.Create(AMemory: Pointer; ASize: NativeInt);
+begin
+  inherited Create;
+  SetPointer(AMemory, ASize);
+end;
+
+function TDextMemoryView.Write(const Buffer; Count: Longint): Longint;
+begin
+  raise EStreamError.Create('Response content stream is read-only.');
+end;
+
 { TRestResponse }
 
 constructor TRestResponse.Create(AStatusCode: Integer; const AStatusText: string; AStream: TStream;
@@ -412,45 +443,52 @@ begin
   FStatusCode := AStatusCode;
   FStatusText := AStatusText;
   FHeaders := AHeaders;
-  FContentStream := TMemoryStream.Create;
   FRawContentStream := TMemoryStream.Create;
-  if Assigned(AStream) then
+  if not Assigned(AStream) then
   begin
-    AStream.Position := 0;
-    FRawContentStream.CopyFrom(AStream, AStream.Size);
-    FRawContentStream.Position := 0;
-    
-    ContentEncoding := GetHeader('Content-Encoding');
-    if SameText(ContentEncoding, 'gzip') then
-    begin
-      Decompressor := TZDecompressionStream.Create(FRawContentStream, 31);
-      try
-        FContentStream.CopyFrom(Decompressor, 0);
-      finally
-        Decompressor.Free;
-      end;
-    end
-    else if SameText(ContentEncoding, 'deflate') then
-    begin
-      Decompressor := TZDecompressionStream.Create(FRawContentStream, 15);
-      try
-        FContentStream.CopyFrom(Decompressor, 0);
-      finally
-        Decompressor.Free;
-      end;
-    end
-    else
-    begin
-      FContentStream.CopyFrom(FRawContentStream, FRawContentStream.Size);
-    end;
-    
-    FContentStream.Position := 0;
-    FRawContentStream.Position := 0;
+    // No payload: keep an empty decoded stream, as before.
+    FContentStream := TMemoryStream.Create;
+    Exit;
   end;
+
+  AStream.Position := 0;
+  FRawContentStream.CopyFrom(AStream, AStream.Size);
+  FRawContentStream.Position := 0;
+
+  ContentEncoding := GetHeader('Content-Encoding');
+  if SameText(ContentEncoding, 'gzip') or SameText(ContentEncoding, 'deflate')
+  then
+  begin
+    // Compressed: the decoded content really is different from the raw bytes,
+    // so it needs its own stream.
+    FContentStream := TMemoryStream.Create;
+    if SameText(ContentEncoding, 'gzip') then
+      Decompressor := TZDecompressionStream.Create(FRawContentStream, 31)
+    else
+      Decompressor := TZDecompressionStream.Create(FRawContentStream, 15);
+    try
+      TMemoryStream(FContentStream).CopyFrom(Decompressor, 0);
+    finally
+      Decompressor.Free;
+    end;
+  end
+  else
+  begin
+    // Not compressed: decoded content == raw content, byte for byte. Copying it
+    // doubled the memory of every response for nothing -- a 500 MB download kept
+    // 1 GB alive. A view shares the bytes and keeps its own Position, so
+    // ContentStream and RawContentStream stay independent for the caller.
+    FContentStream := TDextMemoryView.Create(FRawContentStream.Memory,
+      FRawContentStream.Size);
+  end;
+
+  FContentStream.Position := 0;
+  FRawContentStream.Position := 0;
 end;
 
 destructor TRestResponse.Destroy;
 begin
+  // The view must go first: it points into FRawContentStream's memory.
   FContentStream.Free;
   FRawContentStream.Free;
   inherited;


### PR DESCRIPTION
A single HTTP response was buffered **up to four times** before the caller could read it. On large downloads that is the difference between holding one copy of the payload and holding two, with a peak higher still.

## Where the copies came from

| | | |
|---|---|---|
| 1 | the RTL (or Indy) buffers the payload | unavoidable today |
| 2 | `TDextHttpResponseImpl.Create` copies it again | **removed** |
| 3 | `TRestResponse.Create` copies into `FRawContentStream` | kept — it *is* the raw content |
| 4 | `TRestResponse.Create` copies that into `FContentStream`, byte for byte, whenever the response is **not** compressed | **removed** |

Copy 4 was the most wasteful: with no `Content-Encoding`, the "decoded" content **is** the raw content. Both streams stayed alive for the lifetime of the response, holding identical bytes.

## What changed

**`Dext.Net.Engine.pas` — copy 2.** The payload is already sitting in a stream that we can either adopt or keep alive:

- **Indy** allocated a `TMemoryStream`, let the response copy it, then freed it. Now the response *adopts* it (`AOwnsStream = True`) and Indy stops freeing it.
- **RTL** exposes `Response.ContentStream`, owned by the `IHTTPResponse` that went out of scope at the end of `Execute` — which is *why* it was copied. Now the response holds the `IHTTPResponse` (`AKeepAlive`), so the bytes stay valid without duplicating them.

The constructor takes ownership explicitly, so there is no ambiguity about who frees what.

**`Dext.Net.RestClient.pas` — copy 4.** When the response is not compressed, `FContentStream` becomes a read-only view over the raw bytes:

```pascal
TDextMemoryView = class(TCustomMemoryStream)  // points at FRawContentStream's memory
```

A *view* rather than the same object on purpose: `ContentStream` and `RawContentStream` keep **independent positions**, so callers reading both behave exactly as before. When the response *is* gzip/deflate the decoded content genuinely differs, and it still gets its own stream.

## Measured

Holding one **601 KB uncompressed** response alive, against a real server:

| | allocated | ratio |
|---|---|---|
| before | 1,214,336 bytes | **2.02x** the payload |
| after | 608,112 bytes | **1.01x** the payload |

## Verification

A harness exercised both branches against a live server and checked, for each:

- body identical byte for byte to what the server sent;
- `ContentStream` / `RawContentStream` positions still independent (moving one does not move the other);
- re-reading a stream gives the same result (no destructive consumption);
- gzip still decompresses — `raw 98,043 → decoded 601,263 bytes`, with a real copy retained.

Beyond that, a downstream project of mine drives this client on **every** call (VCL and web clients, file/BLOB round-trips comparing bytes one by one): its 429-test suite is green with no leaks, and its example applications build and run unchanged.

## Compatibility

No public API changes. `TDextHttpResponseImpl` is declared in the implementation section, and the altered `TRestResponse` fields are private. The only externally visible difference is that `ContentStream` is now read-only when the response is uncompressed — writing to a response body was never meaningful, but it is worth flagging.

One deliberate omission: the RTL still buffers the whole payload before we ever see it (copy 1). Removing *that* means streaming straight into a caller-supplied stream — which is what S58 is about, and I did not want to pre-empt the design you already outlined for it.
