### PR TITLE
chore(hubs): add System.Generics.Collections to the units that inline TJSONArray

### DIFF
--- a/Sources/Hubs/Dext.Web.Hubs.Protocol.Json.pas
+++ b/Sources/Hubs/Dext.Web.Hubs.Protocol.Json.pas
@@ -36,6 +36,7 @@ uses
   System.JSON,
   System.Rtti,
   System.SysUtils,
+  System.Generics.Collections,
   System.TypInfo,
   Dext.Web.Hubs.Interfaces,
   Dext.Core.Reflection,

--- a/Sources/Hubs/Dext.Web.Hubs.Types.pas
+++ b/Sources/Hubs/Dext.Web.Hubs.Types.pas
@@ -126,7 +126,8 @@ type
 implementation
 
 uses
-  System.JSON;
+  System.JSON,
+  System.Generics.Collections;
 
 { TTransportInfo }
 


### PR DESCRIPTION
## Summary

Adds `System.Generics.Collections` to the two Hubs units that call `TJSONArray.GetValue`, so the compiler can expand the inline body instead of falling back to the out-of-line call.

## Why

`TJSONArray.GetValue` is an inline function whose body needs `System.Generics.Collections` in scope. Building `Sources/Hubs` on current `main` emits:

```
Sources\Hubs\Dext.Web.Hubs.Types.pas(216) Hint: H2443 Inline function 'TJSONArray.GetValue'
  has not been expanded because unit 'System.Generics.Collections' is not specified in USES list
Sources\Hubs\Dext.Web.Hubs.Protocol.Json.pas(177) Hint: H2443 ...
Sources\Hubs\Dext.Web.Hubs.Protocol.Json.pas(370) Hint: H2443 ...
```

Nothing fails to compile without this change — the effect is the lost inline expansion plus three hints in every build that reaches these units.

## Measurement

Win64, Delphi 37.0, compiling `Sources/Hubs/Dext.Web.Hubs.Middleware.pas` (which pulls both units), changing **only** the two `uses` clauses:

| unit | H2443 | .dcu size |
|---|---|---|
| `Dext.Web.Hubs.Types` | 3 -> 0 (both units combined) | 108.793 -> 108.885 B (+92) |
| `Dext.Web.Hubs.Protocol.Json` | | 117.183 -> 117.347 B (+164) |

The larger DCUs are the inline bodies now being expanded.

Instrument control: two consecutive builds of the unpatched baseline produce DCUs of identical size (delta 0), so the deltas above come from the change. DCU hashes are not usable as evidence here — the same baseline recompiled yields a different hash, so the artifact is not byte-for-byte deterministic.

## Placement

`Dext.Web.Hubs.Types.pas` gets it in the `implementation` uses (the call site is in the unit body); `Dext.Web.Hubs.Protocol.Json.pas` gets it in the `interface` uses, next to the other `System.*` units it already lists there.

## Scope

Two lines, no behaviour change. Independent of #171 and of the Hubs hardening work: it touches the `implementation` uses of `Types.pas` and the `interface` uses of `Protocol.Json.pas`, neither of which those changes modify.
