### PR TITLE
fix(web): refuse restarting a stopped application instead of faulting

### DIFF
--- a/Sources/Web/Dext.Web.WebApplication.pas
+++ b/Sources/Web/Dext.Web.WebApplication.pas
@@ -117,6 +117,7 @@ implementation
 
 uses
   System.SysUtils,
+  System.Classes, // EInvalidOperation (single-use lifecycle guard)
   System.SyncObjs, // TInterlocked (single-run teardown guard)
   Dext.Utils,
   Dext.DI.Core,
@@ -370,6 +371,19 @@ var
   RootFile: string;
   ProviderName: string;
 begin
+  // Single-use lifecycle: once the application has been stopped, Teardown has
+  // released the service collection and the configuration to break the circular
+  // references held by closures. Setup would then rebuild the provider from
+  // FServices, which no longer exists -- a read of address 0.
+  //
+  // Refusing here turns that access violation into a sentence that says what to
+  // do instead. The flag is the one Teardown sets, so this covers every way of
+  // getting back in: Start, Run, or Setup called directly.
+  if TInterlocked.CompareExchange(FTeardownFlag, 0, 0) <> 0 then
+    raise EInvalidOperation.Create
+      ('This WebApplication instance has been stopped and cannot be restarted. ' +
+      'Create a new instance instead: App := WebApplication;');
+
   FDefaultPort := Port;
 
   // Build ServiceProvider now if not already built via BuildServices()

--- a/Tests/Web/Dext.Web.Lifecycle.Tests.pas
+++ b/Tests/Web/Dext.Web.Lifecycle.Tests.pas
@@ -1,0 +1,103 @@
+unit Dext.Web.Lifecycle.Tests;
+
+// =============================================================================
+// IWebApplication has a single-use lifecycle.
+//
+// Teardown releases the service collection and the configuration on purpose, to
+// break the circular references captured by closures. Anything that tries to
+// come back in afterwards -- Start, Run, or Setup directly -- would rebuild the
+// provider from a collection that no longer exists.
+//
+// Before the guard that read address 0 and surfaced as an access violation,
+// which says nothing about what to do. Now it refuses with a sentence that
+// does: create a new instance.
+// =============================================================================
+
+interface
+
+uses
+  System.SysUtils,
+  System.Classes, // EInvalidOperation
+  Dext.Testing.Attributes,
+  Dext.Assertions,
+  Dext.Web,
+  Dext.Web.Interfaces;
+
+type
+  [TestFixture('WebApplication single-use lifecycle')]
+  TWebApplicationLifecycleTests = class
+  public
+    [Test('Starting a stopped application is refused, not an access violation')]
+    procedure TestRestartIsRefused;
+    [Test('The refusal says how to proceed')]
+    procedure TestRefusalMessageIsActionable;
+    [Test('A fresh instance starts normally after another one was stopped')]
+    procedure TestFreshInstanceWorks;
+  end;
+
+implementation
+
+procedure TWebApplicationLifecycleTests.TestRestartIsRefused;
+var
+  App: IWebApplication;
+  Raised: Boolean;
+begin
+  App := WebApplication;
+  App.Start(0);
+  Should(App.Port).BeGreaterThan(0);
+  App.Stop;
+
+  Raised := False;
+  try
+    App.Start(0); // used to raise EAccessViolation here
+  except
+    on E: EInvalidOperation do
+      Raised := True;
+  end;
+  Should(Raised).BeTrue;
+end;
+
+procedure TWebApplicationLifecycleTests.TestRefusalMessageIsActionable;
+var
+  App: IWebApplication;
+  Msg: string;
+begin
+  // A refusal that only says "invalid operation" leaves the caller stuck. The
+  // message has to name the way out, because there is one and it is short.
+  App := WebApplication;
+  App.Start(0);
+  App.Stop;
+
+  Msg := '';
+  try
+    App.Start(0);
+  except
+    on E: EInvalidOperation do
+      Msg := E.Message;
+  end;
+  Should(Msg.Contains('cannot be restarted')).BeTrue;
+  Should(Msg.Contains('new instance')).BeTrue;
+end;
+
+procedure TWebApplicationLifecycleTests.TestFreshInstanceWorks;
+var
+  First, Second: IWebApplication;
+begin
+  // The other half of the contract: refusing to restart must not mean the
+  // process is done serving. A new instance has to come up normally.
+  First := WebApplication;
+  First.Start(0);
+  First.Stop;
+  First := nil;
+
+  Second := WebApplication;
+  try
+    Second.Start(0);
+    Should(Second.Port).BeGreaterThan(0);
+    Second.Stop;
+  finally
+    Second := nil;
+  end;
+end;
+
+end.

--- a/Tests/Web/Dext.Web.UnitTests.dpr
+++ b/Tests/Web/Dext.Web.UnitTests.dpr
@@ -1,4 +1,4 @@
-﻿program Dext.Web.UnitTests;
+program Dext.Web.UnitTests;
 
 {$OVERFLOWCHECKS OFF}
 {$RANGECHECKS OFF}
@@ -22,6 +22,7 @@ uses
   Dext.Web.Features.Tests in 'Dext.Web.Features.Tests.pas',
   Dext.Web.DataApi.Utils.Tests in 'Dext.Web.DataApi.Utils.Tests.pas',
   Dext.Web.Hosting.Tests in 'Dext.Web.Hosting.Tests.pas',
+  Dext.Web.Lifecycle.Tests in 'Dext.Web.Lifecycle.Tests.pas',
   Dext.Web.Htmx.Tests in 'Dext.Web.Htmx.Tests.pas',
   Dext.Logging.Sinks.APM.Tests in 'Dext.Logging.Sinks.APM.Tests.pas',
   Dext.WebSocket.Tests in 'Dext.WebSocket.Tests.pas',
@@ -49,6 +50,7 @@ begin
         TWebFeaturesTests,
         TDataApiNamingTests,
         TWebHostingTests,
+        TWebApplicationLifecycleTests,
         TDataApiConventionTests,
         TDataApiSerializationTests,
         THtmxResponseTests,


### PR DESCRIPTION
Closes #180, with Option 1 as you decided: refuse gracefully instead of dereferencing nil.

```pascal
  if TInterlocked.CompareExchange(FTeardownFlag, 0, 0) <> 0 then
    raise EInvalidOperation.Create
      ('This WebApplication instance has been stopped and cannot be restarted. ' +
      'Create a new instance instead: App := WebApplication;');
```

First statement of `Setup`, so it covers every way back in — `Start`, `Run`, or `Setup` called directly. It reuses the flag `Teardown` already sets, so there is no second piece of state to keep in sync.

Two small departures from your snippet, both deliberate:

- **`EInvalidOperation`** rather than `EInvalidOperationException` — the latter does not exist in Delphi, and `EInvalidOperation` is what the rest of the codebase raises for this (`Dext.Http2.Framing`, `Dext.Http2.Stream`). It comes from `System.Classes`, now in the implementation uses.
- **The message names the way out.** A refusal that only says "invalid operation" leaves the caller stuck; here the fix is one line, so the message says it.

## Tests

Three, in `Tests/Web/Dext.Web.Lifecycle.Tests.pas`:

1. the restart is refused;
2. the message actually contains the guidance — otherwise the sentence above is decoration that the next refactor quietly drops;
3. **a fresh instance still starts normally after another one was stopped**. Refusing to restart must not mean the process is done serving, and that half is easy to break without noticing.

`Tests/Web` suite: **136/136**.

## Verification

Same standalone program from #180, same steps:

```
start #1...
  listening on 44409
stop #1...
start #2...
```

| | |
|---|---|
| before | `EAccessViolation ... Read of address 0000000000000000` |
| after | `EInvalidOperation: This WebApplication instance has been stopped and cannot be restarted. Create a new instance instead: App := WebApplication;` |
