### PR TITLE
fix(web): make TWebApplication teardown single-run and Stop nil-safe

### DIFF
--- a/Sources/Web/Dext.Web.WebApplication.pas
+++ b/Sources/Web/Dext.Web.WebApplication.pas
@@ -53,6 +53,11 @@ type
     FDefaultPort: Integer;
     FActiveHost: IWebHost; // ? Track active host
     FServerFactory: TServerFactory;
+    /// Guards Teardown so it runs exactly once per Setup. When Run is hosted on
+    /// a background thread, Stop and Run's own finally block can both reach
+    /// Teardown at the same time. Interlocked, because the state check inside
+    /// Teardown is check-then-act and cannot close that window on its own.
+    FTeardownFlag: Integer;
 
     procedure Setup(Port: Integer);
     procedure Teardown;
@@ -112,6 +117,7 @@ implementation
 
 uses
   System.SysUtils,
+  System.SyncObjs, // TInterlocked (single-run teardown guard)
   Dext.Utils,
   Dext.DI.Core,
   Dext.Logging.Global,
@@ -365,7 +371,7 @@ var
   ProviderName: string;
 begin
   FDefaultPort := Port;
-  
+
   // Build ServiceProvider now if not already built via BuildServices()
   // This is the correct place to do it, AFTER all services have been registered
   if FServiceProvider = nil then
@@ -487,6 +493,14 @@ var
   LifetimeIntf: IInterface;
   ManagerIntf: IInterface;
 begin
+  // Exactly one teardown per Setup, whichever thread gets here first.
+  // CompareExchange returns the PREVIOUS value: 0 for the winner, 1 for anyone
+  // arriving afterwards. This has to be the very first statement -- the state
+  // checks below are check-then-act and both threads would pass them, because
+  // the state only becomes asStopped after the whole body has run.
+  if TInterlocked.CompareExchange(FTeardownFlag, 1, 0) <> 0 then
+    Exit;
+
   if FServiceProvider = nil then Exit;
 
   // Resolve services
@@ -610,6 +624,7 @@ end;
 procedure TWebApplication.Stop;
 var
   LifetimeIntf: IInterface;
+  LHost: IWebHost;
 begin
   if FServiceProvider <> nil then
   begin
@@ -618,12 +633,17 @@ begin
       (LifetimeIntf as IHostApplicationLifetime).StopApplication;
   end;
 
-  if FActiveHost <> nil then
+  // Snapshot into a local interface reference. StopApplication above can wake
+  // the Run loop on another thread, whose Teardown sets FActiveHost to nil --
+  // testing the field and then calling through it would dereference nil right
+  // in that window. The local reference also keeps the host alive for the call.
+  LHost := FActiveHost;
+  if LHost <> nil then
   begin
     LogInfo('Stopping active host...');
-    FActiveHost.Stop;
+    LHost.Stop;
   end;
-  
+
   Teardown;
 end;
 


### PR DESCRIPTION
Closes #178, with the two changes you approved there.

## 1. `Teardown` runs exactly once

```pascal
  // Exactly one teardown per Setup, whichever thread gets here first.
  if TInterlocked.CompareExchange(FTeardownFlag, 1, 0) <> 0 then
    Exit;
```

First statement of the method, before anything else. The existing state checks are check-then-act and the state only becomes `asStopped` after the whole body has run, so both threads used to walk past them: `StopAsync` twice, `TDextFireDACManager.Finalize` twice, the interface fields released twice.

## 2. `Stop` snapshots the host

```pascal
  LHost := FActiveHost;
  if LHost <> nil then
  begin
    LogInfo('Stopping active host...');
    LHost.Stop;
  end;
```

`StopApplication` above wakes the Run loop on the other thread, whose `Teardown` sets `FActiveHost := nil` — testing the field and then calling through it could dereference nil right in that window. The local reference also keeps the host alive for the duration of the call.

---

## ⚠️ One note on the snippets in the issue

In both of your snippets the `<>` came out as `<`, and in the first one that is not cosmetic:

```pascal
if TInterlocked.CompareExchange(FTeardownExecuted, 1, 0) < 0 then   // as written
```

`CompareExchange` returns the **previous** value — `0` for the winner, `1` for anyone arriving afterwards — so `< 0` is never true and the guard would never fire. The PR would look correct and change nothing. I read both as `<>` (`<> 0` and `<> nil`), which is what is implemented here.

## What I verified, and what I did not

- `Tests/Web` full suite: **133/133**.
- The fix itself is argued from the code, not proven by a test, and I want to be straight about why there is no new test in this PR.

I wrote one and threw it away. Two approaches, neither honest enough to ship:

1. **Run on a background thread, Stop from the main one, ten cycles.** Passes with the fix — and also passes **without** it. The Run loop polls on a 100 ms tick, so by the time it wakes up the other thread has normally finished tearing down. A test that is green either way is worse than no test.
2. **Eight threads released simultaneously into `Stop`.** This does hit the window, but it **hangs** — and it hangs on `LHost.Stop` called concurrently by several threads, which is code this PR does not touch (it was `FActiveHost.Stop` before, same call). My change only makes the second `Teardown` return earlier, so it cannot be the cause.

That second point looks like a separate issue: **`Stop` called concurrently from more than one thread does not return.** I have not diagnosed it and it is out of scope here, but it is worth knowing, and I am happy to open a dedicated issue with the reproduction if useful.

If you would rather have a test in this PR anyway, tell me which shape you would accept — a timing-dependent one that only sometimes reproduces, or one that asserts on internals — and I will add it.
