### PR TITLE
fix(hubs): stop dereferencing a nil connection on WebSocket upgrade

### DIFF
--- a/Sources/Hubs/Dext.Web.Hubs.Middleware.pas
+++ b/Sources/Hubs/Dext.Web.Hubs.Middleware.pas
@@ -115,7 +115,14 @@ type
     procedure HandleInvoke(const HubPath: string; Ctx: IHttpContext; Dispatcher: THubDispatcher);
     procedure HandlePoll(const HubPath: string; Ctx: IHttpContext; Dispatcher: THubDispatcher);
     procedure HandleWebSocket(const HubPath: string; Ctx: IHttpContext; Dispatcher: THubDispatcher);
-    
+
+    /// <summary>
+    /// Returns True only when the active HTTP engine exposes an upgradable
+    /// connection. IHttpContext.Connection is nil on engines that do not
+    /// implement the raw server connection (Indy, DCS, WebBroker).
+    /// </summary>
+    function ConnectionSupportsUpgrade(const Ctx: IHttpContext): Boolean;
+
     function FindDispatcher(const Path: string; out HubPath: string): THubDispatcher;
   public
     constructor Create;
@@ -141,6 +148,7 @@ implementation
 
 uses
   System.TypInfo,
+  Dext.Server.Engine.Interfaces,
   Dext.Utils;
 
 function ReadStreamToString(AStream: TStream): string;
@@ -353,6 +361,17 @@ begin
   inherited;
 end;
 
+function THubMiddleware.ConnectionSupportsUpgrade(
+  const Ctx: IHttpContext): Boolean;
+var
+  LConnection: IDextServerConnection;
+begin
+  LConnection := Ctx.Connection;
+  Result := Assigned(LConnection);
+  if Result then
+    Result := LConnection.SupportsUpgrade;
+end;
+
 procedure THubMiddleware.Shutdown;
 begin
   if FSSETransport <> nil then
@@ -416,11 +435,22 @@ begin
   end;
   
   // Check for WebSocket upgrade request
-  if SameText(Ctx.Request.Method, 'GET') and 
-     SameText(Ctx.Request.GetHeader('Upgrade'), 'websocket') and
-     Ctx.Connection.SupportsUpgrade then
+  if SameText(Ctx.Request.Method, 'GET') and
+     SameText(Ctx.Request.GetHeader('Upgrade'), 'websocket') then
   begin
-    HandleWebSocket(HubPath, Ctx, Dispatcher);
+    if ConnectionSupportsUpgrade(Ctx) then
+      HandleWebSocket(HubPath, Ctx, Dispatcher)
+    else
+    begin
+      // No upgradable connection on this engine: answer 426 instead of
+      // dereferencing a nil Connection (RFC 7231 section 6.5.15).
+      Ctx.Response.StatusCode := 426;
+      Ctx.Response.AddHeader('Upgrade', 'websocket');
+      Ctx.Response.AddHeader('Connection', 'Upgrade');
+      Ctx.Response.SetContentType('application/json');
+      Ctx.Response.Write(
+        '{"error":"WebSocket upgrade is not supported by the active HTTP engine"}');
+    end;
     Exit;
   end;
   

--- a/Sources/Hubs/Transports/Dext.Web.Hubs.Transport.WebSocket.pas
+++ b/Sources/Hubs/Transports/Dext.Web.Hubs.Transport.WebSocket.pas
@@ -297,8 +297,17 @@ var
   BytesConsumed: Integer;
   PayloadStr: string;
   KeepAliveTimer: TDateTime;
+  ServerConnection: IDextServerConnection;
 begin
-  WSConn := AContext.Connection.UpgradeToWebSocket;
+  // Engines without a raw server connection (Indy, DCS, WebBroker) return nil.
+  ServerConnection := AContext.Connection;
+  if ServerConnection = nil then
+  begin
+    AConnectionId := '';
+    Exit;
+  end;
+
+  WSConn := ServerConnection.UpgradeToWebSocket;
   if WSConn = nil then
   begin
     AConnectionId := '';

--- a/Sources/Web/Dext.Web.Interfaces.pas
+++ b/Sources/Web/Dext.Web.Interfaces.pas
@@ -372,7 +372,12 @@ type
     /// </summary>
     procedure SetRouteParams(const AParams: TRouteValueDictionary);
     
-    /// <summary>Access to the underlying network connection.</summary>
+    /// <summary>
+    ///   Access to the underlying network connection.
+    ///   Can be nil: engines that do not expose a raw server connection
+    ///   (Indy, DCS, WebBroker) return nil, and so does the test double
+    ///   TMockHttpContext. Always check the result before dereferencing it.
+    /// </summary>
     property Connection: IDextServerConnection read GetConnection;
     /// <summary>Access to the incoming request data.</summary>
     property Request: IHttpRequest read GetRequest;

--- a/Tests/Hubs/Dext.Web.Hubs.Middleware.Tests.pas
+++ b/Tests/Hubs/Dext.Web.Hubs.Middleware.Tests.pas
@@ -1,0 +1,184 @@
+{***************************************************************************}
+{                                                                           }
+{           Dext Framework                                                  }
+{                                                                           }
+{           Copyright (C) 2025-2026 Cesar Romero & Dext Contributors        }
+{                                                                           }
+{           Licensed under the Apache License, Version 2.0 (the "License"); }
+{           you may not use this file except in compliance with the License.}
+{           You may obtain a copy of the License at                         }
+{                                                                           }
+{               http://www.apache.org/licenses/LICENSE-2.0                  }
+{                                                                           }
+{           Unless required by applicable law or agreed to in writing,      }
+{           software distributed under the License is distributed on an     }
+{           "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    }
+{           either express or implied. See the License for the specific     }
+{           language governing permissions and limitations under the        }
+{           License.                                                        }
+{                                                                           }
+{***************************************************************************}
+unit Dext.Web.Hubs.Middleware.Tests;
+
+{$I Dext.inc}
+
+interface
+
+procedure RunMiddlewareTests(var APassed, AFailed: Integer);
+
+implementation
+
+uses
+  System.Rtti,
+  System.SysUtils,
+  Dext.Collections,
+  Dext.Collections.Dict,
+  Dext.Mocks,
+  Dext.Web.Hubs.Hub,
+  Dext.Web.Hubs.Middleware,
+  Dext.Web.Interfaces,
+  Dext.Web.Mocks;
+
+type
+  /// <summary>Minimal Hub used only to register a route in the middleware.</summary>
+  TProbeHub = class(THub)
+  end;
+
+var
+  Passed: Integer;
+  Failed: Integer;
+
+procedure Check(ACondition: Boolean; const ATestName: string);
+begin
+  if ACondition then
+  begin
+    Inc(Passed);
+    WriteLn('[PASS] ', ATestName);
+  end
+  else
+  begin
+    Inc(Failed);
+    WriteLn('[FAIL] ', ATestName);
+  end;
+end;
+
+/// <summary>
+/// Builds an IHttpRequest double. Only the members read by THubMiddleware.Handle
+/// are configured: method, path and the Upgrade header.
+/// </summary>
+function CreateRequest(const AMethod, APath, AUpgrade: string): IHttpRequest;
+var
+  MockRequest: Mock<IHttpRequest>;
+  Query: IStringDictionary;
+  Headers: IStringDictionary;
+begin
+  MockRequest := Mock<IHttpRequest>.Create;
+  Query := TCollections.CreateStringDictionary(True);
+  Headers := TCollections.CreateStringDictionary(True);
+
+  MockRequest.Setup.Returns(TValue.From<IStringDictionary>(Query)).When.GetQuery;
+  MockRequest.Setup.Returns(TValue.From<IStringDictionary>(Headers)).When.GetHeaders;
+  MockRequest.Setup.Returns(AMethod).When.GetMethod;
+  MockRequest.Setup.Returns(APath).When.GetPath;
+  MockRequest.Setup.Returns(AUpgrade).When.GetHeader('Upgrade');
+
+  Result := MockRequest.Instance;
+end;
+
+function CreateContext(const AMethod, APath, AUpgrade: string): IHttpContext;
+begin
+  // TMockHttpContext.GetConnection returns nil, exactly like the Indy, DCS and
+  // WebBroker contexts, so this is the engine-without-upgrade scenario.
+  Result := TMockHttpContext.Create(CreateRequest(AMethod, APath, AUpgrade),
+    TMockHttpResponse.Create);
+end;
+
+procedure TestUpgradeRequestWithoutServerConnection;
+var
+  Middleware: THubMiddleware;
+  Ctx: IHttpContext;
+  NextCalled: Boolean;
+  UpgradeHeader: string;
+begin
+  WriteLn;
+  WriteLn('=== THubMiddleware Upgrade Without Connection Tests ===');
+
+  Middleware := THubMiddleware.Create;
+  try
+    Middleware.MapHub('/hubs/probe', TProbeHub);
+
+    Ctx := CreateContext('GET', '/hubs/probe', 'websocket');
+    NextCalled := False;
+    Middleware.Handle(Ctx,
+      procedure(AContext: IHttpContext)
+      begin
+        NextCalled := True;
+      end);
+
+    Check(Ctx.Response.StatusCode = 426,
+      'Upgrade request on engine without connection answers 426');
+    Check(not NextCalled,
+      'Upgrade request on engine without connection is not forwarded to Next');
+
+    UpgradeHeader := '';
+    Ctx.Response.GetHeaders.TryGetValue('Upgrade', UpgradeHeader);
+    Check(SameText(UpgradeHeader, 'websocket'),
+      '426 response advertises the Upgrade header');
+  finally
+    Middleware.Free;
+  end;
+end;
+
+procedure TestRegularRequestStillRouted;
+var
+  Middleware: THubMiddleware;
+  Ctx: IHttpContext;
+  NextCalled: Boolean;
+begin
+  Middleware := THubMiddleware.Create;
+  try
+    Middleware.MapHub('/hubs/probe', TProbeHub);
+
+    // No Upgrade header: the request must reach the SSE handler, which rejects
+    // the missing connection id with 400 instead of touching Connection.
+    Ctx := CreateContext('GET', '/hubs/probe', '');
+    NextCalled := False;
+    Middleware.Handle(Ctx,
+      procedure(AContext: IHttpContext)
+      begin
+        NextCalled := True;
+      end);
+
+    Check(Ctx.Response.StatusCode = 400,
+      'Plain GET without connection id still answers 400');
+    Check(not NextCalled,
+      'Plain GET on a mapped hub is not forwarded to Next');
+
+    // Unmapped path keeps flowing through the pipeline.
+    Ctx := CreateContext('GET', '/api/other', '');
+    NextCalled := False;
+    Middleware.Handle(Ctx,
+      procedure(AContext: IHttpContext)
+      begin
+        NextCalled := True;
+      end);
+
+    Check(NextCalled, 'Unmapped path is forwarded to Next');
+  finally
+    Middleware.Free;
+  end;
+end;
+
+procedure RunMiddlewareTests(var APassed, AFailed: Integer);
+begin
+  Passed := 0;
+  Failed := 0;
+
+  TestUpgradeRequestWithoutServerConnection;
+  TestRegularRequestStillRouted;
+
+  APassed := APassed + Passed;
+  AFailed := AFailed + Failed;
+end;
+
+end.

--- a/Tests/Hubs/TestDextHubs.dpr
+++ b/Tests/Hubs/TestDextHubs.dpr
@@ -19,7 +19,8 @@ uses
   Dext.Web.Hubs.Clients,
   Dext.Web.Hubs.Context,
   Dext.Web.Hubs.Protocol.Json,
-  Dext.Web.Hubs.Client.Tests;
+  Dext.Web.Hubs.Client.Tests,
+  Dext.Web.Hubs.Middleware.Tests;
 
 var
   TestsPassed: Integer = 0;
@@ -605,6 +606,9 @@ begin
     TestProtocolMultipleArguments;
     TestProtocolWithInvocationId;
     
+    // Hub middleware tests (engines without an upgradable connection)
+    RunMiddlewareTests(TestsPassed, TestsFailed);
+
     // Delphi Hub Client Tests
     RunClientTests(TestsPassed, TestsFailed);
     

--- a/Tests/Hubs/TestDextHubs.dproj
+++ b/Tests/Hubs/TestDextHubs.dproj
@@ -46,7 +46,7 @@
         <Base>true</Base>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base)'!=''">
-        <DCC_UnitSearchPath>..\..\Sources\Common;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <DCC_UnitSearchPath>..\..\Sources\Common;..\Common;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
         <DCC_E>false</DCC_E>
         <DCC_F>false</DCC_F>
         <DCC_K>false</DCC_K>


### PR DESCRIPTION
## Summary

- `THubMiddleware.Handle` no longer dereferences `IHttpContext.Connection` when a client requests a WebSocket upgrade
- engines that cannot upgrade now answer `426 Upgrade Required` instead of failing with HTTP 500
- `TWebSocketHubTransport.ProcessConnection` gets the same guard, because it is public and reachable without the middleware check
- `IHttpContext.Connection` is documented as nullable, so the next caller does not repeat the assumption
- new test suite covers the upgrade path, the SSE path and pipeline passthrough

## Root cause

`IHttpContext.Connection` is nil on every context that does not expose a raw server connection:

| Context | `GetConnection` returns |
|---|---|
| `TDextIndyHttpContext` — `Sources/Web/Dext.Web.Indy.pas` | `nil` |
| `TDextDCSContext` — `Sources/Web/Dext.Web.DCS.pas` | `nil` |
| `TDextWebBrokerContext` — `Sources/Web/Dext.Web.WebBroker.pas` | `nil` |
| `TMockHttpContext` — `Tests/Common/Dext.Web.Mocks.pas` | `nil` |
| `TDextNativeHttpContext` — `Sources/Server/Dext.Server.Native.pas` | the engine connection |

`THubMiddleware.Handle` read `Ctx.Connection.SupportsUpgrade` as the third operand of the upgrade check:

```pascal
if SameText(Ctx.Request.Method, 'GET') and
   SameText(Ctx.Request.GetHeader('Upgrade'), 'websocket') and
   Ctx.Connection.SupportsUpgrade then
```

Any `GET` carrying `Upgrade: websocket` on one of those engines raised an access violation, which surfaced as HTTP 500. Short-circuit evaluation kept the remaining routes (negotiate, SSE stream, invoke, poll) safe, so the crash was confined to the upgrade path — but it is unrecoverable from the client side, since no header or status tells the client that the engine simply has no upgrade support.

## Fix

1. `THubMiddleware.ConnectionSupportsUpgrade` resolves the connection once and returns `False` when it is nil, instead of dereferencing it.
2. When the client asked for an upgrade and the engine cannot provide one, the middleware answers `426 Upgrade Required` with `Upgrade: websocket` and `Connection: Upgrade` (RFC 7231 section 6.5.15) plus a JSON body. Before this change the request would have fallen through to the SSE handler and produced a misleading `400 Missing connection id`.
3. `TWebSocketHubTransport.ProcessConnection` resolves `AContext.Connection` into a local variable and exits early when it is nil. The method is public, so the middleware guard alone does not cover every caller.
4. The nullable contract is documented on `IHttpContext.Connection` itself, listing the engines that return nil.

No behaviour changes for engines that do support upgrades: `ConnectionSupportsUpgrade` returns exactly `Connection.SupportsUpgrade` when the connection exists.

## Validation

`Tests/Hubs/TestDextHubs.dpr`, Win64, Delphi 37.0.

With the fix:

```
=== THubMiddleware Upgrade Without Connection Tests ===
[PASS] Upgrade request on engine without connection answers 426
[PASS] Upgrade request on engine without connection is not forwarded to Next
[PASS] 426 response advertises the Upgrade header
[PASS] Plain GET without connection id still answers 400
[PASS] Plain GET on a mapped hub is not forwarded to Next
[PASS] Unmapped path is forwarded to Next

Results: 103 passed, 0 failed
```

With the patch reverted and the same test suite (instrument check — the test really does reach the defect):

```
=== THubMiddleware Upgrade Without Connection Tests ===
EXCEPTION: EAccessViolation: Access violation at address 00007FF7A08D1DEC in module
'TestDextHubs.exe' (offset 5F1DEC). Read of address 0000000000000000
```

The test double needed no new infrastructure: `TMockHttpContext.GetConnection` already returns nil, which is the same condition the Indy, DCS and WebBroker contexts produce in production.

`Tests/Hubs/TestDextHubs.dproj` gained `..\Common` in `DCC_UnitSearchPath` so the suite can use the existing `Dext.Web.Mocks` doubles, following `Tests/Web/Dext.Web.UnitTests.dproj`.

## Scope

Only the nil-connection defect. Deliberately left out:

- Hub hardening (client-invokable method allowlist, connection principal binding, receive-message limit, transport enablement) — that work carries breaking changes and will come as its own PR with the breaking changes declared.
- Any change to `THubOptions` defaults, to the negotiate payload or to the JavaScript client.

This PR replaces #170, which mixed the nil-connection fix with unrelated commits from my fork.
