### PR TITLE
feat(hubs)!: harden realtime invocation, transports and connection ownership

### DIFF
--- a/Examples/04-Advanced/Hubs/HubsExample.dpr
+++ b/Examples/04-Advanced/Hubs/HubsExample.dpr
@@ -34,21 +34,25 @@ type
     /// <summary>
     /// Client invokes this to send a message to everyone
     /// </summary>
+    [HubMethod]
     procedure SendMessage(const User, Message: string);
     
     /// <summary>
     /// Client invokes this to join a group
     /// </summary>
+    [HubMethod]
     procedure JoinGroup(const GroupName: string);
     
     /// <summary>
     /// Client invokes this to leave a group
     /// </summary>
+    [HubMethod]
     procedure LeaveGroup(const GroupName: string);
     
     /// <summary>
     /// Client invokes this to send a message to a group
     /// </summary>
+    [HubMethod]
     procedure SendToGroup(const GroupName, User, Message: string);
   end;
 
@@ -153,7 +157,7 @@ begin
     
     WriteLn('Hub endpoints:');
     WriteLn('  POST /hubs/demo/negotiate - Get connection ID');
-    WriteLn('  GET  /hubs/demo/poll?id=xxx - Poll for messages');
+    WriteLn('  GET  /hubs/demo?id=xxx    - SSE stream');
     WriteLn('  POST /hubs/demo?id=xxx    - Invoke method');
     WriteLn;
     WriteLn('Static files: ./wwwroot');

--- a/Examples/04-Advanced/Hubs/README.md
+++ b/Examples/04-Advanced/Hubs/README.md
@@ -72,7 +72,9 @@ Examples/Hubs/
 type
   TDemoHub = class(THub)
   public
+    [HubMethod]
     procedure SendMessage(const User, Message: string);
+    [HubMethod]
     procedure JoinGroup(const GroupName: string);
   end;
 
@@ -125,23 +127,12 @@ await hub.start();
 await hub.invoke('SendMessage', 'John', 'Hello!');
 ```
 
-## Transport: Polling
+## Transports
 
-This example uses **Long Polling** for server-to-client communication:
-
-| Feature | Polling (Current) | SSE (Planned) | WebSocket (Future) |
-|---------|-------------------|---------------|-------------------|
-| Server → Client | Every 500ms | ✅ Real-time | ✅ Real-time |
-| Client → Server | HTTP POST | HTTP POST | ✅ Real-time |
-| Complexity | Simple | Simple | More complex |
-| Browser support | Universal | Universal | Universal |
-
-**Why Polling?**
-The Indy HTTP server doesn't support proper SSE flush semantics. Polling provides reliable communication with minimal latency (500ms).
-
-**Future Plans:**
-- SSE with proper flush support when HTTP server is upgraded
-- WebSocket support in Phase 4 for true bidirectional communication
+Negotiation advertises WebSockets only when the active HTTP engine supports
+upgrade, with Server-Sent Events as the automatic fallback. Long Polling is not
+advertised. Authentication credentials and the connection principal are kept
+across negotiation, connection, and invocation requests.
 
 ## See Also
 

--- a/Examples/04-Advanced/Hubs/wwwroot/dext-hubs.js
+++ b/Examples/04-Advanced/Hubs/wwwroot/dext-hubs.js
@@ -5,7 +5,7 @@
  * 
  * Usage:
  *   const connection = new DextHubConnection('/hubs/dashboard');
- *   connection.on('ReceiveMessage', (msg) => console.log(msg));
+ *   connection.on('ReceiveMessage', handleMessage);
  *   await connection.start();
  *   await connection.invoke('SendMessage', 'Hello!');
  * 
@@ -20,22 +20,29 @@ class DextHubConnection {
    * @param {Object} options - Connection options
    */
   constructor(hubUrl, options = {}) {
-    this.hubUrl = hubUrl;
+    // Drop a trailing slash so the derived URLs stay canonical: '/hubs/demo/'
+    // would otherwise produce '/hubs/demo//negotiate', which the server routes
+    // as a distinct path and rejects.
+    this.hubUrl = hubUrl.length > 1 ? hubUrl.replace(/\/+$/, '') : hubUrl;
     this.options = {
-      transport: 'serverSentEvents', // or 'longPolling'
+      transport: 'auto',
+      fallback: true,
+      withCredentials: true,
       reconnect: true,
       reconnectDelay: 3000,
       ...options
     };
-
+    
     this.connectionId = null;
     this.eventSource = null;
+    this.socket = null;
+    this.transport = null;
     this.handlers = new Map();
     this.state = 'disconnected'; // disconnected, connecting, connected, reconnecting
     this.invocationId = 0;
     this.pendingInvocations = new Map();
   }
-
+  
   /**
    * Registers a handler for a Hub method
    * @param {string} methodName - The method name to handle
@@ -48,7 +55,7 @@ class DextHubConnection {
     this.handlers.get(methodName).push(handler);
     return this;
   }
-
+  
   /**
    * Removes a handler for a Hub method
    * @param {string} methodName - The method name
@@ -66,7 +73,7 @@ class DextHubConnection {
     }
     return this;
   }
-
+  
   /**
    * Starts the Hub connection
    * @returns {Promise<void>}
@@ -75,47 +82,67 @@ class DextHubConnection {
     if (this.state === 'connected') {
       return;
     }
-
+    
     this.state = 'connecting';
-
+    // Clear the previous transport: a reconnect that finds no usable transport
+    // must fail closed instead of reporting 'connected' on a stale value.
+    this.transport = null;
+    
     try {
       // Step 1: Negotiate
       const negotiateResponse = await this._negotiate();
       this.connectionId = negotiateResponse.connectionId;
-
-      // Step 2: Connect transport
-      if (this.options.transport === 'serverSentEvents') {
-        await this._connectSSE();
-      } else {
-        await this._connectLongPolling();
+      
+      // Step 2: Connect the best advertised transport, with a real fallback.
+      const transports = this._getTransportCandidates(negotiateResponse);
+      let lastError = null;
+      for (const transport of transports) {
+        try {
+          if (transport === 'webSockets') {
+            await this._connectWebSocket();
+          } else if (transport === 'serverSentEvents') {
+            await this._connectSSE();
+          }
+          this.transport = transport;
+          lastError = null;
+          break;
+        } catch (error) {
+          lastError = error;
+          this._cleanupTransport();
+        }
       }
 
+      if (lastError || !this.transport) {
+        throw lastError || new Error('No compatible Hub transport is available');
+      }
+      
       this.state = 'connected';
       this._triggerHandlers('connected', { connectionId: this.connectionId });
-
+      
     } catch (error) {
       this.state = 'disconnected';
       throw error;
     }
   }
-
+  
   /**
    * Stops the Hub connection
    * @returns {Promise<void>}
    */
   async stop() {
-    this._stopPolling();
+    this._cleanupTransport();
 
-    if (this.eventSource) {
-      this.eventSource.close();
-      this.eventSource = null;
+    for (const pending of this.pendingInvocations.values()) {
+      pending.reject(new Error('Hub connection stopped'));
     }
-
+    this.pendingInvocations.clear();
+    
     this.state = 'disconnected';
     this.connectionId = null;
+    this.transport = null;
     this._triggerHandlers('disconnected', {});
   }
-
+  
   /**
    * Invokes a Hub method on the server
    * @param {string} methodName - The method to invoke
@@ -126,32 +153,45 @@ class DextHubConnection {
     if (this.state !== 'connected') {
       throw new Error('Cannot invoke: not connected');
     }
-
+    
     const invocationId = String(++this.invocationId);
-
+    
     const request = {
       type: 1, // Invocation
       invocationId: invocationId,
       target: methodName,
       arguments: args
     };
-
+    
+    if (this.transport === 'webSockets' && this.socket) {
+      return new Promise((resolve, reject) => {
+        this.pendingInvocations.set(invocationId, { resolve, reject });
+        try {
+          this.socket.send(JSON.stringify(request) + '\x1e');
+        } catch (error) {
+          this.pendingInvocations.delete(invocationId);
+          reject(error);
+        }
+      });
+    }
+    
     return new Promise(async (resolve, reject) => {
       this.pendingInvocations.set(invocationId, { resolve, reject });
-
+      
       try {
         const response = await fetch(`${this.hubUrl}?id=${this.connectionId}`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json'
           },
+          credentials: this.options.withCredentials ? 'same-origin' : 'omit',
           body: JSON.stringify(request)
         });
-
+        
         const result = await response.json();
-
+        
         this.pendingInvocations.delete(invocationId);
-
+        
         if (result.error) {
           reject(new Error(result.error));
         } else {
@@ -163,7 +203,7 @@ class DextHubConnection {
       }
     });
   }
-
+  
   /**
    * Sends a message without waiting for result
    * @param {string} methodName - The method to invoke
@@ -173,22 +213,27 @@ class DextHubConnection {
     if (this.state !== 'connected') {
       throw new Error('Cannot send: not connected');
     }
-
+    
     const request = {
       type: 1, // Invocation
       target: methodName,
       arguments: args
     };
-
-    await fetch(`${this.hubUrl}?id=${this.connectionId}`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify(request)
-    });
+    
+    if (this.transport === 'webSockets' && this.socket) {
+      this.socket.send(JSON.stringify(request) + '\x1e');
+    } else {
+      await fetch(`${this.hubUrl}?id=${this.connectionId}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        credentials: this.options.withCredentials ? 'same-origin' : 'omit',
+        body: JSON.stringify(request)
+      });
+    }
   }
-
+  
   /**
    * Negotiate connection
    * @private
@@ -198,77 +243,168 @@ class DextHubConnection {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'
-      }
+      },
+      credentials: this.options.withCredentials ? 'same-origin' : 'omit'
     });
-
+    
     if (!response.ok) {
       throw new Error(`Negotiate failed: ${response.status}`);
     }
-
+    
     return await response.json();
   }
 
   /**
-   * Connect using polling (SSE doesn't flush properly with Indy)
+   * Returns client/server compatible transports in connection priority order.
+   * @private
+   */
+  _getTransportCandidates(negotiateResponse) {
+    const advertised = new Set(
+      (negotiateResponse.availableTransports || []).map(item => item.transport)
+    );
+    const supported = [];
+    if (advertised.has('WebSockets') && typeof WebSocket !== 'undefined') {
+      supported.push('webSockets');
+    }
+    if (advertised.has('ServerSentEvents') && typeof EventSource !== 'undefined') {
+      supported.push('serverSentEvents');
+    }
+
+    const requested = String(this.options.transport || 'auto').toLowerCase();
+    if (requested === 'auto') {
+      return supported;
+    }
+
+    const normalized = requested === 'websockets'
+      ? 'webSockets'
+      : requested === 'serversentevents'
+        ? 'serverSentEvents'
+        : null;
+    if (!normalized) {
+      throw new Error(`Unsupported Hub transport: ${this.options.transport}`);
+    }
+
+    const selected = supported.filter(item => item === normalized);
+    if (this.options.fallback && normalized === 'webSockets') {
+      selected.push(...supported.filter(item => item !== normalized));
+    }
+    return selected;
+  }
+
+  /** @private */
+  _cleanupTransport() {
+    if (this.socket) {
+      this.socket.onopen = null;
+      this.socket.onerror = null;
+      this.socket.onclose = null;
+      this.socket.onmessage = null;
+      this.socket.close();
+      this.socket = null;
+    }
+    if (this.eventSource) {
+      this.eventSource.onopen = null;
+      this.eventSource.onerror = null;
+      this.eventSource.onmessage = null;
+      this.eventSource.close();
+      this.eventSource = null;
+    }
+  }
+  
+  /**
+   * Connect using Server-Sent Events
    * @private
    */
   async _connectSSE() {
-    // Use polling instead of SSE - more reliable with Indy HTTP server
-    this._startPolling();
-    return Promise.resolve();
+    return new Promise((resolve, reject) => {
+      const url = `${this.hubUrl}?id=${this.connectionId}`;
+      let settled = false;
+      this.eventSource = new EventSource(url, {
+        withCredentials: this.options.withCredentials
+      });
+      
+      this.eventSource.onopen = () => {
+        settled = true;
+        resolve();
+      };
+      
+      this.eventSource.onerror = (event) => {
+        if (!settled) {
+          settled = true;
+          reject(new Error('SSE connection failed'));
+        } else if (this.options.reconnect && this.state === 'connected') {
+          this._handleReconnect();
+        }
+      };
+      
+      // Handle default message event (Hub invocations)
+      this.eventSource.onmessage = (event) => {
+        this._handleMessage(event.data);
+      };
+    });
   }
-
+  
   /**
-   * Start polling for messages
+   * Connect using WebSockets
    * @private
    */
-  _startPolling() {
-    if (this._pollingInterval) {
-      clearInterval(this._pollingInterval);
-    }
-
-    this._pollingInterval = setInterval(async () => {
-      if (this.state !== 'connected') {
-        clearInterval(this._pollingInterval);
-        return;
+  async _connectWebSocket() {
+    return new Promise((resolve, reject) => {
+      let wsUrl;
+      let settled = false;
+      if (this.hubUrl.startsWith('http://') || this.hubUrl.startsWith('https://')) {
+        wsUrl = this.hubUrl.replace(/^http/, 'ws');
+      } else {
+        const loc = window.location;
+        const protocol = loc.protocol === 'https:' ? 'wss:' : 'ws:';
+        const host = loc.host;
+        const path = this.hubUrl.startsWith('/') ? this.hubUrl : '/' + this.hubUrl;
+        wsUrl = `${protocol}//${host}${path}`;
       }
-
-      try {
-        const response = await fetch(`${this.hubUrl}/poll?id=${this.connectionId}`);
-        if (response.ok) {
-          const messages = await response.json();
-          if (Array.isArray(messages)) {
-            for (const msg of messages) {
-              this._handleMessage(msg);
-            }
+      
+      wsUrl += `?id=${this.connectionId}`;
+      
+      this.socket = new WebSocket(wsUrl);
+      
+      this.socket.onopen = () => {
+        settled = true;
+        resolve();
+      };
+      
+      this.socket.onerror = (error) => {
+        if (!settled) {
+          settled = true;
+          reject(new Error('WebSocket connection failed'));
+        } else if (this.options.reconnect && this.state === 'connected') {
+          this._handleReconnect();
+        }
+      };
+      
+      this.socket.onclose = () => {
+        if (!settled) {
+          settled = true;
+          reject(new Error('WebSocket connection closed before opening'));
+          return;
+        }
+        if (this.state === 'connected') {
+          if (this.options.reconnect) {
+            this._handleReconnect();
+          } else {
+            this.stop();
           }
         }
-      } catch (error) {
-        console.error('Polling error:', error);
-      }
-    }, 500);
+      };
+      
+      this.socket.onmessage = (event) => {
+        const records = event.data.split('\x1e');
+        for (const record of records) {
+          if (record) {
+            this._handleMessage(record);
+          }
+        }
+      };
+    });
   }
-
-  /**
-   * Stop polling
-   * @private
-   */
-  _stopPolling() {
-    if (this._pollingInterval) {
-      clearInterval(this._pollingInterval);
-      this._pollingInterval = null;
-    }
-  }
-
-  /**
-   * Connect using Long Polling (fallback)
-   * @private
-   */
-  async _connectLongPolling() {
-    this._startPolling();
-    return Promise.resolve();
-  }
-
+  
   /**
    * Handle incoming message
    * @private
@@ -278,9 +414,9 @@ class DextHubConnection {
       // Remove record separator if present
       const cleanData = data.replace(/\x1e$/, '');
       if (!cleanData) return;
-
+      
       const message = JSON.parse(cleanData);
-
+      
       switch (message.type) {
         case 1: // Invocation
           this._handleInvocation(message);
@@ -299,7 +435,7 @@ class DextHubConnection {
       console.error('Error handling message:', error, data);
     }
   }
-
+  
   /**
    * Handle Hub method invocation from server
    * @private
@@ -308,7 +444,7 @@ class DextHubConnection {
     const { target, arguments: args } = message;
     this._triggerHandlers(target, ...(args || []));
   }
-
+  
   /**
    * Handle completion message
    * @private
@@ -324,42 +460,43 @@ class DextHubConnection {
       }
     }
   }
-
+  
   /**
    * Handle close message
    * @private
    */
   _handleClose(message) {
-    console.log('Hub connection closed:', message.error || 'No error');
     this.stop();
   }
-
+  
   /**
    * Handle reconnection
    * @private
    */
   async _handleReconnect() {
     if (this.state === 'reconnecting') return;
-
+    
     this.state = 'reconnecting';
-    console.log('Attempting to reconnect...');
-
+    if (this.socket) {
+      this.socket.close();
+      this.socket = null;
+    }
+    
     if (this.eventSource) {
       this.eventSource.close();
       this.eventSource = null;
     }
-
+    
     setTimeout(async () => {
       try {
         await this.start();
-        console.log('Reconnected successfully');
       } catch (error) {
         console.error('Reconnection failed:', error);
         this._handleReconnect(); // Try again
       }
     }, this.options.reconnectDelay);
   }
-
+  
   /**
    * Trigger handlers for a method
    * @private
@@ -376,7 +513,7 @@ class DextHubConnection {
       });
     }
   }
-
+  
   /**
    * Gets the current connection state
    */

--- a/Examples/07-UseCases/Web.AirFlow/AirFlow.Hubs.pas
+++ b/Examples/07-UseCases/Web.AirFlow/AirFlow.Hubs.pas
@@ -6,13 +6,17 @@ uses
   System.SysUtils,
   System.Rtti,
   Dext.Web.Hubs.Hub,
+  Dext.Web.Hubs.Types,
   AirFlow.Domain;
 
 type
   TAirFlowHub = class(THub)
   public
+    [HubMethod]
     procedure JoinRegion(const ARegionName: string);
+    [HubMethod]
     procedure LeaveRegion(const ARegionName: string);
+    [HubMethod]
     procedure BroadcastAlert(const AVehicleId, AMessage: string);
   end;
 

--- a/Examples/07-UseCases/Web.AirFlow/airflow_wwwroot/dext-hubs.js
+++ b/Examples/07-UseCases/Web.AirFlow/airflow_wwwroot/dext-hubs.js
@@ -5,7 +5,7 @@
  * 
  * Usage:
  *   const connection = new DextHubConnection('/hubs/dashboard');
- *   connection.on('ReceiveMessage', (msg) => console.log(msg));
+ *   connection.on('ReceiveMessage', handleMessage);
  *   await connection.start();
  *   await connection.invoke('SendMessage', 'Hello!');
  * 
@@ -20,9 +20,14 @@ class DextHubConnection {
    * @param {Object} options - Connection options
    */
   constructor(hubUrl, options = {}) {
-    this.hubUrl = hubUrl;
+    // Drop a trailing slash so the derived URLs stay canonical: '/hubs/demo/'
+    // would otherwise produce '/hubs/demo//negotiate', which the server routes
+    // as a distinct path and rejects.
+    this.hubUrl = hubUrl.length > 1 ? hubUrl.replace(/\/+$/, '') : hubUrl;
     this.options = {
-      transport: typeof WebSocket !== 'undefined' ? 'webSockets' : 'serverSentEvents', // or 'serverSentEvents', 'longPolling'
+      transport: 'auto',
+      fallback: true,
+      withCredentials: true,
       reconnect: true,
       reconnectDelay: 3000,
       ...options
@@ -31,6 +36,7 @@ class DextHubConnection {
     this.connectionId = null;
     this.eventSource = null;
     this.socket = null;
+    this.transport = null;
     this.handlers = new Map();
     this.state = 'disconnected'; // disconnected, connecting, connected, reconnecting
     this.invocationId = 0;
@@ -78,19 +84,36 @@ class DextHubConnection {
     }
     
     this.state = 'connecting';
+    // Clear the previous transport: a reconnect that finds no usable transport
+    // must fail closed instead of reporting 'connected' on a stale value.
+    this.transport = null;
     
     try {
       // Step 1: Negotiate
       const negotiateResponse = await this._negotiate();
       this.connectionId = negotiateResponse.connectionId;
       
-      // Step 2: Connect transport
-      if (this.options.transport === 'webSockets') {
-        await this._connectWebSocket();
-      } else if (this.options.transport === 'serverSentEvents') {
-        await this._connectSSE();
-      } else {
-        await this._connectLongPolling();
+      // Step 2: Connect the best advertised transport, with a real fallback.
+      const transports = this._getTransportCandidates(negotiateResponse);
+      let lastError = null;
+      for (const transport of transports) {
+        try {
+          if (transport === 'webSockets') {
+            await this._connectWebSocket();
+          } else if (transport === 'serverSentEvents') {
+            await this._connectSSE();
+          }
+          this.transport = transport;
+          lastError = null;
+          break;
+        } catch (error) {
+          lastError = error;
+          this._cleanupTransport();
+        }
+      }
+
+      if (lastError || !this.transport) {
+        throw lastError || new Error('No compatible Hub transport is available');
       }
       
       this.state = 'connected';
@@ -107,18 +130,16 @@ class DextHubConnection {
    * @returns {Promise<void>}
    */
   async stop() {
-    if (this.socket) {
-      this.socket.close();
-      this.socket = null;
+    this._cleanupTransport();
+
+    for (const pending of this.pendingInvocations.values()) {
+      pending.reject(new Error('Hub connection stopped'));
     }
-    
-    if (this.eventSource) {
-      this.eventSource.close();
-      this.eventSource = null;
-    }
+    this.pendingInvocations.clear();
     
     this.state = 'disconnected';
     this.connectionId = null;
+    this.transport = null;
     this._triggerHandlers('disconnected', {});
   }
   
@@ -142,7 +163,7 @@ class DextHubConnection {
       arguments: args
     };
     
-    if (this.options.transport === 'webSockets' && this.socket) {
+    if (this.transport === 'webSockets' && this.socket) {
       return new Promise((resolve, reject) => {
         this.pendingInvocations.set(invocationId, { resolve, reject });
         try {
@@ -163,6 +184,7 @@ class DextHubConnection {
           headers: {
             'Content-Type': 'application/json'
           },
+          credentials: this.options.withCredentials ? 'same-origin' : 'omit',
           body: JSON.stringify(request)
         });
         
@@ -198,7 +220,7 @@ class DextHubConnection {
       arguments: args
     };
     
-    if (this.options.transport === 'webSockets' && this.socket) {
+    if (this.transport === 'webSockets' && this.socket) {
       this.socket.send(JSON.stringify(request) + '\x1e');
     } else {
       await fetch(`${this.hubUrl}?id=${this.connectionId}`, {
@@ -206,6 +228,7 @@ class DextHubConnection {
         headers: {
           'Content-Type': 'application/json'
         },
+        credentials: this.options.withCredentials ? 'same-origin' : 'omit',
         body: JSON.stringify(request)
       });
     }
@@ -220,7 +243,8 @@ class DextHubConnection {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'
-      }
+      },
+      credentials: this.options.withCredentials ? 'same-origin' : 'omit'
     });
     
     if (!response.ok) {
@@ -228,6 +252,62 @@ class DextHubConnection {
     }
     
     return await response.json();
+  }
+
+  /**
+   * Returns client/server compatible transports in connection priority order.
+   * @private
+   */
+  _getTransportCandidates(negotiateResponse) {
+    const advertised = new Set(
+      (negotiateResponse.availableTransports || []).map(item => item.transport)
+    );
+    const supported = [];
+    if (advertised.has('WebSockets') && typeof WebSocket !== 'undefined') {
+      supported.push('webSockets');
+    }
+    if (advertised.has('ServerSentEvents') && typeof EventSource !== 'undefined') {
+      supported.push('serverSentEvents');
+    }
+
+    const requested = String(this.options.transport || 'auto').toLowerCase();
+    if (requested === 'auto') {
+      return supported;
+    }
+
+    const normalized = requested === 'websockets'
+      ? 'webSockets'
+      : requested === 'serversentevents'
+        ? 'serverSentEvents'
+        : null;
+    if (!normalized) {
+      throw new Error(`Unsupported Hub transport: ${this.options.transport}`);
+    }
+
+    const selected = supported.filter(item => item === normalized);
+    if (this.options.fallback && normalized === 'webSockets') {
+      selected.push(...supported.filter(item => item !== normalized));
+    }
+    return selected;
+  }
+
+  /** @private */
+  _cleanupTransport() {
+    if (this.socket) {
+      this.socket.onopen = null;
+      this.socket.onerror = null;
+      this.socket.onclose = null;
+      this.socket.onmessage = null;
+      this.socket.close();
+      this.socket = null;
+    }
+    if (this.eventSource) {
+      this.eventSource.onopen = null;
+      this.eventSource.onerror = null;
+      this.eventSource.onmessage = null;
+      this.eventSource.close();
+      this.eventSource = null;
+    }
   }
   
   /**
@@ -237,25 +317,24 @@ class DextHubConnection {
   async _connectSSE() {
     return new Promise((resolve, reject) => {
       const url = `${this.hubUrl}?id=${this.connectionId}`;
-      this.eventSource = new EventSource(url);
+      let settled = false;
+      this.eventSource = new EventSource(url, {
+        withCredentials: this.options.withCredentials
+      });
       
       this.eventSource.onopen = () => {
+        settled = true;
         resolve();
       };
       
       this.eventSource.onerror = (event) => {
-        if (this.state === 'connecting') {
+        if (!settled) {
+          settled = true;
           reject(new Error('SSE connection failed'));
         } else if (this.options.reconnect && this.state === 'connected') {
           this._handleReconnect();
         }
       };
-      
-      // Handle 'connected' event
-      this.eventSource.addEventListener('connected', (event) => {
-        const data = JSON.parse(event.data);
-        console.log('Hub connected:', data.connectionId);
-      });
       
       // Handle default message event (Hub invocations)
       this.eventSource.onmessage = (event) => {
@@ -271,6 +350,7 @@ class DextHubConnection {
   async _connectWebSocket() {
     return new Promise((resolve, reject) => {
       let wsUrl;
+      let settled = false;
       if (this.hubUrl.startsWith('http://') || this.hubUrl.startsWith('https://')) {
         wsUrl = this.hubUrl.replace(/^http/, 'ws');
       } else {
@@ -286,11 +366,13 @@ class DextHubConnection {
       this.socket = new WebSocket(wsUrl);
       
       this.socket.onopen = () => {
+        settled = true;
         resolve();
       };
       
       this.socket.onerror = (error) => {
-        if (this.state === 'connecting') {
+        if (!settled) {
+          settled = true;
           reject(new Error('WebSocket connection failed'));
         } else if (this.options.reconnect && this.state === 'connected') {
           this._handleReconnect();
@@ -298,6 +380,11 @@ class DextHubConnection {
       };
       
       this.socket.onclose = () => {
+        if (!settled) {
+          settled = true;
+          reject(new Error('WebSocket connection closed before opening'));
+          return;
+        }
         if (this.state === 'connected') {
           if (this.options.reconnect) {
             this._handleReconnect();
@@ -316,15 +403,6 @@ class DextHubConnection {
         }
       };
     });
-  }
-  
-  /**
-   * Connect using Long Polling (fallback)
-   * @private
-   */
-  async _connectLongPolling() {
-    // Long polling implementation would go here
-    throw new Error('Long polling not yet implemented');
   }
   
   /**
@@ -388,7 +466,6 @@ class DextHubConnection {
    * @private
    */
   _handleClose(message) {
-    console.log('Hub connection closed:', message.error || 'No error');
     this.stop();
   }
   
@@ -400,8 +477,6 @@ class DextHubConnection {
     if (this.state === 'reconnecting') return;
     
     this.state = 'reconnecting';
-    console.log('Attempting to reconnect...');
-    
     if (this.socket) {
       this.socket.close();
       this.socket = null;
@@ -415,7 +490,6 @@ class DextHubConnection {
     setTimeout(async () => {
       try {
         await this.start();
-        console.log('Reconnected successfully');
       } catch (error) {
         console.error('Reconnection failed:', error);
         this._handleReconnect(); // Try again

--- a/Sources/Hubs/Dext.Hubs.pas
+++ b/Sources/Hubs/Dext.Hubs.pas
@@ -28,11 +28,13 @@ type
   // Dext.Web.Hubs
   THubOptions = Dext.Web.Hubs.THubOptions;
   TNegotiateResponse = Dext.Web.Hubs.TNegotiateResponse;
+  HubMethodAttribute = Dext.Web.Hubs.HubMethodAttribute;
   TJsonHubProtocol = Dext.Web.Hubs.TJsonHubProtocol;
   EHubException = Dext.Web.Hubs.EHubException;
   EConnectionNotFoundException = Dext.Web.Hubs.EConnectionNotFoundException;
   EHubMethodNotFoundException = Dext.Web.Hubs.EHubMethodNotFoundException;
   EHubInvocationException = Dext.Web.Hubs.EHubInvocationException;
+  EHubPayloadTooLargeException = Dext.Web.Hubs.EHubPayloadTooLargeException;
 
   // Dext.Web.Hubs.Clients
   TClientProxy = Dext.Web.Hubs.Clients.TClientProxy;

--- a/Sources/Hubs/Dext.Web.Hubs.Client.pas
+++ b/Sources/Hubs/Dext.Web.Hubs.Client.pas
@@ -212,6 +212,7 @@ type
 
     // Negotiation
     procedure Negotiate;
+    function BuildTransportQueryParams: TArray<TClientQueryParam>;
     procedure InitializeHandshake;
     procedure StartPingLoop;
     procedure StopPingLoop;
@@ -851,6 +852,29 @@ begin
   Result := FConnectionId;
 end;
 
+/// <summary>
+/// Returns the configured query parameters plus the negotiated connection id,
+/// which the server requires on the transport request. A parameter named 'id'
+/// supplied by the caller wins, so an explicit override still works.
+/// </summary>
+function TDextHubConnection.BuildTransportQueryParams: TArray<TClientQueryParam>;
+var
+  LParam: TClientQueryParam;
+  LIndex: Integer;
+begin
+  Result := FQueryParams;
+  if FConnectionId = '' then
+    Exit;
+
+  for LIndex := 0 to High(Result) do
+    if SameText(Result[LIndex].Name, 'id') then
+      Exit;
+
+  LParam.Name := 'id';
+  LParam.Value := FConnectionId;
+  Result := Result + [LParam];
+end;
+
 procedure TDextHubConnection.Start;
 var
   LId: string;
@@ -873,8 +897,8 @@ begin
     FTransport.SetOnMessage(procedure(Msg: string) begin HandleIncomingMessage(Msg); end);
     FTransport.SetOnClose(procedure(E: Exception) begin HandleDisconnect(E); end);
 
-    // 3. Connect transport
-    FTransport.Connect(FUrl, FHeaders, FQueryParams);
+    // 3. Connect transport, carrying the negotiated connection id
+    FTransport.Connect(FUrl, FHeaders, BuildTransportQueryParams);
 
     FState := csConnected;
 

--- a/Sources/Hubs/Dext.Web.Hubs.Context.pas
+++ b/Sources/Hubs/Dext.Web.Hubs.Context.pas
@@ -75,11 +75,13 @@ type
     FItems: IDictionary<string, TValue>;
     FAbortToken: ICancellationToken;
     FTransportType: TTransportType;
+    FAbortHandler: TProc;
   public
     constructor Create(const AConnectionId: string;
                        ATransportType: TTransportType;
                        const AUser: IClaimsPrincipal = nil;
-                       const AAbortToken: ICancellationToken = nil);
+                       const AAbortToken: ICancellationToken = nil;
+                       const AAbortHandler: TProc = nil);
     destructor Destroy; override;
     
     function GetConnectionId: string;
@@ -124,13 +126,14 @@ end;
 
 constructor THubCallerContext.Create(const AConnectionId: string;
   ATransportType: TTransportType; const AUser: IClaimsPrincipal;
-  const AAbortToken: ICancellationToken);
+  const AAbortToken: ICancellationToken; const AAbortHandler: TProc);
 begin
   inherited Create;
   FConnectionId := AConnectionId;
   FTransportType := ATransportType;
   FUser := AUser;
   FAbortToken := AAbortToken;
+  FAbortHandler := AAbortHandler;
   FItems := TCollections.CreateDictionary<string, TValue>;
 end;
 
@@ -175,8 +178,8 @@ end;
 
 procedure THubCallerContext.Abort;
 begin
-  // Abort is handled at transport level
-  // This is just a marker
+  if Assigned(FAbortHandler) then
+    FAbortHandler();
 end;
 
 end.

--- a/Sources/Hubs/Dext.Web.Hubs.Extensions.pas
+++ b/Sources/Hubs/Dext.Web.Hubs.Extensions.pas
@@ -69,7 +69,9 @@ type
     /// Adds Hub middleware to the application pipeline.
     /// Call this before MapHub if you need to configure options.
     /// </summary>
-    class procedure UseHubs(const App: IApplicationBuilder);
+    class procedure UseHubs(const App: IApplicationBuilder); overload;
+    class procedure UseHubs(const App: IApplicationBuilder;
+      const Options: THubOptions); overload;
     
     /// <summary>
     /// Registers Hub services in DI container.
@@ -125,9 +127,15 @@ end;
 
 class procedure THubExtensions.UseHubs(const App: IApplicationBuilder);
 begin
+  UseHubs(App, THubOptions.Default);
+end;
+
+class procedure THubExtensions.UseHubs(const App: IApplicationBuilder;
+  const Options: THubOptions);
+begin
   if FMiddleware = nil then
   begin
-    FMiddleware := THubMiddleware.Create;
+    FMiddleware := THubMiddleware.Create(Options);
     
     // Add middleware to pipeline
     App.Use(

--- a/Sources/Hubs/Dext.Web.Hubs.Hub.pas
+++ b/Sources/Hubs/Dext.Web.Hubs.Hub.pas
@@ -41,13 +41,16 @@ uses
 type
   /// <summary>
   /// Base class for Hub implementations.
-  /// Inherit from this class and add public methods that clients can invoke.
+  /// Inherit from this class and annotate client-invokable methods with
+  /// HubMethod. Other public methods remain server-side only.
   /// </summary>
   /// <example>
   /// <code>
   ///   TMyHub = class(THub)
   ///   public
+  ///     [HubMethod]
   ///     procedure SendMessage(const User, Message: string);
+  ///     [HubMethod]
   ///     procedure JoinGroup(const GroupName: string);
   ///   end;
   /// 

--- a/Sources/Hubs/Dext.Web.Hubs.Middleware.pas
+++ b/Sources/Hubs/Dext.Web.Hubs.Middleware.pas
@@ -36,6 +36,7 @@ uses
   System.Classes,
   System.JSON,
   System.Rtti,
+  System.SyncObjs,
   System.SysUtils,
   Dext.Collections,
   Dext.Collections.Dict,
@@ -71,11 +72,15 @@ type
     FGroupManager: IGroupManager;
     FSSETransport: TSSETransport;
     FProtocol: TJsonHubProtocol;
+    FRequireHubMethodAttribute: Boolean;
+    function CreateCallerContext(const ConnectionId: string): IHubCallerContext;
+    function IsClientInvokableMethod(const Method: TRttiMethod): Boolean;
   public
     constructor Create(AHubClass: THubClass;
                        const AConnectionManager: IConnectionManager;
                        const AGroupManager: IGroupManager;
-                       ASSETransport: TSSETransport);
+                       ASSETransport: TSSETransport;
+                       ARequireHubMethodAttribute: Boolean = True);
     destructor Destroy; override;
     
     /// <summary>Invokes a method on the Hub</summary>
@@ -109,23 +114,33 @@ type
     FSSETransport: TSSETransport;
     FWebSocketTransport: TWebSocketHubTransport;
     FConnectionDispatchers: IDictionary<string, THubDispatcher>;
+    FConnectionDispatchersLock: TCriticalSection;
+    FOptions: THubOptions;
+    procedure Initialize(const Options: THubOptions);
     
     procedure HandleNegotiate(const HubPath: string; Ctx: IHttpContext);
     procedure HandleSSEStream(const HubPath: string; Ctx: IHttpContext; Dispatcher: THubDispatcher);
     procedure HandleInvoke(const HubPath: string; Ctx: IHttpContext; Dispatcher: THubDispatcher);
     procedure HandlePoll(const HubPath: string; Ctx: IHttpContext; Dispatcher: THubDispatcher);
     procedure HandleWebSocket(const HubPath: string; Ctx: IHttpContext; Dispatcher: THubDispatcher);
-
+    function TryReserveConnection(const ConnectionId: string;
+      Dispatcher: THubDispatcher): Boolean;
+    function TryGetConnectionDispatcher(const ConnectionId: string;
+      out Dispatcher: THubDispatcher): Boolean;
+    procedure ReleaseConnection(const ConnectionId: string);
+    function ClientError(const DetailedMessage, SafeMessage: string): string;
+    function IsTransportEnabled(const TransportName: string): Boolean;
     /// <summary>
     /// Returns True only when the active HTTP engine exposes an upgradable
     /// connection. IHttpContext.Connection is nil on engines that do not
     /// implement the raw server connection (Indy, DCS, WebBroker).
     /// </summary>
     function ConnectionSupportsUpgrade(const Ctx: IHttpContext): Boolean;
-
+    
     function FindDispatcher(const Path: string; out HubPath: string): THubDispatcher;
   public
-    constructor Create;
+    constructor Create; overload;
+    constructor Create(const Options: THubOptions); overload;
     destructor Destroy; override;
     
     /// <summary>Registers a Hub at the specified path</summary>
@@ -148,24 +163,88 @@ implementation
 
 uses
   System.TypInfo,
+  Dext.Auth.Identity,
   Dext.Server.Engine.Interfaces,
   Dext.Utils,
   Dext.Web.Hubs.Protocol.MessagePack;
 
-function ReadStreamToString(AStream: TStream): string;
+function ReadStreamToString(AStream: TStream; AMaximumBytes: Int64): string;
 var
   SS: TStringStream;
+  LSize: Int64;
 begin
   if AStream = nil then
     Exit('');
+  if AMaximumBytes <= 0 then
+    raise EHubPayloadTooLargeException.Create(
+      'Hub receive limit must be greater than zero');
+  LSize := AStream.Size;
+  if LSize > AMaximumBytes then
+    raise EHubPayloadTooLargeException.CreateFmt(
+      'Hub payload exceeds the configured limit of %d bytes',
+      [AMaximumBytes]);
   AStream.Position := 0;
   SS := TStringStream.Create('', TEncoding.UTF8);
   try
-    SS.CopyFrom(AStream, AStream.Size);
+    SS.CopyFrom(AStream, LSize);
     Result := SS.DataString;
   finally
     SS.Free;
   end;
+end;
+
+function IsValidConnectionId(const AValue: string): Boolean;
+var
+  LChar: Char;
+begin
+  if AValue.Length <> 32 then
+    Exit(False);
+  for LChar in AValue do
+    if not CharInSet(LChar, ['0'..'9', 'a'..'f', 'A'..'F']) then
+      Exit(False);
+  Result := True;
+end;
+
+/// <summary>
+/// Stable identifier of a principal: the 'sub' claim, falling back to the
+/// identity name. FindClaim returns an empty TClaim when the claim is absent,
+/// so an absent 'sub' yields an empty string without a separate HasClaim probe.
+/// Returns an empty string when the principal carries no usable identifier.
+/// </summary>
+function PrincipalKey(const APrincipal: IClaimsPrincipal): string;
+begin
+  if APrincipal = nil then
+    Exit('');
+  Result := APrincipal.FindClaim('sub').Value;
+  if Result <> '' then
+    Exit;
+  if APrincipal.Identity <> nil then
+    Result := APrincipal.Identity.Name;
+end;
+
+/// <summary>
+/// Decides whether the caller of a request is the principal that opened the
+/// connection. Two anonymous callers match; an anonymous caller never matches
+/// an authenticated one.
+/// </summary>
+function IsSamePrincipal(const AExpected, AActual: IClaimsPrincipal): Boolean;
+var
+  LExpectedKey, LActualKey: string;
+begin
+  if (AExpected = nil) or (AActual = nil) then
+    Exit((AExpected = nil) and (AActual = nil));
+  LExpectedKey := PrincipalKey(AExpected);
+  LActualKey := PrincipalKey(AActual);
+  // Fail closed: with no usable identifier on either side the only safe match
+  // is the very same principal instance, so an unidentifiable caller cannot
+  // inherit somebody else's connection.
+  if (LExpectedKey = '') or (LActualKey = '') then
+    Exit(AExpected = AActual);
+  // Case-insensitive on purpose: 'sub' values and identity names reach us with
+  // inconsistent casing across requests, and locking the legitimate owner out
+  // over casing is worse than the collision this allows between two accounts
+  // that differ only in case.
+  Result := SameText(LExpectedKey, LActualKey);
 end;
 
 { THubDispatcher }
@@ -173,7 +252,8 @@ end;
 constructor THubDispatcher.Create(AHubClass: THubClass;
   const AConnectionManager: IConnectionManager;
   const AGroupManager: IGroupManager;
-  ASSETransport: TSSETransport);
+  ASSETransport: TSSETransport;
+  ARequireHubMethodAttribute: Boolean);
 begin
   inherited Create;
   FHubClass := AHubClass;
@@ -181,12 +261,46 @@ begin
   FGroupManager := AGroupManager;
   FSSETransport := ASSETransport;
   FProtocol := TJsonHubProtocol.Create;
+  FRequireHubMethodAttribute := ARequireHubMethodAttribute;
 end;
 
 destructor THubDispatcher.Destroy;
 begin
   FProtocol.Free;
   inherited;
+end;
+
+function THubDispatcher.CreateCallerContext(
+  const ConnectionId: string): IHubCallerContext;
+var
+  LConnection: IHubConnection;
+begin
+  if not FConnectionManager.TryGet(ConnectionId, LConnection) then
+    raise EConnectionNotFoundException.CreateFmt(
+      'Connection not found: %s', [ConnectionId]);
+
+  Result := THubCallerContext.Create(ConnectionId,
+    LConnection.TransportType, LConnection.User, LConnection.AbortToken,
+    procedure
+    begin
+      LConnection.Close('Aborted by Hub');
+    end);
+end;
+
+function THubDispatcher.IsClientInvokableMethod(
+  const Method: TRttiMethod): Boolean;
+var
+  LAttribute: TCustomAttribute;
+begin
+  Result := False;
+  if not Assigned(Method) then
+    Exit;
+  for LAttribute in Method.GetAttributes do
+    if LAttribute is HubMethodAttribute then
+      Exit(True);
+  // Migration escape hatch: when the allowlist is disabled every public method
+  // found by RTTI stays invokable, which is the pre-allowlist behaviour.
+  Result := not FRequireHubMethodAttribute;
 end;
 
 function THubDispatcher.InvokeMethod(const ConnectionId, MethodName: string;
@@ -205,7 +319,7 @@ begin
   Hub := FHubClass.Create;
   try
     // Setup context
-    CallerContext := THubCallerContext.Create(ConnectionId, ttServerSentEvents);
+    CallerContext := CreateCallerContext(ConnectionId);
     HubClients := THubClients.Create(FConnectionManager, ConnectionId);
     Hub.SetContext(CallerContext, HubClients, FGroupManager);
     
@@ -213,7 +327,7 @@ begin
     RttiType := TReflection.Context.GetType(FHubClass);
     Method := RttiType.GetMethod(MethodName);
     
-    if Method = nil then
+    if (Method = nil) or not IsClientInvokableMethod(Method) then
       raise EHubMethodNotFoundException.CreateFmt('Method not found: %s', [MethodName]);
     
     // Convert args if needed
@@ -232,7 +346,7 @@ var
 begin
   Hub := FHubClass.Create;
   try
-    CallerContext := THubCallerContext.Create(ConnectionId, ttServerSentEvents);
+    CallerContext := CreateCallerContext(ConnectionId);
     HubClients := THubClients.Create(FConnectionManager, ConnectionId);
     Hub.SetContext(CallerContext, HubClients, FGroupManager);
     Hub.OnConnectedAsync;
@@ -249,7 +363,7 @@ var
 begin
   Hub := FHubClass.Create;
   try
-    CallerContext := THubCallerContext.Create(ConnectionId, ttServerSentEvents);
+    CallerContext := CreateCallerContext(ConnectionId);
     HubClients := THubClients.Create(FConnectionManager, ConnectionId);
     Hub.SetContext(CallerContext, HubClients, FGroupManager);
     Hub.OnDisconnectedAsync(Error);
@@ -261,18 +375,35 @@ end;
 { THubMiddleware }
 
 constructor THubMiddleware.Create;
+begin
+  inherited Create;
+  Initialize(THubOptions.Default);
+end;
+
+constructor THubMiddleware.Create(const Options: THubOptions);
+begin
+  inherited Create;
+  Initialize(Options);
+end;
+
+procedure THubMiddleware.Initialize(const Options: THubOptions);
 var
   LConnectionManager: TConnectionManager;
 begin
-  inherited Create;
+  if Options.MaximumReceiveMessageSize <= 0 then
+    raise EArgumentOutOfRangeException.Create(
+      'MaximumReceiveMessageSize must be greater than zero');
+  FOptions := Options;
   FHubs := TCollections.CreateDictionary<string, THubDispatcher>;
   FGroupManager := TGroupManager.Create;
   LConnectionManager := TConnectionManager.Create;
   LConnectionManager.SetGroupManager(FGroupManager);
   FConnectionManager := LConnectionManager;
   FSSETransport := TSSETransport.Create;
-  FWebSocketTransport := TWebSocketHubTransport.Create;
+  FWebSocketTransport := TWebSocketHubTransport.Create(
+    FOptions.MaximumReceiveMessageSize);
   FConnectionDispatchers := TCollections.CreateDictionary<string, THubDispatcher>;
+  FConnectionDispatchersLock := TCriticalSection.Create;
   
   FWebSocketTransport.SetOnConnected(
     procedure(const ConnectionId: string)
@@ -281,15 +412,16 @@ begin
       Dispatcher: THubDispatcher;
     begin
       Conn := FWebSocketTransport.GetConnection(ConnectionId);
-      if Conn <> nil then
-        FConnectionManager.Add(Conn);
+      if Conn = nil then
+        Exit;
+      FConnectionManager.Add(Conn);
         
-      if FConnectionDispatchers.TryGetValue(ConnectionId, Dispatcher) then
+      if TryGetConnectionDispatcher(ConnectionId, Dispatcher) then
       begin
         try
           Dispatcher.OnConnected(ConnectionId);
         except
-          // Log but don't fail
+          Conn.Close('Hub rejected connection');
         end;
       end;
     end
@@ -300,16 +432,16 @@ begin
     var
       Dispatcher: THubDispatcher;
     begin
-      FConnectionManager.Remove(ConnectionId);
-      if FConnectionDispatchers.TryGetValue(ConnectionId, Dispatcher) then
+      if TryGetConnectionDispatcher(ConnectionId, Dispatcher) then
       begin
         try
           Dispatcher.OnDisconnected(ConnectionId, nil);
         except
           // Log but don't fail
         end;
-        FConnectionDispatchers.Remove(ConnectionId);
+        ReleaseConnection(ConnectionId);
       end;
+      FConnectionManager.Remove(ConnectionId);
     end
   );
   
@@ -323,7 +455,7 @@ begin
       ResponseMsg: THubMessage;
       ResponseStr: string;
     begin
-      if FConnectionDispatchers.TryGetValue(ConnectionId, Dispatcher) then
+      if TryGetConnectionDispatcher(ConnectionId, Dispatcher) then
       begin
         Protocol := TJsonHubProtocol.Create;
         try
@@ -335,7 +467,13 @@ begin
               ResponseMsg := THubMessage.Completion(Msg.InvocationId, ResultValue);
             except
               on E: Exception do
-                ResponseMsg := THubMessage.CompletionError(Msg.InvocationId, E.Message);
+              begin
+                ResponseMsg := THubMessage.CompletionError(Msg.InvocationId,
+                  ClientError(E.Message, 'Hub invocation failed'));
+                // SafeWriteLn instead of Writeln: a host with no console must
+                // not lose the connection over a failed diagnostic write.
+                SafeWriteLn('Hub: invocation failed: ' + E.Message);
+              end;
             end;
             ResponseStr := Protocol.Serialize(ResponseMsg);
             FWebSocketTransport.SendAsync(ConnectionId, ResponseStr);
@@ -402,13 +540,69 @@ var
   Dispatcher: THubDispatcher;
 begin
   Shutdown; // Close all connections first
-  for Dispatcher in FHubs.Values do
-    Dispatcher.Free;
+  if FHubs <> nil then
+    for Dispatcher in FHubs.Values do
+      Dispatcher.Free;
   // FHubs is ARC
-  FSSETransport.Free;
-  FWebSocketTransport.Free;
+  FreeAndNil(FSSETransport);
+  FreeAndNil(FWebSocketTransport);
+  FreeAndNil(FConnectionDispatchersLock);
   // Note: TConnectionManager and TGroupManager are interfaced, will be freed automatically
   inherited;
+end;
+
+function THubMiddleware.TryReserveConnection(const ConnectionId: string;
+  Dispatcher: THubDispatcher): Boolean;
+begin
+  FConnectionDispatchersLock.Enter;
+  try
+    Result := not FConnectionDispatchers.ContainsKey(ConnectionId);
+    if Result then
+      FConnectionDispatchers.Add(ConnectionId, Dispatcher);
+  finally
+    FConnectionDispatchersLock.Leave;
+  end;
+end;
+
+function THubMiddleware.TryGetConnectionDispatcher(const ConnectionId: string;
+  out Dispatcher: THubDispatcher): Boolean;
+begin
+  FConnectionDispatchersLock.Enter;
+  try
+    Result := FConnectionDispatchers.TryGetValue(ConnectionId, Dispatcher);
+  finally
+    FConnectionDispatchersLock.Leave;
+  end;
+end;
+
+procedure THubMiddleware.ReleaseConnection(const ConnectionId: string);
+begin
+  FConnectionDispatchersLock.Enter;
+  try
+    FConnectionDispatchers.Remove(ConnectionId);
+  finally
+    FConnectionDispatchersLock.Leave;
+  end;
+end;
+
+function THubMiddleware.ClientError(const DetailedMessage,
+  SafeMessage: string): string;
+begin
+  if FOptions.EnableDetailedErrors then
+    Result := DetailedMessage
+  else
+    Result := SafeMessage;
+end;
+
+function THubMiddleware.IsTransportEnabled(
+  const TransportName: string): Boolean;
+var
+  LEnabledTransport: string;
+begin
+  Result := False;
+  for LEnabledTransport in FOptions.EnabledTransports do
+    if SameText(LEnabledTransport, TransportName) then
+      Exit(True);
 end;
 
 function THubMiddleware.ConnectionSupportsUpgrade(
@@ -438,8 +632,11 @@ begin
   NormalizedPath := Path.ToLower;
   if not NormalizedPath.StartsWith('/') then
     NormalizedPath := '/' + NormalizedPath;
+  while (NormalizedPath.Length > 1) and NormalizedPath.EndsWith('/') do
+    Delete(NormalizedPath, NormalizedPath.Length, 1);
     
-  Dispatcher := THubDispatcher.Create(HubClass, FConnectionManager, FGroupManager, FSSETransport);
+  Dispatcher := THubDispatcher.Create(HubClass, FConnectionManager,
+    FGroupManager, FSSETransport, FOptions.RequireHubMethodAttribute);
   FHubs.AddOrSetValue(NormalizedPath, Dispatcher);
 end;
 
@@ -459,7 +656,7 @@ begin
   
   for Key in FHubs.Keys do
   begin
-    if LowerPath.StartsWith(Key) then
+    if SameText(LowerPath, Key) or LowerPath.StartsWith(Key + '/') then
     begin
       HubPath := Key;
       Result := FHubs[Key];
@@ -474,6 +671,11 @@ var
   Dispatcher: THubDispatcher;
 begin
   Path := Ctx.Request.Path.ToLower;
+  // Normalize the request path the same way MapHub normalizes the registered
+  // one, otherwise '/hubs/chat/' resolves a dispatcher and then matches no
+  // route. Dext's own router does the same (Dext.Web.Routing.pas).
+  while (Path.Length > 1) and Path.EndsWith('/') do
+    Delete(Path, Path.Length, 1);
   
   // Check if this is a hub request
   Dispatcher := FindDispatcher(Path, HubPath);
@@ -484,11 +686,17 @@ begin
     Exit;
   end;
   
-  // Check for WebSocket upgrade request
-  if SameText(Ctx.Request.Method, 'GET') and
+  // A WebSocket upgrade must never silently fall through to an SSE stream.
+  if SameText(Path, HubPath) and SameText(Ctx.Request.Method, 'GET') and
      SameText(Ctx.Request.GetHeader('Upgrade'), 'websocket') then
   begin
-    if ConnectionSupportsUpgrade(Ctx) then
+    if not IsTransportEnabled('WebSockets') then
+    begin
+      Ctx.Response.StatusCode := 404;
+      Ctx.Response.SetContentType('application/json');
+      Ctx.Response.Write('{"error":"WebSocket transport is disabled"}');
+    end
+    else if ConnectionSupportsUpgrade(Ctx) then
       HandleWebSocket(HubPath, Ctx, Dispatcher)
     else
     begin
@@ -505,13 +713,17 @@ begin
   end;
   
   // Route to appropriate handler
-  if Path.EndsWith('/negotiate') then
+  if SameText(Path, HubPath + '/negotiate') and
+     SameText(Ctx.Request.Method, 'POST') then
     HandleNegotiate(HubPath, Ctx)
-  else if Path.EndsWith('/poll') then
+  else if SameText(Path, HubPath + '/poll') and
+          SameText(Ctx.Request.Method, 'GET') and
+          IsTransportEnabled('ServerSentEvents') then
     HandlePoll(HubPath, Ctx, Dispatcher)
-  else if Ctx.Request.Method = 'GET' then
+  else if SameText(Path, HubPath) and SameText(Ctx.Request.Method, 'GET') and
+          IsTransportEnabled('ServerSentEvents') then
     HandleSSEStream(HubPath, Ctx, Dispatcher)
-  else if Ctx.Request.Method = 'POST' then
+  else if SameText(Path, HubPath) and SameText(Ctx.Request.Method, 'POST') then
     HandleInvoke(HubPath, Ctx, Dispatcher)
   else
     Next(Ctx);
@@ -521,17 +733,32 @@ procedure THubMiddleware.HandleNegotiate(const HubPath: string; Ctx: IHttpContex
 var
   ConnectionId: string;
   Response: TNegotiateResponse;
+  LTransportCount: Integer;
 begin
   // Generate unique connection ID
   ConnectionId := TGUID.NewGuid.ToString.Replace('{', '').Replace('}', '').Replace('-', '');
   
   // Build negotiate response
   Response := TNegotiateResponse.Create(ConnectionId);
+  SetLength(Response.AvailableTransports, 0);
+  LTransportCount := 0;
+  if IsTransportEnabled('WebSockets') and
+     ConnectionSupportsUpgrade(Ctx) then
+  begin
+    SetLength(Response.AvailableTransports, LTransportCount + 1);
+    Response.AvailableTransports[LTransportCount] :=
+      TTransportInfo.WebSockets;
+    Inc(LTransportCount);
+  end;
+  if IsTransportEnabled('ServerSentEvents') then
+  begin
+    SetLength(Response.AvailableTransports, LTransportCount + 1);
+    Response.AvailableTransports[LTransportCount] := TTransportInfo.SSE;
+  end;
   
   Ctx.Response.StatusCode := 200;
   Ctx.Response.SetContentType('application/json');
   Ctx.Response.Write(Response.ToJson);
-  Writeln('Hub: Negotiate request on path ', HubPath, ' - generated ID: ', ConnectionId);
 end;
 
 procedure THubMiddleware.HandleSSEStream(const HubPath: string; Ctx: IHttpContext;
@@ -546,85 +773,95 @@ begin
   // Get connection ID from query
   if not Ctx.Request.Query.TryGetValue('id', ConnectionId) then
     ConnectionId := '';
-  if ConnectionId = '' then
+  if not IsValidConnectionId(ConnectionId) then
   begin
     Ctx.Response.StatusCode := 400;
-    Ctx.Response.Write('{"error": "Missing connection id"}');
+    Ctx.Response.SetContentType('application/json');
+    Ctx.Response.Write('{"error":"Invalid connection id"}');
     Exit;
   end;
-  
-  // Writeln('Hub: SSE stream requested for HubPath: ', HubPath, ', ConnectionId: ', ConnectionId);
-  
-  // Create SSE connection
-  Connection := FSSETransport.CreateConnection(ConnectionId);
-  Connection.SetConnected;
-  
-  // Add to connection manager (as interface)
-  FConnectionManager.Add(Connection);
-  // Writeln('Hub: Connection added to manager for ID: ', ConnectionId);
-  
-  // Configure SSE response
-  TSSEWriter.ConfigureResponse(Ctx.Response);
-  TSSEWriter.WriteRetry(Ctx.Response, 3000); // Retry after 3s on disconnect
-  
-  // Trigger OnConnected
-  try
-    Dispatcher.OnConnected(ConnectionId);
-  except
-    on E: Exception do
-      // Writeln('Hub: Error invoking OnConnected: ', E.Message);
-  end;
-  
-  // Send connected event
-  TSSEWriter.WriteEvent(Ctx.Response, 'connected', '{"connectionId":"' + ConnectionId + '"}');
-  Ctx.Response.Flush;
-  // Writeln('Hub: Connected event sent to ID: ', ConnectionId);
-  
-  KeepAliveCounter := 0;
-  
-  // SSE loop - keep connection open
-  // Check BOTH connection closed AND transport shutdown
-  while (not Connection.Closed) and (not FSSETransport.IsShuttingDown) do
+  if FConnectionManager.Contains(ConnectionId) or
+     not TryReserveConnection(ConnectionId, Dispatcher) then
   begin
-    // Check for pending messages
-    HasMessages := False;
-    while Connection.HasPendingMessages and (not FSSETransport.IsShuttingDown) do
+    Ctx.Response.StatusCode := 409;
+    Ctx.Response.SetContentType('application/json');
+    Ctx.Response.Write('{"error":"Connection id is already active"}');
+    Exit;
+  end;
+  Connection := nil;
+  try
+    // Create SSE connection
+    Connection := FSSETransport.CreateConnection(ConnectionId, Ctx.User);
+    Connection.SetConnected;
+
+    // Add to connection manager (as interface)
+    FConnectionManager.Add(Connection);
+
+    // Configure SSE response
+    TSSEWriter.ConfigureResponse(Ctx.Response);
+    TSSEWriter.WriteRetry(Ctx.Response, 3000); // Retry after 3s on disconnect
+
+    // Trigger OnConnected
+    try
+      Dispatcher.OnConnected(ConnectionId);
+    except
+      on E: Exception do
+        Connection.Close('Hub rejected connection');
+    end;
+
+    if not Connection.Closed then
     begin
-      Msg := Connection.DequeueMessage;
-      if Msg <> '' then
+      // Send connected event only after the Hub accepted the connection.
+      TSSEWriter.WriteEvent(Ctx.Response, 'connected',
+        '{"connectionId":"' + ConnectionId + '"}');
+      Ctx.Response.Flush;
+
+      KeepAliveCounter := 0;
+
+      // SSE loop - keep connection open
+      while (not Connection.Closed) and (not FSSETransport.IsShuttingDown) do
       begin
-        // Writeln('Hub: Sending SSE payload to ID ', ConnectionId, ': ', Msg);
-        TSSEWriter.WriteData(Ctx.Response, Msg);
-        HasMessages := True;
+        HasMessages := False;
+        while Connection.HasPendingMessages and
+          (not FSSETransport.IsShuttingDown) do
+        begin
+          Msg := Connection.DequeueMessage;
+          if Msg <> '' then
+          begin
+            TSSEWriter.WriteData(Ctx.Response, Msg);
+            HasMessages := True;
+          end;
+        end;
+        if HasMessages then
+          Ctx.Response.Flush;
+
+        Inc(KeepAliveCounter);
+        if KeepAliveCounter >= 150 then
+        begin
+          TSSEWriter.WriteComment(Ctx.Response, 'ping');
+          Ctx.Response.Flush;
+          KeepAliveCounter := 0;
+        end;
+
+        Sleep(100);
       end;
     end;
-    if HasMessages then
-      Ctx.Response.Flush;
-    
-    // Send keep-alive comment every 15 seconds (150 * 100ms)
-    Inc(KeepAliveCounter);
-    if KeepAliveCounter >= 150 then
-    begin
-      TSSEWriter.WriteComment(Ctx.Response, 'ping');
-      Ctx.Response.Flush;
-      KeepAliveCounter := 0;
+
+    // Keep the connection available while OnDisconnectedAsync executes.
+    try
+      Dispatcher.OnDisconnected(ConnectionId, nil);
+    except
+      // OnDisconnectedAsync must not abort the teardown of the connection.
+      on E: Exception do
+        SafeWriteLn('Hub: OnDisconnected failed: ' + E.Message);
     end;
-    
-    Sleep(100);
-  end;
-  
-  // Writeln('Hub: SSE Connection closed for ID: ', ConnectionId, ' (Connection.Closed=', Connection.Closed, ', FSSETransport.IsShuttingDown=', FSSETransport.IsShuttingDown, ')');
-  
-  // Cleanup
-  FConnectionManager.Remove(ConnectionId);
-  FSSETransport.RemoveConnection(ConnectionId);
-  
-  // Trigger OnDisconnected
-  try
-    Dispatcher.OnDisconnected(ConnectionId, nil);
-  except
-    on E: Exception do
-      Writeln('Hub: Error invoking OnDisconnected: ', E.Message);
+  finally
+    if Connection <> nil then
+    begin
+      FConnectionManager.Remove(ConnectionId);
+      FSSETransport.RemoveConnection(ConnectionId);
+    end;
+    ReleaseConnection(ConnectionId);
   end;
 end;
 
@@ -633,33 +870,37 @@ procedure THubMiddleware.HandlePoll(const HubPath: string; Ctx: IHttpContext;
 var
   ConnectionId: string;
   Connection: TSSEConnection;
+  HubConnection: IHubConnection;
   Messages: TJSONArray;
   Msg: string;
 begin
   if not Ctx.Request.Query.TryGetValue('id', ConnectionId) then
     ConnectionId := '';
-  if ConnectionId = '' then
+  if not IsValidConnectionId(ConnectionId) then
   begin
     Ctx.Response.StatusCode := 400;
-    Ctx.Response.Write('{"error": "Missing connection id"}');
+    Ctx.Response.SetContentType('application/json');
+    Ctx.Response.Write('{"error":"Invalid connection id"}');
     Exit;
   end;
   
   // Get connection
   Connection := FSSETransport.GetConnection(ConnectionId);
+  if (Connection <> nil) and
+    (not FConnectionManager.TryGet(ConnectionId, HubConnection) or
+     not IsSamePrincipal(HubConnection.User, Ctx.User)) then
+  begin
+    Ctx.Response.StatusCode := 403;
+    Ctx.Response.SetContentType('application/json');
+    Ctx.Response.Write('{"error":"Connection principal mismatch"}');
+    Exit;
+  end;
   if Connection = nil then
   begin
-    // No connection yet - create one
-    Connection := FSSETransport.CreateConnection(ConnectionId);
-    Connection.SetConnected;
-    FConnectionManager.Add(Connection);
-    
-    // Trigger OnConnected
-    try
-      Dispatcher.OnConnected(ConnectionId);
-    except
-      // Log but don't fail
-    end;
+    Ctx.Response.StatusCode := 404;
+    Ctx.Response.SetContentType('application/json');
+    Ctx.Response.Write('{"error":"Connection not found"}');
+    Exit;
   end;
   
   // Collect pending messages
@@ -689,30 +930,57 @@ var
   Args: TArray<TValue>;
   I: Integer;
   ResultValue: TValue;
+  JsonValue: TJSONValue;
   ConnectionId: string;
+  Connection: IHubConnection;
 begin
   if not Ctx.Request.Query.TryGetValue('id', ConnectionId) then
     ConnectionId := '';
-  if ConnectionId = '' then
+  if not IsValidConnectionId(ConnectionId) then
   begin
     Ctx.Response.StatusCode := 400;
-    Ctx.Response.Write('{"error": "Missing connection id"}');
+    Ctx.Response.SetContentType('application/json');
+    Ctx.Response.Write('{"error":"Invalid connection id"}');
+    Exit;
+  end;
+
+  if not FConnectionManager.TryGet(ConnectionId, Connection) then
+  begin
+    Ctx.Response.StatusCode := 404;
+    Ctx.Response.SetContentType('application/json');
+    Ctx.Response.Write('{"error":"Connection not found"}');
+    Exit;
+  end;
+  if not IsSamePrincipal(Connection.User, Ctx.User) then
+  begin
+    Ctx.Response.StatusCode := 403;
+    Ctx.Response.SetContentType('application/json');
+    Ctx.Response.Write('{"error":"Connection principal mismatch"}');
     Exit;
   end;
   
-  // Read body
-  Body := ReadStreamToString(Ctx.Request.Body);
-  Writeln('Hub: Invoking method target on Path: ', HubPath, ', ConnectionId: ', ConnectionId, ', Body: ', Body);
-  
+  Request := Default(TInvocationRequest);
   try
+    // Read body using the configured receive limit.
+    Body := ReadStreamToString(Ctx.Request.Body,
+      FOptions.MaximumReceiveMessageSize);
+
     // Parse invocation request
     Request := TInvocationRequest.FromJson(Body);
     
     // Convert JSON strings to TValues
     SetLength(Args, Length(Request.Arguments));
     for I := 0 to High(Request.Arguments) do
-      Args[I] := TJsonHubProtocol.JsonToValue(
-        TJSONObject.ParseJSONValue(Request.Arguments[I]), nil);
+    begin
+      JsonValue := TJSONObject.ParseJSONValue(Request.Arguments[I]);
+      if JsonValue = nil then
+        raise EHubException.Create('Invalid JSON argument');
+      try
+        Args[I] := TJsonHubProtocol.JsonToValue(JsonValue, nil);
+      finally
+        JsonValue.Free;
+      end;
+    end;
     
     // Invoke method
     ResultValue := Dispatcher.InvokeMethod(ConnectionId, Request.Target, Args);
@@ -721,27 +989,53 @@ begin
     if ResultValue.IsEmpty then
       InvResult := TInvocationResult.Success(Request.InvocationId, 'null')
     else
-      InvResult := TInvocationResult.Success(Request.InvocationId,
-        TJsonHubProtocol.ValueToJson(ResultValue).ToJSON);
+    begin
+      JsonValue := TJsonHubProtocol.ValueToJson(ResultValue);
+      try
+        InvResult := TInvocationResult.Success(Request.InvocationId,
+          JsonValue.ToJSON);
+      finally
+        JsonValue.Free;
+      end;
+    end;
     
     Ctx.Response.StatusCode := 200;
     Ctx.Response.SetContentType('application/json');
     Ctx.Response.Write(InvResult.ToJson);
     
   except
+    on E: EHubPayloadTooLargeException do
+    begin
+      InvResult := TInvocationResult.Failure(Request.InvocationId,
+        ClientError(E.Message, 'Hub payload is too large'));
+      Ctx.Response.StatusCode := 413;
+      Ctx.Response.SetContentType('application/json');
+      Ctx.Response.Write(InvResult.ToJson);
+    end;
     on E: EHubMethodNotFoundException do
     begin
-      InvResult := TInvocationResult.Failure(Request.InvocationId, E.Message);
+      InvResult := TInvocationResult.Failure(Request.InvocationId,
+        ClientError(E.Message, 'Hub method not found'));
       Ctx.Response.StatusCode := 404;
+      Ctx.Response.SetContentType('application/json');
+      Ctx.Response.Write(InvResult.ToJson);
+    end;
+    on E: EHubException do
+    begin
+      InvResult := TInvocationResult.Failure(Request.InvocationId,
+        ClientError(E.Message, 'Invalid Hub request'));
+      Ctx.Response.StatusCode := 400;
       Ctx.Response.SetContentType('application/json');
       Ctx.Response.Write(InvResult.ToJson);
     end;
     on E: Exception do
     begin
-      InvResult := TInvocationResult.Failure(Request.InvocationId, E.Message);
+      InvResult := TInvocationResult.Failure(Request.InvocationId,
+        ClientError(E.Message, 'Hub invocation failed'));
       Ctx.Response.StatusCode := 500;
       Ctx.Response.SetContentType('application/json');
       Ctx.Response.Write(InvResult.ToJson);
+      SafeWriteLn('Hub: invocation failed: ' + E.Message);
     end;
   end;
 end;
@@ -749,18 +1043,31 @@ end;
 procedure THubMiddleware.HandleWebSocket(const HubPath: string; Ctx: IHttpContext;
   Dispatcher: THubDispatcher);
 var
-  ConnectionId: string;
+  ConnectionId, RequestedConnectionId: string;
 begin
-  ConnectionId := TGUID.NewGuid.ToString.Replace('{', '').Replace('}', '').Replace('-', '');
-  FConnectionDispatchers.Add(ConnectionId, Dispatcher);
+  if not Ctx.Request.Query.TryGetValue('id', ConnectionId) then
+    ConnectionId := '';
+  if not IsValidConnectionId(ConnectionId) then
+  begin
+    Ctx.Response.StatusCode := 400;
+    Ctx.Response.SetContentType('application/json');
+    Ctx.Response.Write('{"error":"Invalid connection id"}');
+    Exit;
+  end;
+  if FConnectionManager.Contains(ConnectionId) or
+     not TryReserveConnection(ConnectionId, Dispatcher) then
+  begin
+    Ctx.Response.StatusCode := 409;
+    Ctx.Response.SetContentType('application/json');
+    Ctx.Response.Write('{"error":"Connection id is already active"}');
+    Exit;
+  end;
+
+  RequestedConnectionId := ConnectionId;
   try
     FWebSocketTransport.ProcessConnection(Ctx, ConnectionId);
-  except
-    on E: Exception do
-    begin
-      FConnectionDispatchers.Remove(ConnectionId);
-      raise;
-    end;
+  finally
+    ReleaseConnection(RequestedConnectionId);
   end;
 end;
 

--- a/Sources/Hubs/Dext.Web.Hubs.Types.pas
+++ b/Sources/Hubs/Dext.Web.Hubs.Types.pas
@@ -33,9 +33,16 @@ unit Dext.Web.Hubs.Types;
 interface
 
 uses
+  System.Rtti,
   System.SysUtils;
 
 type
+  /// <summary>
+  /// Explicitly allows a public Hub method to be invoked by a remote client.
+  /// Public methods without this attribute remain server-side only.
+  /// </summary>
+  HubMethodAttribute = class(TCustomAttribute);
+
   /// <summary>
   /// Transport information in negotiate response.
   /// </summary>
@@ -58,7 +65,10 @@ type
     AvailableTransports: TArray<TTransportInfo>;
     
     function ToJson: string;
-    class function Create(const AConnectionId: string): TNegotiateResponse; static;
+    class function Create(const AConnectionId: string): TNegotiateResponse;
+      overload; static;
+    class function Create(const AConnectionId: string;
+      ASupportsWebSockets: Boolean): TNegotiateResponse; overload; static;
   end;
   
   /// <summary>
@@ -99,6 +109,13 @@ type
     MaximumReceiveMessageSize: Int64;
     /// <summary>Enabled transports</summary>
     EnabledTransports: TArray<string>;
+    /// <summary>
+    ///   When True (the default) only methods annotated with HubMethod can be
+    ///   invoked by a remote client. Set it to False to restore the previous
+    ///   behaviour, where every public method reachable through RTTI was
+    ///   invokable, while annotating an existing Hub.
+    /// </summary>
+    RequireHubMethodAttribute: Boolean;
     
     class function Default: THubOptions; static;
   end;
@@ -122,6 +139,11 @@ type
   /// Exception when invocation fails.
   /// </summary>
   EHubInvocationException = class(EHubException);
+
+  /// <summary>
+  /// Exception when a Hub request exceeds the configured receive limit.
+  /// </summary>
+  EHubPayloadTooLargeException = class(EHubException);
 
 implementation
 
@@ -153,10 +175,19 @@ end;
 
 class function TNegotiateResponse.Create(const AConnectionId: string): TNegotiateResponse;
 begin
+  Result := Create(AConnectionId, False);
+end;
+
+class function TNegotiateResponse.Create(const AConnectionId: string;
+  ASupportsWebSockets: Boolean): TNegotiateResponse;
+begin
   Result.ConnectionId := AConnectionId;
   Result.ConnectionToken := AConnectionId; // For now, same as ConnectionId
   Result.NegotiateVersion := 1;
-  Result.AvailableTransports := [TTransportInfo.WebSockets, TTransportInfo.SSE, TTransportInfo.LongPolling];
+  if ASupportsWebSockets then
+    Result.AvailableTransports := [TTransportInfo.WebSockets, TTransportInfo.SSE]
+  else
+    Result.AvailableTransports := [TTransportInfo.SSE];
 end;
 
 function TNegotiateResponse.ToJson: string;
@@ -268,7 +299,8 @@ begin
   Result.ClientTimeoutInterval := 30;
   Result.KeepAliveInterval := 15;
   Result.MaximumReceiveMessageSize := 32 * 1024; // 32KB
-  Result.EnabledTransports := ['WebSockets', 'ServerSentEvents', 'LongPolling'];
+  Result.EnabledTransports := ['WebSockets', 'ServerSentEvents'];
+  Result.RequireHubMethodAttribute := True;
 end;
 
 end.

--- a/Sources/Hubs/Dext.Web.Hubs.pas
+++ b/Sources/Hubs/Dext.Web.Hubs.pas
@@ -31,6 +31,7 @@
 {    type                                                                   }
 {      TMyHub = class(THub)                                                 }
 {      public                                                               }
+{        [HubMethod]                                                        }
 {        procedure SendMessage(const Text: string);                         }
 {      end;                                                                 }
 {                                                                           }
@@ -85,6 +86,7 @@ type
   THubMessage = Dext.Web.Hubs.Interfaces.THubMessage;
   THubOptions = Dext.Web.Hubs.Types.THubOptions;
   TNegotiateResponse = Dext.Web.Hubs.Types.TNegotiateResponse;
+  HubMethodAttribute = Dext.Web.Hubs.Types.HubMethodAttribute;
   
   // Implementations
   THubConnection = Dext.Web.Hubs.Connections.THubConnection;
@@ -98,6 +100,7 @@ type
   EConnectionNotFoundException = Dext.Web.Hubs.Types.EConnectionNotFoundException;
   EHubMethodNotFoundException = Dext.Web.Hubs.Types.EHubMethodNotFoundException;
   EHubInvocationException = Dext.Web.Hubs.Types.EHubInvocationException;
+  EHubPayloadTooLargeException = Dext.Web.Hubs.Types.EHubPayloadTooLargeException;
 
 implementation
 

--- a/Sources/Hubs/README.md
+++ b/Sources/Hubs/README.md
@@ -86,7 +86,9 @@ uses
 type
   TMyHub = class(THub)
   public
+    [HubMethod]
     procedure SendMessage(const Text: string);
+    [HubMethod]
     procedure JoinGroup(const GroupName: string);
   end;
 
@@ -100,6 +102,9 @@ begin
   Groups.AddToGroupAsync(Context.ConnectionId, GroupName);
 end;
 ```
+
+Only methods explicitly annotated with `[HubMethod]` are remotely invokable.
+Other public methods remain server-side helpers and cannot be called by a client.
 
 ### 3. Register the Hub
 

--- a/Sources/Hubs/Transports/Dext.Web.Hubs.Transport.SSE.pas
+++ b/Sources/Hubs/Transports/Dext.Web.Hubs.Transport.SSE.pas
@@ -56,12 +56,15 @@ type
   private
     FConnectionId: string;
     FState: TConnectionState;
+    FUser: IClaimsPrincipal;
     FItems: IDictionary<string, TValue>;
+    FAbortTokenSource: TCancellationTokenSource;
     FMessageQueue: IQueue<string>;
     FQueueLock: TCriticalSection;
     FClosed: Int64; // 0 = open, 1 = closed (using Integer for TInterlocked)
   public
-    constructor Create(const AConnectionId: string);
+    constructor Create(const AConnectionId: string;
+      const AUser: IClaimsPrincipal = nil);
     destructor Destroy; override;
     
     // IHubConnection
@@ -113,7 +116,8 @@ type
     procedure SetOnDisconnected(const Handler: TOnConnectionEvent);
     
     // Connection management
-    function CreateConnection(const ConnectionId: string): TSSEConnection;
+    function CreateConnection(const ConnectionId: string;
+      const User: IClaimsPrincipal = nil): TSSEConnection;
     function GetConnection(const ConnectionId: string): TSSEConnection;
     procedure RemoveConnection(const ConnectionId: string);
     
@@ -150,12 +154,15 @@ implementation
 
 { TSSEConnection }
 
-constructor TSSEConnection.Create(const AConnectionId: string);
+constructor TSSEConnection.Create(const AConnectionId: string;
+  const AUser: IClaimsPrincipal);
 begin
   inherited Create;
   FConnectionId := AConnectionId;
   FState := csConnecting;
+  FUser := AUser;
   FItems := TCollections.CreateDictionary<string, TValue>;
+  FAbortTokenSource := TCancellationTokenSource.Create;
   FMessageQueue := TCollections.CreateQueue<string>;
   FQueueLock := TCriticalSection.Create;
   FClosed := 0;
@@ -163,6 +170,8 @@ end;
 
 destructor TSSEConnection.Destroy;
 begin
+  FAbortTokenSource.Free;
+  FUser := nil;
   FQueueLock.Free;
   // FMessageQueue is ARC managed
   // FItems is ARC
@@ -186,12 +195,15 @@ end;
 
 function TSSEConnection.GetUser: IClaimsPrincipal;
 begin
-  Result := nil; // Set externally if needed
+  Result := FUser;
 end;
 
 function TSSEConnection.GetUserIdentifier: string;
 begin
-  Result := '';
+  if FUser <> nil then
+    Result := FUser.FindClaim('sub').Value // Standard claim for user ID
+  else
+    Result := '';
 end;
 
 function TSSEConnection.GetItems: IDictionary<string, TValue>;
@@ -201,7 +213,7 @@ end;
 
 function TSSEConnection.GetAbortToken: ICancellationToken;
 begin
-  Result := nil; // Could be implemented with external source
+  Result := FAbortTokenSource.Token;
 end;
 
 procedure TSSEConnection.SendAsync(const Message: string);
@@ -219,6 +231,7 @@ end;
 procedure TSSEConnection.Close(const Reason: string);
 begin
   FState := csDisconnected;
+  FAbortTokenSource.Cancel;
   TInterlocked.Exchange(FClosed, 1);
 end;
 
@@ -379,9 +392,10 @@ begin
   FOnDisconnected := Handler;
 end;
 
-function TSSETransport.CreateConnection(const ConnectionId: string): TSSEConnection;
+function TSSETransport.CreateConnection(const ConnectionId: string;
+  const User: IClaimsPrincipal): TSSEConnection;
 begin
-  Result := TSSEConnection.Create(ConnectionId);
+  Result := TSSEConnection.Create(ConnectionId, User);
   
   FLock.Enter;
   try

--- a/Sources/Hubs/Transports/Dext.Web.Hubs.Transport.WebSocket.pas
+++ b/Sources/Hubs/Transports/Dext.Web.Hubs.Transport.WebSocket.pas
@@ -75,7 +75,9 @@ type
     FConnectionId: string;
     FWSConnection: IDextWebSocketConnection;
     FState: TConnectionState;
+    FUser: IClaimsPrincipal;
     FItems: IDictionary<string, TValue>;
+    FAbortTokenSource: TCancellationTokenSource;
     FLock: TCriticalSection;
     FReceiveBuffer: TBytes;
     FReceiveStart: Integer;
@@ -88,7 +90,9 @@ type
     FHandshakeComplete: Boolean;
     FProtocolName: string;
   public
-    constructor Create(const AConnectionId: string; const AWSConnection: IDextWebSocketConnection);
+    constructor Create(const AConnectionId: string;
+      const AWSConnection: IDextWebSocketConnection;
+      const AUser: IClaimsPrincipal = nil);
     destructor Destroy; override;
 
     // IHubConnection
@@ -191,13 +195,16 @@ begin
 end;
 
 constructor TWebSocketHubConnection.Create(const AConnectionId: string;
-  const AWSConnection: IDextWebSocketConnection);
+  const AWSConnection: IDextWebSocketConnection;
+  const AUser: IClaimsPrincipal);
 begin
   inherited Create;
   FConnectionId := AConnectionId;
   FWSConnection := AWSConnection;
   FState := csConnected;
+  FUser := AUser;
   FItems := TCollections.CreateDictionary<string, TValue>;
+  FAbortTokenSource := TCancellationTokenSource.Create;
   FLock := TCriticalSection.Create;
   FReceiveStart := 0;
   FReceiveEnd := 0;
@@ -209,7 +216,9 @@ end;
 
 destructor TWebSocketHubConnection.Destroy;
 begin
+  FAbortTokenSource.Free;
   FItems := nil;
+  FUser := nil;
   FWSConnection := nil;
   FReceiveBuffer := nil;
   FFragmentPayload := nil;
@@ -234,12 +243,15 @@ end;
 
 function TWebSocketHubConnection.GetUser: IClaimsPrincipal;
 begin
-  Result := nil;
+  Result := FUser;
 end;
 
 function TWebSocketHubConnection.GetUserIdentifier: string;
 begin
-  Result := '';
+  if FUser <> nil then
+    Result := FUser.FindClaim('sub').Value // Standard claim for user ID
+  else
+    Result := '';
 end;
 
 function TWebSocketHubConnection.GetItems: IDictionary<string, TValue>;
@@ -249,7 +261,7 @@ end;
 
 function TWebSocketHubConnection.GetAbortToken: ICancellationToken;
 begin
-  Result := nil;
+  Result := FAbortTokenSource.Token;
 end;
 
 procedure TWebSocketHubConnection.SendAsync(const Message: string);
@@ -307,6 +319,7 @@ begin
     if FState = csConnected then
     begin
       FState := csDisconnected;
+      FAbortTokenSource.Cancel;
       FWSConnection.Close(1000, Reason);
     end;
   finally
@@ -558,7 +571,8 @@ begin
     ConnectionId := AConnectionId;
 
   AConnectionId := ConnectionId;
-  HubConnection := TWebSocketHubConnection.Create(ConnectionId, WSConn);
+  HubConnection := TWebSocketHubConnection.Create(ConnectionId, WSConn,
+    AContext.User);
 
   FLock.Enter;
   try

--- a/Sources/Hubs/wwwroot/dext-hubs.js
+++ b/Sources/Hubs/wwwroot/dext-hubs.js
@@ -5,7 +5,7 @@
  * 
  * Usage:
  *   const connection = new DextHubConnection('/hubs/dashboard');
- *   connection.on('ReceiveMessage', (msg) => console.log(msg));
+ *   connection.on('ReceiveMessage', handleMessage);
  *   await connection.start();
  *   await connection.invoke('SendMessage', 'Hello!');
  * 
@@ -20,9 +20,14 @@ class DextHubConnection {
    * @param {Object} options - Connection options
    */
   constructor(hubUrl, options = {}) {
-    this.hubUrl = hubUrl;
+    // Drop a trailing slash so the derived URLs stay canonical: '/hubs/demo/'
+    // would otherwise produce '/hubs/demo//negotiate', which the server routes
+    // as a distinct path and rejects.
+    this.hubUrl = hubUrl.length > 1 ? hubUrl.replace(/\/+$/, '') : hubUrl;
     this.options = {
-      transport: typeof WebSocket !== 'undefined' ? 'webSockets' : 'serverSentEvents', // or 'serverSentEvents', 'longPolling'
+      transport: 'auto',
+      fallback: true,
+      withCredentials: true,
       reconnect: true,
       reconnectDelay: 3000,
       ...options
@@ -31,6 +36,7 @@ class DextHubConnection {
     this.connectionId = null;
     this.eventSource = null;
     this.socket = null;
+    this.transport = null;
     this.handlers = new Map();
     this.state = 'disconnected'; // disconnected, connecting, connected, reconnecting
     this.invocationId = 0;
@@ -78,19 +84,36 @@ class DextHubConnection {
     }
     
     this.state = 'connecting';
+    // Clear the previous transport: a reconnect that finds no usable transport
+    // must fail closed instead of reporting 'connected' on a stale value.
+    this.transport = null;
     
     try {
       // Step 1: Negotiate
       const negotiateResponse = await this._negotiate();
       this.connectionId = negotiateResponse.connectionId;
       
-      // Step 2: Connect transport
-      if (this.options.transport === 'webSockets') {
-        await this._connectWebSocket();
-      } else if (this.options.transport === 'serverSentEvents') {
-        await this._connectSSE();
-      } else {
-        await this._connectLongPolling();
+      // Step 2: Connect the best advertised transport, with a real fallback.
+      const transports = this._getTransportCandidates(negotiateResponse);
+      let lastError = null;
+      for (const transport of transports) {
+        try {
+          if (transport === 'webSockets') {
+            await this._connectWebSocket();
+          } else if (transport === 'serverSentEvents') {
+            await this._connectSSE();
+          }
+          this.transport = transport;
+          lastError = null;
+          break;
+        } catch (error) {
+          lastError = error;
+          this._cleanupTransport();
+        }
+      }
+
+      if (lastError || !this.transport) {
+        throw lastError || new Error('No compatible Hub transport is available');
       }
       
       this.state = 'connected';
@@ -107,18 +130,16 @@ class DextHubConnection {
    * @returns {Promise<void>}
    */
   async stop() {
-    if (this.socket) {
-      this.socket.close();
-      this.socket = null;
+    this._cleanupTransport();
+
+    for (const pending of this.pendingInvocations.values()) {
+      pending.reject(new Error('Hub connection stopped'));
     }
-    
-    if (this.eventSource) {
-      this.eventSource.close();
-      this.eventSource = null;
-    }
+    this.pendingInvocations.clear();
     
     this.state = 'disconnected';
     this.connectionId = null;
+    this.transport = null;
     this._triggerHandlers('disconnected', {});
   }
   
@@ -142,7 +163,7 @@ class DextHubConnection {
       arguments: args
     };
     
-    if (this.options.transport === 'webSockets' && this.socket) {
+    if (this.transport === 'webSockets' && this.socket) {
       return new Promise((resolve, reject) => {
         this.pendingInvocations.set(invocationId, { resolve, reject });
         try {
@@ -163,6 +184,7 @@ class DextHubConnection {
           headers: {
             'Content-Type': 'application/json'
           },
+          credentials: this.options.withCredentials ? 'same-origin' : 'omit',
           body: JSON.stringify(request)
         });
         
@@ -198,7 +220,7 @@ class DextHubConnection {
       arguments: args
     };
     
-    if (this.options.transport === 'webSockets' && this.socket) {
+    if (this.transport === 'webSockets' && this.socket) {
       this.socket.send(JSON.stringify(request) + '\x1e');
     } else {
       await fetch(`${this.hubUrl}?id=${this.connectionId}`, {
@@ -206,6 +228,7 @@ class DextHubConnection {
         headers: {
           'Content-Type': 'application/json'
         },
+        credentials: this.options.withCredentials ? 'same-origin' : 'omit',
         body: JSON.stringify(request)
       });
     }
@@ -220,7 +243,8 @@ class DextHubConnection {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'
-      }
+      },
+      credentials: this.options.withCredentials ? 'same-origin' : 'omit'
     });
     
     if (!response.ok) {
@@ -228,6 +252,62 @@ class DextHubConnection {
     }
     
     return await response.json();
+  }
+
+  /**
+   * Returns client/server compatible transports in connection priority order.
+   * @private
+   */
+  _getTransportCandidates(negotiateResponse) {
+    const advertised = new Set(
+      (negotiateResponse.availableTransports || []).map(item => item.transport)
+    );
+    const supported = [];
+    if (advertised.has('WebSockets') && typeof WebSocket !== 'undefined') {
+      supported.push('webSockets');
+    }
+    if (advertised.has('ServerSentEvents') && typeof EventSource !== 'undefined') {
+      supported.push('serverSentEvents');
+    }
+
+    const requested = String(this.options.transport || 'auto').toLowerCase();
+    if (requested === 'auto') {
+      return supported;
+    }
+
+    const normalized = requested === 'websockets'
+      ? 'webSockets'
+      : requested === 'serversentevents'
+        ? 'serverSentEvents'
+        : null;
+    if (!normalized) {
+      throw new Error(`Unsupported Hub transport: ${this.options.transport}`);
+    }
+
+    const selected = supported.filter(item => item === normalized);
+    if (this.options.fallback && normalized === 'webSockets') {
+      selected.push(...supported.filter(item => item !== normalized));
+    }
+    return selected;
+  }
+
+  /** @private */
+  _cleanupTransport() {
+    if (this.socket) {
+      this.socket.onopen = null;
+      this.socket.onerror = null;
+      this.socket.onclose = null;
+      this.socket.onmessage = null;
+      this.socket.close();
+      this.socket = null;
+    }
+    if (this.eventSource) {
+      this.eventSource.onopen = null;
+      this.eventSource.onerror = null;
+      this.eventSource.onmessage = null;
+      this.eventSource.close();
+      this.eventSource = null;
+    }
   }
   
   /**
@@ -237,25 +317,24 @@ class DextHubConnection {
   async _connectSSE() {
     return new Promise((resolve, reject) => {
       const url = `${this.hubUrl}?id=${this.connectionId}`;
-      this.eventSource = new EventSource(url);
+      let settled = false;
+      this.eventSource = new EventSource(url, {
+        withCredentials: this.options.withCredentials
+      });
       
       this.eventSource.onopen = () => {
+        settled = true;
         resolve();
       };
       
       this.eventSource.onerror = (event) => {
-        if (this.state === 'connecting') {
+        if (!settled) {
+          settled = true;
           reject(new Error('SSE connection failed'));
         } else if (this.options.reconnect && this.state === 'connected') {
           this._handleReconnect();
         }
       };
-      
-      // Handle 'connected' event
-      this.eventSource.addEventListener('connected', (event) => {
-        const data = JSON.parse(event.data);
-        console.log('Hub connected:', data.connectionId);
-      });
       
       // Handle default message event (Hub invocations)
       this.eventSource.onmessage = (event) => {
@@ -271,6 +350,7 @@ class DextHubConnection {
   async _connectWebSocket() {
     return new Promise((resolve, reject) => {
       let wsUrl;
+      let settled = false;
       if (this.hubUrl.startsWith('http://') || this.hubUrl.startsWith('https://')) {
         wsUrl = this.hubUrl.replace(/^http/, 'ws');
       } else {
@@ -286,11 +366,13 @@ class DextHubConnection {
       this.socket = new WebSocket(wsUrl);
       
       this.socket.onopen = () => {
+        settled = true;
         resolve();
       };
       
       this.socket.onerror = (error) => {
-        if (this.state === 'connecting') {
+        if (!settled) {
+          settled = true;
           reject(new Error('WebSocket connection failed'));
         } else if (this.options.reconnect && this.state === 'connected') {
           this._handleReconnect();
@@ -298,6 +380,11 @@ class DextHubConnection {
       };
       
       this.socket.onclose = () => {
+        if (!settled) {
+          settled = true;
+          reject(new Error('WebSocket connection closed before opening'));
+          return;
+        }
         if (this.state === 'connected') {
           if (this.options.reconnect) {
             this._handleReconnect();
@@ -316,15 +403,6 @@ class DextHubConnection {
         }
       };
     });
-  }
-  
-  /**
-   * Connect using Long Polling (fallback)
-   * @private
-   */
-  async _connectLongPolling() {
-    // Long polling implementation would go here
-    throw new Error('Long polling not yet implemented');
   }
   
   /**
@@ -388,7 +466,6 @@ class DextHubConnection {
    * @private
    */
   _handleClose(message) {
-    console.log('Hub connection closed:', message.error || 'No error');
     this.stop();
   }
   
@@ -400,8 +477,6 @@ class DextHubConnection {
     if (this.state === 'reconnecting') return;
     
     this.state = 'reconnecting';
-    console.log('Attempting to reconnect...');
-    
     if (this.socket) {
       this.socket.close();
       this.socket = null;
@@ -415,7 +490,6 @@ class DextHubConnection {
     setTimeout(async () => {
       try {
         await this.start();
-        console.log('Reconnected successfully');
       } catch (error) {
         console.error('Reconnection failed:', error);
         this._handleReconnect(); // Try again

--- a/Tests/Hubs/Dext.Web.Hubs.Middleware.Tests.pas
+++ b/Tests/Hubs/Dext.Web.Hubs.Middleware.Tests.pas
@@ -154,6 +154,21 @@ begin
     Check(not NextCalled,
       'Plain GET on a mapped hub is not forwarded to Next');
 
+    // A trailing slash must resolve the same hub: MapHub trims it on the
+    // registered path, so the request path has to be trimmed as well.
+    Ctx := CreateContext('GET', '/hubs/probe/', '');
+    NextCalled := False;
+    Middleware.Handle(Ctx,
+      procedure(AContext: IHttpContext)
+      begin
+        NextCalled := True;
+      end);
+
+    Check(Ctx.Response.StatusCode = 400,
+      'Trailing slash still routes to the hub');
+    Check(not NextCalled,
+      'Trailing slash is not forwarded to Next');
+
     // Unmapped path keeps flowing through the pipeline.
     Ctx := CreateContext('GET', '/api/other', '');
     NextCalled := False;

--- a/Tests/Hubs/TestDextHubs.dpr
+++ b/Tests/Hubs/TestDextHubs.dpr
@@ -11,6 +11,7 @@ uses
   System.Rtti,
   System.JSON,
   Dext.Collections,
+  Dext.Auth.Identity,
   // Dext.Hubs units
   Dext.Web.Hubs.Interfaces,
   Dext.Web.Hubs.Types,
@@ -18,8 +19,10 @@ uses
   Dext.Web.Hubs.Connections,
   Dext.Web.Hubs.Clients,
   Dext.Web.Hubs.Context,
+  Dext.Web.Hubs.Middleware,
   Dext.Web.Hubs.Protocol.Json,
   Dext.Web.Hubs.Protocol.MessagePack,
+  Dext.Web.Hubs.Transport.SSE,
   Dext.Web.Hubs.Client.Tests,
   Dext.Web.Hubs.Middleware.Tests;
 
@@ -252,7 +255,7 @@ end;
 
 procedure TestTNegotiateResponse;
 var
-  Response: TNegotiateResponse;
+  Response, WebSocketResponse: TNegotiateResponse;
   Json: string;
 begin
   WriteLn;
@@ -262,12 +265,68 @@ begin
   
   Check(Response.ConnectionId = 'test-connection-id', 'ConnectionId');
   Check(Response.NegotiateVersion = 1, 'NegotiateVersion');
-  Check(Length(Response.AvailableTransports) = 3, 'AvailableTransports count');
+  Check(Length(Response.AvailableTransports) = 1, 'SSE-only transport count');
+  Check(Response.AvailableTransports[0].Transport = 'ServerSentEvents',
+    'SSE-only negotiation does not over-advertise transports');
+
+  WebSocketResponse := TNegotiateResponse.Create('test-connection-id', True);
+  Check(Length(WebSocketResponse.AvailableTransports) = 2,
+    'WebSocket-capable transport count');
+  Check(WebSocketResponse.AvailableTransports[0].Transport = 'WebSockets',
+    'WebSocket is preferred when the HTTP engine supports upgrade');
+  Check(WebSocketResponse.AvailableTransports[1].Transport = 'ServerSentEvents',
+    'SSE remains the WebSocket fallback');
   
   Json := Response.ToJson;
   Check(Pos('"connectionId":"test-connection-id"', Json) > 0, 'ToJson connectionId');
   Check(Pos('"negotiateVersion":1', Json) > 0, 'ToJson negotiateVersion');
   Check(Pos('"availableTransports":', Json) > 0, 'ToJson availableTransports');
+end;
+
+procedure TestAuthenticatedCallerContextAbort;
+var
+  Identity: IIdentity;
+  Principal: IClaimsPrincipal;
+  ClaimsBuilder: IClaimsBuilder;
+  Connection: THubConnection;
+  Context: THubCallerContext;
+begin
+  WriteLn;
+  WriteLn('=== Authenticated Hub Context Tests ===');
+
+  Identity := TClaimsIdentity.Create('user-1', 'Test');
+  ClaimsBuilder := TClaimsBuilder.Create;
+  ClaimsBuilder.WithNameIdentifier('user-1');
+  Principal := TClaimsPrincipal.Create(Identity, ClaimsBuilder.Build);
+
+  Connection := THubConnection.Create('auth-connection', ttWebSockets,
+    Principal);
+  try
+    Connection.SetState(csConnected);
+    Context := THubCallerContext.Create(Connection.ConnectionId,
+      Connection.TransportType, Connection.GetUser, Connection.GetAbortToken,
+      procedure
+      begin
+        Connection.Close('test abort');
+      end);
+    try
+      Check(Context.User = Principal, 'Caller principal is propagated');
+      Check(Context.UserIdentifier = 'user-1',
+        'Caller user identifier is propagated');
+      Check(Context.TransportType = ttWebSockets,
+        'Caller transport type is propagated');
+
+      Context.Abort;
+      Check(Connection.State = csDisconnected,
+        'Abort closes the underlying connection');
+      Check(Connection.GetAbortToken.IsCancellationRequested,
+        'Abort cancels the connection token');
+    finally
+      Context.Free;
+    end;
+  finally
+    Connection.Free;
+  end;
 end;
 
 procedure TestTHubContext;
@@ -319,13 +378,20 @@ end;
 type
   TTestHub = class(THub)
   public
+    [HubMethod]
     procedure TestMethod(const Message: string);
+    procedure ServerOnlyMethod;
   end;
 
 procedure TTestHub.TestMethod(const Message: string);
 begin
   // Test method - would normally send to clients
   Clients.All.SendAsync('Echo', [TValue.From(Message)]);
+end;
+
+procedure TTestHub.ServerOnlyMethod;
+begin
+  // Intentionally public, but not remotely invokable.
 end;
 
 procedure TestTHub;
@@ -368,6 +434,134 @@ begin
     end;
   finally
     Hub.Free;
+  end;
+end;
+
+procedure TestHubMethodAllowlist;
+var
+  ConnectionManager: IConnectionManager;
+  ConcreteConnectionManager: TConnectionManager;
+  GroupManager: IGroupManager;
+  Connection: IHubConnection;
+  SSETransport: TSSETransport;
+  Dispatcher: THubDispatcher;
+begin
+  WriteLn;
+  WriteLn('=== Hub Method Allowlist Tests ===');
+
+  GroupManager := TGroupManager.Create;
+  ConcreteConnectionManager := TConnectionManager.Create;
+  ConcreteConnectionManager.SetGroupManager(GroupManager);
+  ConnectionManager := ConcreteConnectionManager;
+  Connection := THubConnection.Create('allowlist-connection',
+    ttServerSentEvents);
+  ConnectionManager.Add(Connection);
+  SSETransport := TSSETransport.Create;
+  Dispatcher := THubDispatcher.Create(TTestHub, ConnectionManager,
+    GroupManager, SSETransport);
+  try
+    try
+      Dispatcher.InvokeMethod('allowlist-connection', 'TestMethod',
+        [TValue.From('allowed')]);
+      Check(True, 'Annotated Hub method is client-invokable');
+    except
+      Check(False, 'Annotated Hub method is client-invokable');
+    end;
+
+    try
+      Dispatcher.InvokeMethod('allowlist-connection', 'ServerOnlyMethod', []);
+      Check(False, 'Public server-only method is blocked');
+    except
+      on E: EHubMethodNotFoundException do
+        Check(True, 'Public server-only method is blocked');
+      else
+        Check(False, 'Public server-only method is blocked');
+    end;
+
+    try
+      Dispatcher.InvokeMethod('allowlist-connection', 'OnConnectedAsync', []);
+      Check(False, 'Hub lifecycle method is blocked');
+    except
+      on E: EHubMethodNotFoundException do
+        Check(True, 'Hub lifecycle method is blocked');
+      else
+        Check(False, 'Hub lifecycle method is blocked');
+    end;
+  finally
+    Dispatcher.Free;
+    SSETransport.Free;
+  end;
+end;
+
+procedure TestHubMethodAllowlistOptOut;
+var
+  ConnectionManager: IConnectionManager;
+  ConcreteConnectionManager: TConnectionManager;
+  GroupManager: IGroupManager;
+  Connection: IHubConnection;
+  SSETransport: TSSETransport;
+  Dispatcher: THubDispatcher;
+begin
+  WriteLn;
+  WriteLn('=== Hub Method Allowlist Opt-Out Tests ===');
+
+  ConcreteConnectionManager := TConnectionManager.Create;
+  ConnectionManager := ConcreteConnectionManager;
+  GroupManager := TGroupManager.Create;
+  Connection := THubConnection.Create('optout-connection', ttServerSentEvents);
+  ConnectionManager.Add(Connection);
+  SSETransport := TSSETransport.Create;
+
+  // RequireHubMethodAttribute = False restores the pre-allowlist behaviour, so
+  // an existing Hub keeps working while its methods are being annotated.
+  Dispatcher := THubDispatcher.Create(TTestHub, ConnectionManager, GroupManager,
+    SSETransport, False);
+  try
+    try
+      Dispatcher.InvokeMethod('optout-connection', 'ServerOnlyMethod', []);
+      Check(True, 'Opt-out allows an unannotated public method');
+    except
+      Check(False, 'Opt-out allows an unannotated public method');
+    end;
+
+    try
+      Dispatcher.InvokeMethod('optout-connection', 'NoSuchMethod', []);
+      Check(False, 'Opt-out still rejects a method that does not exist');
+    except
+      on E: EHubMethodNotFoundException do
+        Check(True, 'Opt-out still rejects a method that does not exist');
+      else
+        Check(False, 'Opt-out still rejects a method that does not exist');
+    end;
+  finally
+    Dispatcher.Free;
+    SSETransport.Free;
+  end;
+end;
+
+procedure TestHubReceiveLimitConfiguration;
+var
+  Options: THubOptions;
+  Middleware: THubMiddleware;
+begin
+  WriteLn;
+  WriteLn('=== Hub Receive Limit Configuration Tests ===');
+
+  Options := THubOptions.Default;
+  Options.MaximumReceiveMessageSize := 0;
+  Middleware := nil;
+  try
+    try
+      Middleware := THubMiddleware.Create(Options);
+      Check(False, 'Zero receive limit is rejected');
+    except
+      on E: EArgumentOutOfRangeException do
+        Check(True, 'Zero receive limit is rejected');
+      else
+        Check(False, 'Zero receive limit is rejected');
+    end;
+  finally
+    Middleware.Free;
   end;
 end;
 
@@ -643,7 +837,11 @@ begin
     TestTNegotiateResponse;
     TestTHubContext;
     TestTHubCallerContext;
+    TestAuthenticatedCallerContextAbort;
     TestTHub;
+    TestHubMethodAllowlist;
+    TestHubMethodAllowlistOptOut;
+    TestHubReceiveLimitConfiguration;
     TestValueSerialization;
     
     // New tests

--- a/Tests/Hubs/dext-hubs.client.test.js
+++ b/Tests/Hubs/dext-hubs.client.test.js
@@ -1,0 +1,186 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const path = require('node:path')
+
+const clientPath = path.resolve(__dirname, '../../Sources/Hubs/wwwroot/dext-hubs.js')
+const { DextHubConnection } = require(clientPath)
+
+class FailingWebSocket {
+  static instances = 0
+
+  constructor(url) {
+    this.url = url
+    FailingWebSocket.instances += 1
+    queueMicrotask(() => this.onerror && this.onerror(new Error('blocked')))
+  }
+
+  close() {}
+}
+
+class WorkingWebSocket {
+  static instances = 0
+
+  constructor(url) {
+    this.url = url
+    WorkingWebSocket.instances += 1
+    queueMicrotask(() => this.onopen && this.onopen())
+  }
+
+  send() {}
+  close() {}
+}
+
+class WorkingEventSource {
+  static instances = 0
+
+  constructor(url, options) {
+    this.url = url
+    this.options = options
+    WorkingEventSource.instances += 1
+    queueMicrotask(() => this.onopen && this.onopen())
+  }
+
+  addEventListener() {}
+  close() {}
+}
+
+async function testWebSocketFallsBackToSSE() {
+  const fetchCalls = []
+  global.WebSocket = FailingWebSocket
+  global.EventSource = WorkingEventSource
+  global.fetch = async (url, options) => {
+    fetchCalls.push({ url, options })
+    return {
+      ok: true,
+      json: async () => ({
+        connectionId: '0123456789abcdef0123456789abcdef',
+        availableTransports: [
+          { transport: 'WebSockets', transferFormats: ['Text'] },
+          { transport: 'ServerSentEvents', transferFormats: ['Text'] }
+        ]
+      })
+    }
+  }
+
+  const connection = new DextHubConnection('https://example.test/hubs/events')
+  await connection.start()
+
+  assert.equal(FailingWebSocket.instances, 1)
+  assert.equal(WorkingEventSource.instances, 1)
+  assert.equal(connection.transport, 'serverSentEvents')
+  assert.equal(connection.connectionState, 'connected')
+  assert.equal(fetchCalls[0].options.credentials, 'same-origin')
+  assert.equal(connection.eventSource.options.withCredentials, true)
+
+  await connection.stop()
+}
+
+async function testNegotiationCapabilitiesAreRespected() {
+  FailingWebSocket.instances = 0
+  WorkingEventSource.instances = 0
+  global.fetch = async () => ({
+    ok: true,
+    json: async () => ({
+      connectionId: 'fedcba9876543210fedcba9876543210',
+      availableTransports: [
+        { transport: 'ServerSentEvents', transferFormats: ['Text'] }
+      ]
+    })
+  })
+
+  const connection = new DextHubConnection('https://example.test/hubs/events')
+  await connection.start()
+
+  assert.equal(FailingWebSocket.instances, 0)
+  assert.equal(WorkingEventSource.instances, 1)
+  assert.equal(connection.transport, 'serverSentEvents')
+
+  await connection.stop()
+}
+
+async function testDisabledFallbackFailsClosed() {
+  FailingWebSocket.instances = 0
+  WorkingEventSource.instances = 0
+  global.fetch = async () => ({
+    ok: true,
+    json: async () => ({
+      connectionId: '00112233445566778899aabbccddeeff',
+      availableTransports: [
+        { transport: 'WebSockets', transferFormats: ['Text'] },
+        { transport: 'ServerSentEvents', transferFormats: ['Text'] }
+      ]
+    })
+  })
+
+  const connection = new DextHubConnection('https://example.test/hubs/events', {
+    transport: 'webSockets',
+    fallback: false
+  })
+
+  await assert.rejects(connection.start(), /WebSocket connection failed/)
+  assert.equal(WorkingEventSource.instances, 0)
+  assert.equal(connection.connectionState, 'disconnected')
+}
+
+// A second start() whose negotiation no longer advertises the transport the
+// connection was using must fail closed, instead of reporting 'connected' on
+// the transport left over from the previous session.
+async function testRestartWithNoCandidateFailsClosed() {
+  let advertiseWebSockets = true
+  global.WebSocket = WorkingWebSocket
+  global.EventSource = WorkingEventSource
+  global.fetch = async () => ({
+    ok: true,
+    json: async () => ({
+      connectionId: 'ffeeddccbbaa99887766554433221100',
+      availableTransports: advertiseWebSockets
+        ? [{ transport: 'WebSockets', transferFormats: ['Text'] }]
+        : [{ transport: 'ServerSentEvents', transferFormats: ['Text'] }]
+    })
+  })
+
+  const connection = new DextHubConnection('https://example.test/hubs/events', {
+    transport: 'webSockets',
+    fallback: false
+  })
+
+  await connection.start()
+  assert.equal(connection.transport, 'webSockets')
+
+  // Reproduce the reconnect path: _handleReconnect() drops the socket and calls
+  // start() again without going through stop(), so start() is what has to clear
+  // the transport left over from the previous session.
+  connection.state = 'reconnecting'
+  connection.socket = null
+  advertiseWebSockets = false
+
+  await assert.rejects(connection.start(),
+    /No compatible Hub transport is available/)
+  assert.equal(connection.transport, null)
+  assert.equal(connection.connectionState, 'disconnected')
+}
+
+// A hub URL with a trailing slash must not produce '//negotiate', which the
+// server routes as a distinct path.
+function testHubUrlIsCanonicalized() {
+  assert.equal(new DextHubConnection('/hubs/demo/').hubUrl, '/hubs/demo')
+  assert.equal(new DextHubConnection('https://example.test/hubs/demo//').hubUrl,
+    'https://example.test/hubs/demo')
+  assert.equal(new DextHubConnection('/hubs/demo').hubUrl, '/hubs/demo')
+  assert.equal(new DextHubConnection('/').hubUrl, '/')
+}
+
+async function main() {
+  testHubUrlIsCanonicalized()
+  await testWebSocketFallsBackToSSE()
+  await testNegotiationCapabilitiesAreRespected()
+  await testDisabledFallbackFailsClosed()
+  await testRestartWithNoCandidateFailsClosed()
+  console.log('Dext Hub JavaScript client tests passed')
+}
+
+main().catch(error => {
+  console.error(error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
Supersedes #173, which went stale the moment #174 landed.

PR #174 rewrote the WebSocket receive loop — fixed-size buffer replaced by an adaptive one with `BufferStart`/`BufferEnd` compaction, a keep-alive thread, and frame handling extracted into `DispatchFrame`. #173 had rewritten the same loop to enforce a payload limit through a buffer sized as `limit + 14`. The two are not textually mergeable and, more to the point, they are not conceptually mergeable: one of the designs has to win, and yours is the one already in `main`.

So this PR is #173 minus that single concern, rebased on top of #174 as one commit.

## What is in

| Area | Change |
|---|---|
| `HubMethod` | Gates client-invokable methods. `THubOptions.RequireHubMethodAttribute` defaults to `True`, so a public method without the attribute is no longer reachable from a remote client. |
| `THubOptions` | New `UseHubs` overload taking options, so transports and limits stop being hard-coded. |
| Transport gating | A WebSocket upgrade never silently falls through to an SSE stream; a disabled transport answers 404 instead of pretending to work. |
| Connection ownership | A WebSocket connection carries the authenticated `IClaimsPrincipal`, resolves `GetUserIdentifier` from the `sub` claim, and owns a real abort token — all three previously returned `nil` or `''`. |
| Dispatcher reservation | Connection-to-dispatcher mapping under a lock, so an id cannot be claimed twice or dispatched to the wrong hub. |
| HTTP payload limit | `MaximumReceiveMessageSize` enforced on the invocation body, `EHubPayloadTooLargeException` answering 413. |
| Error text | `EnableDetailedErrors` decides whether the client sees the exception message or a generic one. |
| Client | Reconnect and protocol handling in `dext-hubs.js`, plus a JavaScript test suite. |

## What is out, and why

The WebSocket receive-buffer payload limit. `THubOptions.MaximumReceiveMessageSize` still exists and still protects the HTTP invocation path, but it is no longer passed to `TWebSocketHubTransport` — the constructor is back to your signature, and both the field declaration and the call site say so in a comment, so the gap is not silent.

Applying a cap to the adaptive buffer is a real design question — whether the ceiling limits buffer growth, whether the check belongs inside `DispatchFrame`, and what a client should observe when it trips. That deserves its own PR against the loop as you wrote it, not a merge resolution.

## Breaking change

Public hub methods now require the `HubMethod` attribute to be invokable by remote clients. `THubOptions.RequireHubMethodAttribute := False` restores the previous behaviour.

## Validation

- `dcc64` Win64 builds `Tests/Hubs/TestDextHubs.dpr` (85,658 lines) with no warnings
- Hubs suite: **129 passed, 0 failed** — including the MessagePack and async WebSocket tests that came with #174, which exercise precisely the transport this slice leaves alone
