### PR TITLE
fix(httpsys): free the thread-local pools of the thread that calls Start

### DIFF
--- a/Sources/Server/Dext.Server.HttpSys.pas
+++ b/Sources/Server/Dext.Server.HttpSys.pas
@@ -416,6 +416,23 @@ threadvar
   FLocalRequestPool: TList;
   FLocalResponsePool: TList;
 
+/// <summary>Frees the calling thread's lock-free pools.</summary>
+/// <remarks>
+///   These are threadvars, so only the owning thread can release them, and any
+///   thread that touches Acquire/Release creates them lazily. Worker threads do
+///   it when their loop ends -- but so must the thread that calls Start, which
+///   pre-posts the initial receives from there
+///   (PostReceiveRequest(AcquireContext)) and so ends up owning a pool nobody
+///   was freeing. The lists hold pointers to objects the engine owns, so
+///   freeing the list is all that belongs here.
+/// </remarks>
+procedure ReleaseThreadLocalPools;
+begin
+  FreeAndNil(FLocalContextPool);
+  FreeAndNil(FLocalRequestPool);
+  FreeAndNil(FLocalResponsePool);
+end;
+
 { TDextHttpSysContext }
 
 constructor TDextHttpSysContext.Create;
@@ -2186,12 +2203,7 @@ begin
     end;
   end;
   finally
-    FLocalContextPool.Free;
-    FLocalContextPool := nil;
-    FLocalRequestPool.Free;
-    FLocalRequestPool := nil;
-    FLocalResponsePool.Free;
-    FLocalResponsePool := nil;
+    ReleaseThreadLocalPools;
   end;
 end;
 
@@ -2434,6 +2446,10 @@ begin
 
   HttpTerminate(HTTP_INITIALIZE_SERVER, nil);
   FReqQueue := 0;
+
+  // Start pre-posted the first receives from THIS thread, which gave it a pool
+  // of its own. Only this thread can free it.
+  ReleaseThreadLocalPools;
 end;
 
 function TDextHttpSysEngine.GetActiveConnections: Integer;


### PR DESCRIPTION
# PR — fix(httpsys): free the thread-local pools of the thread that calls Start

**Branch**: `Stemonik:fix/httpsys-threadlocal-pool-leak` → `cesarliws:main`
**Size**: one file, +22 −6.

---

The HTTP.sys engine keeps its lock-free pools in `threadvar`s, and every thread
that touches Acquire/Release creates them lazily. Worker threads free theirs
when their loop ends — but `Start` pre-posts the initial receives from the
**calling** thread:

```pascal
for i := 0 to (ThreadCount * FOptions.OutstandingReceiveDepth) - 1 do
  PostReceiveRequest(AcquireContext);
```

so that thread gets a pool of its own, and nothing ever freed it.

One `TList` leaks per process. Forty bytes, so nothing dramatic in itself —
except it makes **every clean shutdown report a leak**, and a leak report that
cries wolf by habit is the best way not to notice a real one. That is how it
surfaced for us: a VCL server that reported a leak at exit no matter what.

The three frees move into a small `ReleaseThreadLocalPools`, called from the
worker loop exactly as before and at the end of `Stop`, which runs on the same
thread that called `Start`. The lists hold pointers to objects the engine owns,
so freeing the list is all that belongs there.

**Verified** with a start/stop harness on the native engine:
`ReportMemoryLeaksOnShutdown` printed

```
Unexpected Memory Leak
25 - 40 bytes: TList x 1
```

before, and nothing after.
