### PR TITLE
fix(net): make the Indy HTTP client engine compile

### DIFF
--- a/Sources/Net/Dext.Net.Engine.pas
+++ b/Sources/Net/Dext.Net.Engine.pas
@@ -170,10 +170,16 @@ end;
 
 {$IF defined(DEXT_FORCE_INDY) or (CompilerVersion < 29.0)}
 type
+  /// <summary>
+  ///   Reaches TIdCustomHTTP.DoRequest, which is protected and has no public
+  ///   equivalent for an arbitrary verb (PATCH, QUERY, ...).
+  /// </summary>
+  TIdHTTPAccess = class(TIdHTTP);
+
   TDextIndyHttpEngine = class(TInterfacedObject, IDextHttpEngine)
   private
     FIdHttp: TIdHTTP;
-    function VerifyPeer(ADb: TIdSSLContext; AHandshake: TIdSSLHandShake; ACert: TIdSSLCertificate): Boolean;
+    function VerifyPeer(ACertificate: TIdX509; AOk: Boolean; ADepth, AError: Integer): Boolean;
   public
     constructor Create;
     destructor Destroy; override;
@@ -214,7 +220,8 @@ begin
   FIdHttp.ReadTimeout := AMilliseconds;
 end;
 
-function TDextIndyHttpEngine.VerifyPeer(ADb: TIdSSLContext; AHandshake: TIdSSLHandShake; ACert: TIdSSLCertificate): Boolean;
+function TDextIndyHttpEngine.VerifyPeer(ACertificate: TIdX509; AOk: Boolean;
+  ADepth, AError: Integer): Boolean;
 begin
   Result := True;
 end;
@@ -267,7 +274,7 @@ begin
       else if SameText(AMethod, 'DELETE') then
         FIdHttp.Delete(AUrl, ResponseStream)
       else
-        FIdHttp.DoRequest(AMethod, AUrl, ABody, ResponseStream, []);
+        TIdHTTPAccess(FIdHttp).DoRequest(AMethod, AUrl, ABody, ResponseStream, []);
     except
       on E: Exception do
       begin


### PR DESCRIPTION
Building `Dext.Net.Engine` with `DEXT_FORCE_INDY` against the Indy that ships
with Delphi 12 fails with six errors — and they are not new. I checked out `main`
untouched and got exactly the same ones:

```
E2003 Undeclared identifier: 'TIdSSLHandShake'
E2003 Undeclared identifier: 'TIdSSLCertificate'
E2005 'TIdSSLHandShake' is not a type identifier
E2005 'TIdSSLCertificate' is not a type identifier
E2010 Incompatible types: 'TIdX509' and 'TIdSSLContext'
E2362 Cannot access protected symbol TIdCustomHTTP.DoRequest
```

Two causes:

- **`VerifyPeer` has a signature that does not exist.** It is declared
  `(ADb: TIdSSLContext; AHandshake: TIdSSLHandShake; ACert: TIdSSLCertificate)`,
  while `TVerifyPeerEvent` in `IdSSLOpenSSL` is
  `(Certificate: TIdX509; AOk: Boolean; ADepth, AError: Integer): Boolean`.

- **`TIdCustomHTTP.DoRequest` is protected**, so the fallback branch that handles
  verbs other than GET/POST/PUT/DELETE cannot call it as written. A local
  accessor class is the usual way in and keeps the call exactly where it was.

So as it stands that engine is only reachable on `CompilerVersion < 29`, where
the same code would fail for the same reasons — which is to say it is not
reachable at all.

Both branches compile after this: with `DEXT_FORCE_INDY` and without.

Found while implementing S58, which has to work on Indy too — without this fix
there was no way to test it there. Sent separately because it stands on its own.
