### PR TITLE
fix(hubs): main does not build -- stale argument at the TWebSocketHubTransport.Create call site

### DIFF
--- a/Sources/Hubs/Dext.Web.Hubs.Middleware.pas
+++ b/Sources/Hubs/Dext.Web.Hubs.Middleware.pas
@@ -400,8 +400,10 @@ begin
   LConnectionManager.SetGroupManager(FGroupManager);
   FConnectionManager := LConnectionManager;
   FSSETransport := TSSETransport.Create;
-  FWebSocketTransport := TWebSocketHubTransport.Create(
-    FOptions.MaximumReceiveMessageSize);
+  // MaximumReceiveMessageSize is enforced on the HTTP invoke body only (see
+  // HandleInvoke). The WebSocket transport grows its receive buffer on demand,
+  // so wiring the limit into that loop is a separate change.
+  FWebSocketTransport := TWebSocketHubTransport.Create;
   FConnectionDispatchers := TCollections.CreateDictionary<string, THubDispatcher>;
   FConnectionDispatchersLock := TCriticalSection.Create;
   

--- a/Sources/Hubs/Dext.Web.Hubs.Types.pas
+++ b/Sources/Hubs/Dext.Web.Hubs.Types.pas
@@ -105,7 +105,12 @@ type
     ClientTimeoutInterval: Integer;
     /// <summary>Keep-alive ping interval in seconds</summary>
     KeepAliveInterval: Integer;
-    /// <summary>Maximum message size in bytes</summary>
+    /// <summary>
+    ///   Maximum message size in bytes, enforced on the body of an HTTP
+    ///   invocation. The WebSocket transport is not covered yet: it sizes its
+    ///   receive buffer on demand, so applying this limit there is a separate
+    ///   change.
+    /// </summary>
     MaximumReceiveMessageSize: Int64;
     /// <summary>Enabled transports</summary>
     EnabledTransports: TArray<string>;


### PR DESCRIPTION
`main` does not build right now, and it is my fault — please merge this before anything else.

## The break

PR #175 restored the parameterless `TWebSocketHubTransport` constructor, but the call site in `THubMiddleware.Initialize` kept passing `FOptions.MaximumReceiveMessageSize`:

```
Sources\Hubs\Dext.Web.Hubs.Middleware.pas(404)
  Error: E2034 Too many actual parameters
Tests\Hubs\TestDextHubs.dpr(22)
  Fatal: F2063 Could not compile used unit 'Dext.Web.Hubs.Middleware.pas'
```

Two lines that I validated together with #175 never made it into that commit — I staged the conflicted files and missed the two that had merged cleanly and were then edited. The build I ran was green because the compiler reads the working tree, not the index, so the check that should have caught this passed on a state that was never committed.

## The fix

Restores the intended end state of #175: `MaximumReceiveMessageSize` keeps guarding the HTTP invocation body, and the WebSocket transport keeps the adaptive receive buffer from #174. The call site and the option declaration now both say so, so the gap between the two paths is documented instead of silent.

Two files, ten added lines, no behaviour change beyond making it compile again.

## Validation

Same branch, same base, only the fix varying:

| | Result |
|---|---|
| Without the fix | `E2034` at `Middleware.pas(404)`, `F2063` fatal |
| With the fix | 85,658 lines compiled, no warnings; Hubs suite **129 passed, 0 failed** |
